### PR TITLE
Use narrower spacing for fluid containers

### DIFF
--- a/src/mnd-bootstrap/_variables.scss
+++ b/src/mnd-bootstrap/_variables.scss
@@ -133,7 +133,7 @@ $icon-font-svg-id:        "glyphicons_halflingsregular";
 //
 //## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
 
-$container-fluid-padding: 40px;
+$container-fluid-padding: 20px;
 
 $padding-base-vertical:     6px;
 $padding-base-horizontal:   12px;


### PR DESCRIPTION
Makes the mobile view look good. Fixes also made in mndx-web.

![screen shot 2015-06-04 at 15 42 27](https://cloud.githubusercontent.com/assets/676873/7985345/5ca93c24-0ad0-11e5-88e9-03604a117acd.png)
