### PR TITLE
Modal example

### DIFF
--- a/src/mnd-bootstrap/javascript/_modal.scss
+++ b/src/mnd-bootstrap/javascript/_modal.scss
@@ -1,0 +1,31 @@
+/*doc
+---
+title: Modal
+name: modal
+category: JavaScript
+
+---
+```html
+<div class="modal show">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Modal title</h4>
+      </div>
+      <div class="modal-body">
+        <p>One fine body&hellip;</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+```
+*/
+.modal-backdrop {
+  position: fixed;
+  bottom: 0;
+}


### PR DESCRIPTION
- Since we use react-bootstrap we need to modify the behavior on the backdrop. Code is taken from the react-bootstrap css. The problem we’re solving is that react bootstrap modal backdrops won’t get a height.