### PR TITLE
Made it optional to have a transparent jumbotron

### DIFF
--- a/src/mnd-bootstrap/components/_jumbotron.scss
+++ b/src/mnd-bootstrap/components/_jumbotron.scss
@@ -102,3 +102,31 @@ $jumbotron-padding-x2: $jumbotron-padding * 2;
     }
   }
 }
+
+.jumbotron-transparent {
+  background: transparent;
+  border: 0;
+
+  .jumbotron-description {
+
+    h1,
+    p {
+      color: $white;
+    }
+  }
+
+  .control-label {
+    color: $white;
+  }
+
+  .form-control {
+    background: $white;
+  }
+
+  .form-links {
+
+    a {
+      color: $white;
+    }
+  }
+}


### PR DESCRIPTION
![jumbotron-transparent](https://cloud.githubusercontent.com/assets/3883404/9522614/f20d5fd8-4cd5-11e5-8212-75c2849366a9.png)
