### PR TITLE
Compile only the needed sass file and use it

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,9 +6,8 @@
   ],
   "description": "MND theme for Bootstrap.",
   "main": [
-    "src/bootstrap.scss",
-    "src/mnd-bootstrap.scss",
-    "src/mnd-bootstrap/*.scss"
+    "dist/mnd-bootstrap.min.css","
+    "src/mnd-bootstrap/_variables.scss"
   ],
   "keywords": [
     "bootstrap"

--- a/doc_assets/_header.html
+++ b/doc_assets/_header.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Mynewsdesk Style Guide: <%= title %></title>
-    <link rel="stylesheet" href="dist/mnd-bootstrap-dev.css">
+    <link rel="stylesheet" href="dist/mnd-bootstrap.css">
     <link rel="stylesheet" href="docs.css">
     <link rel="stylesheet" href="github.css">
     <link rel="stylesheet" href="styleguide.css">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,8 +32,8 @@ gulp.task('watch', function() {
 
 // Compile sass files
 gulp.task('sass', function() {
-  return gulp.src('src/mnd-bootstrap*.scss')
-    .pipe(sass({ style: 'expanded', loadPath: ['./bower_components/'] }))
+  return gulp.src('src/mnd-bootstrap.scss')
+    .pipe(sass({ style: 'compressed', loadPath: ['./bower_components/'] }))
     .on('error', function (err) { console.log(err.message); })
     .pipe(gulp.dest('dist/'))
     .pipe(notify({message: 'Sass task complete'}));


### PR DESCRIPTION
Just compile mnd-bootstrap.scss to dist/mnd-bootstrap.css
Use the "compressed" output, which mean minify basically.
As we agreed on during the frontend chapter, we only expose the generated mnd-bootstrap.css and _variables.scss.