### PR TITLE
Don't use bootstrap containers in sections

### DIFF
--- a/src/mnd-bootstrap/components/_sections.scss
+++ b/src/mnd-bootstrap/components/_sections.scss
@@ -8,7 +8,7 @@ Modular section setup which allows using a combination of header, body and foote
 
 ```html_example
 <section>
-  <div class="container">
+  <div class="content">
     <header>
       <h1>Title</h1>
     </header>
@@ -24,7 +24,7 @@ Modular section setup which allows using a combination of header, body and foote
 
 ```html_example
 <section class="solid">
-  <div class="container">
+  <div class="content">
     <header>
       <h1>Title</h1>
     </header>
@@ -41,7 +41,7 @@ section {
     background-color: #F2F2F2;
   }
 
-  > .container {
+  > .content {
     header, .body, footer {
       text-align: center;
     }


### PR DESCRIPTION
Avoid extra padding by not using bootstrap containers where they aren't needed.

When this has been merged and deployed this should be merged: https://github.com/mynewsdesk/mndx-web/pull/114