### PR TITLE
Boost sass performance

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "bower_components"
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
-gem 'sass', '~> 3.4.11'
 gem 'hologram', '~> 1.3.1'
 gem 'uuidtools'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ GEM
       rouge (>= 1.5)
     redcarpet (3.2.2)
     rouge (1.8.0)
-    sass (3.4.11)
     uuidtools (2.1.5)
 
 PLATFORMS
@@ -14,5 +13,4 @@ PLATFORMS
 
 DEPENDENCIES
   hologram (~> 1.3.1)
-  sass (~> 3.4.11)
   uuidtools

--- a/dist/mnd-bootstrap.css
+++ b/dist/mnd-bootstrap.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /*doc
  ---
  title: Units extended
@@ -101,23 +100,16 @@
   </div>
 </div>
  */
-@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
-/*!
- * Bootstrap v3.3.5 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
- */
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic");
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic");
 html {
   font-family: sans-serif;
   -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-}
+  -webkit-text-size-adjust: 100%; }
 
 body {
-  margin: 0;
-}
+  margin: 0; }
 
 article,
 aside,
@@ -132,107 +124,87 @@ menu,
 nav,
 section,
 summary {
-  display: block;
-}
+  display: block; }
 
 audio,
 canvas,
 progress,
 video {
   display: inline-block;
-  vertical-align: baseline;
-}
+  vertical-align: baseline; }
 
 audio:not([controls]) {
   display: none;
-  height: 0;
-}
+  height: 0; }
 
 [hidden],
 template {
-  display: none;
-}
+  display: none; }
 
 a {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
 a:active,
 a:hover {
-  outline: 0;
-}
+  outline: 0; }
 
 abbr[title] {
-  border-bottom: 1px dotted;
-}
+  border-bottom: 1px dotted; }
 
 b,
 strong {
-  font-weight: bold;
-}
+  font-weight: bold; }
 
 dfn {
-  font-style: italic;
-}
+  font-style: italic; }
 
 h1 {
   font-size: 2em;
-  margin: 0.67em 0;
-}
+  margin: 0.67em 0; }
 
 mark {
   background: #ff0;
-  color: #000;
-}
+  color: #000; }
 
 small {
-  font-size: 80%;
-}
+  font-size: 80%; }
 
 sub,
 sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
-  vertical-align: baseline;
-}
+  vertical-align: baseline; }
 
 sup {
-  top: -0.5em;
-}
+  top: -0.5em; }
 
 sub {
-  bottom: -0.25em;
-}
+  bottom: -0.25em; }
 
 img {
-  border: 0;
-}
+  border: 0; }
 
 svg:not(:root) {
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 figure {
-  margin: 1em 40px;
-}
+  margin: 1em 40px; }
 
 hr {
+  -moz-box-sizing: content-box;
   box-sizing: content-box;
-  height: 0;
-}
+  height: 0; }
 
 pre {
-  overflow: auto;
-}
+  overflow: auto; }
 
 code,
 kbd,
 pre,
 samp {
   font-family: monospace, monospace;
-  font-size: 1em;
-}
+  font-size: 1em; }
 
 button,
 input,
@@ -241,90 +213,74 @@ select,
 textarea {
   color: inherit;
   font: inherit;
-  margin: 0;
-}
+  margin: 0; }
 
 button {
-  overflow: visible;
-}
+  overflow: visible; }
 
 button,
 select {
-  text-transform: none;
-}
+  text-transform: none; }
 
 button,
-html input[type="button"],
-input[type="reset"],
+html input[type="button"], input[type="reset"],
 input[type="submit"] {
   -webkit-appearance: button;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 button[disabled],
 html input[disabled] {
-  cursor: default;
-}
+  cursor: default; }
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
   border: 0;
-  padding: 0;
-}
+  padding: 0; }
 
 input {
-  line-height: normal;
-}
+  line-height: normal; }
 
 input[type="checkbox"],
 input[type="radio"] {
   box-sizing: border-box;
-  padding: 0;
-}
+  padding: 0; }
 
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
+  height: auto; }
 
 input[type="search"] {
   -webkit-appearance: textfield;
-  box-sizing: content-box;
-}
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box; }
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
+  -webkit-appearance: none; }
 
 fieldset {
   border: 1px solid #c0c0c0;
   margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
-}
+  padding: 0.35em 0.625em 0.75em; }
 
 legend {
   border: 0;
-  padding: 0;
-}
+  padding: 0; }
 
 textarea {
-  overflow: auto;
-}
+  overflow: auto; }
 
 optgroup {
-  font-weight: bold;
-}
+  font-weight: bold; }
 
 table {
   border-collapse: collapse;
-  border-spacing: 0;
-}
+  border-spacing: 0; }
 
 td,
 th {
-  padding: 0;
-}
+  padding: 0; }
 
 /*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
 @media print {
@@ -334,90 +290,60 @@ th {
     background: transparent !important;
     color: #000 !important;
     box-shadow: none !important;
-    text-shadow: none !important;
-  }
-
+    text-shadow: none !important; }
   a,
   a:visited {
-    text-decoration: underline;
-  }
-
+    text-decoration: underline; }
   a[href]:after {
-    content: " (" attr(href) ")";
-  }
-
+    content: " (" attr(href) ")"; }
   abbr[title]:after {
-    content: " (" attr(title) ")";
-  }
-
+    content: " (" attr(title) ")"; }
   a[href^="#"]:after,
   a[href^="javascript:"]:after {
-    content: "";
-  }
-
+    content: ""; }
   pre,
   blockquote {
     border: 1px solid #999;
-    page-break-inside: avoid;
-  }
-
+    page-break-inside: avoid; }
   thead {
-    display: table-header-group;
-  }
-
+    display: table-header-group; }
   tr,
   img {
-    page-break-inside: avoid;
-  }
-
+    page-break-inside: avoid; }
   img {
-    max-width: 100% !important;
-  }
-
+    max-width: 100% !important; }
   p,
   h2,
   h3 {
     orphans: 3;
-    widows: 3;
-  }
-
+    widows: 3; }
   h2,
   h3 {
-    page-break-after: avoid;
-  }
-
+    page-break-after: avoid; }
+  select {
+    background: #fff !important; }
   .navbar {
-    display: none;
-  }
-
-  .btn > .caret, .btn-ghost > .caret,
-  .dropup > .btn > .caret,
-  .dropup > .btn-ghost > .caret {
-    border-top-color: #000 !important;
-  }
-
+    display: none; }
+  .btn > .caret,
+  .btn-ghost > .caret,
+  .dropup > .btn > .caret, .dropup > .btn-ghost > .caret {
+    border-top-color: #000 !important; }
   .label {
-    border: 1px solid #000;
-  }
-
+    border: 1px solid #000; }
   .table {
-    border-collapse: collapse !important;
-  }
-  .table td,
-  .table th {
-    background-color: #fff !important;
-  }
-
+    border-collapse: collapse !important; }
+    .table td,
+    .table th {
+      background-color: #fff !important; }
   .table-bordered th,
   .table-bordered td {
-    border: 1px solid #ddd !important;
-  }
-}
+    border: 1px solid #ddd !important; } }
+
 @font-face {
   font-family: 'Glyphicons Halflings';
   src: url("bootstrap/glyphicons-halflings-regular.eot");
-  src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
-}
+  src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg"); }
+
 .glyphicon {
   position: relative;
   top: 1px;
@@ -427,1083 +353,816 @@ th {
   font-weight: normal;
   line-height: 1;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+  -moz-osx-font-smoothing: grayscale; }
 
 .glyphicon-asterisk:before {
-  content: "\2a";
-}
+  content: "\2a"; }
 
 .glyphicon-plus:before {
-  content: "\2b";
-}
+  content: "\2b"; }
 
 .glyphicon-euro:before,
 .glyphicon-eur:before {
-  content: "\20ac";
-}
+  content: "\20ac"; }
 
 .glyphicon-minus:before {
-  content: "\2212";
-}
+  content: "\2212"; }
 
 .glyphicon-cloud:before {
-  content: "\2601";
-}
+  content: "\2601"; }
 
 .glyphicon-envelope:before {
-  content: "\2709";
-}
+  content: "\2709"; }
 
 .glyphicon-pencil:before {
-  content: "\270f";
-}
+  content: "\270f"; }
 
 .glyphicon-glass:before {
-  content: "\e001";
-}
+  content: "\e001"; }
 
 .glyphicon-music:before {
-  content: "\e002";
-}
+  content: "\e002"; }
 
 .glyphicon-search:before {
-  content: "\e003";
-}
+  content: "\e003"; }
 
 .glyphicon-heart:before {
-  content: "\e005";
-}
+  content: "\e005"; }
 
 .glyphicon-star:before {
-  content: "\e006";
-}
+  content: "\e006"; }
 
 .glyphicon-star-empty:before {
-  content: "\e007";
-}
+  content: "\e007"; }
 
 .glyphicon-user:before {
-  content: "\e008";
-}
+  content: "\e008"; }
 
 .glyphicon-film:before {
-  content: "\e009";
-}
+  content: "\e009"; }
 
 .glyphicon-th-large:before {
-  content: "\e010";
-}
+  content: "\e010"; }
 
 .glyphicon-th:before {
-  content: "\e011";
-}
+  content: "\e011"; }
 
 .glyphicon-th-list:before {
-  content: "\e012";
-}
+  content: "\e012"; }
 
 .glyphicon-ok:before {
-  content: "\e013";
-}
+  content: "\e013"; }
 
 .glyphicon-remove:before {
-  content: "\e014";
-}
+  content: "\e014"; }
 
 .glyphicon-zoom-in:before {
-  content: "\e015";
-}
+  content: "\e015"; }
 
 .glyphicon-zoom-out:before {
-  content: "\e016";
-}
+  content: "\e016"; }
 
 .glyphicon-off:before {
-  content: "\e017";
-}
+  content: "\e017"; }
 
 .glyphicon-signal:before {
-  content: "\e018";
-}
+  content: "\e018"; }
 
 .glyphicon-cog:before {
-  content: "\e019";
-}
+  content: "\e019"; }
 
 .glyphicon-trash:before {
-  content: "\e020";
-}
+  content: "\e020"; }
 
 .glyphicon-home:before {
-  content: "\e021";
-}
+  content: "\e021"; }
 
 .glyphicon-file:before {
-  content: "\e022";
-}
+  content: "\e022"; }
 
 .glyphicon-time:before {
-  content: "\e023";
-}
+  content: "\e023"; }
 
 .glyphicon-road:before {
-  content: "\e024";
-}
+  content: "\e024"; }
 
 .glyphicon-download-alt:before {
-  content: "\e025";
-}
+  content: "\e025"; }
 
 .glyphicon-download:before {
-  content: "\e026";
-}
+  content: "\e026"; }
 
 .glyphicon-upload:before {
-  content: "\e027";
-}
+  content: "\e027"; }
 
 .glyphicon-inbox:before {
-  content: "\e028";
-}
+  content: "\e028"; }
 
 .glyphicon-play-circle:before {
-  content: "\e029";
-}
+  content: "\e029"; }
 
 .glyphicon-repeat:before {
-  content: "\e030";
-}
+  content: "\e030"; }
 
 .glyphicon-refresh:before {
-  content: "\e031";
-}
+  content: "\e031"; }
 
 .glyphicon-list-alt:before {
-  content: "\e032";
-}
+  content: "\e032"; }
 
 .glyphicon-lock:before {
-  content: "\e033";
-}
+  content: "\e033"; }
 
 .glyphicon-flag:before {
-  content: "\e034";
-}
+  content: "\e034"; }
 
 .glyphicon-headphones:before {
-  content: "\e035";
-}
+  content: "\e035"; }
 
 .glyphicon-volume-off:before {
-  content: "\e036";
-}
+  content: "\e036"; }
 
 .glyphicon-volume-down:before {
-  content: "\e037";
-}
+  content: "\e037"; }
 
 .glyphicon-volume-up:before {
-  content: "\e038";
-}
+  content: "\e038"; }
 
 .glyphicon-qrcode:before {
-  content: "\e039";
-}
+  content: "\e039"; }
 
 .glyphicon-barcode:before {
-  content: "\e040";
-}
+  content: "\e040"; }
 
 .glyphicon-tag:before {
-  content: "\e041";
-}
+  content: "\e041"; }
 
 .glyphicon-tags:before {
-  content: "\e042";
-}
+  content: "\e042"; }
 
 .glyphicon-book:before {
-  content: "\e043";
-}
+  content: "\e043"; }
 
 .glyphicon-bookmark:before {
-  content: "\e044";
-}
+  content: "\e044"; }
 
 .glyphicon-print:before {
-  content: "\e045";
-}
+  content: "\e045"; }
 
 .glyphicon-camera:before {
-  content: "\e046";
-}
+  content: "\e046"; }
 
 .glyphicon-font:before {
-  content: "\e047";
-}
+  content: "\e047"; }
 
 .glyphicon-bold:before {
-  content: "\e048";
-}
+  content: "\e048"; }
 
 .glyphicon-italic:before {
-  content: "\e049";
-}
+  content: "\e049"; }
 
 .glyphicon-text-height:before {
-  content: "\e050";
-}
+  content: "\e050"; }
 
 .glyphicon-text-width:before {
-  content: "\e051";
-}
+  content: "\e051"; }
 
 .glyphicon-align-left:before {
-  content: "\e052";
-}
+  content: "\e052"; }
 
 .glyphicon-align-center:before {
-  content: "\e053";
-}
+  content: "\e053"; }
 
 .glyphicon-align-right:before {
-  content: "\e054";
-}
+  content: "\e054"; }
 
 .glyphicon-align-justify:before {
-  content: "\e055";
-}
+  content: "\e055"; }
 
 .glyphicon-list:before {
-  content: "\e056";
-}
+  content: "\e056"; }
 
 .glyphicon-indent-left:before {
-  content: "\e057";
-}
+  content: "\e057"; }
 
 .glyphicon-indent-right:before {
-  content: "\e058";
-}
+  content: "\e058"; }
 
 .glyphicon-facetime-video:before {
-  content: "\e059";
-}
+  content: "\e059"; }
 
 .glyphicon-picture:before {
-  content: "\e060";
-}
+  content: "\e060"; }
 
 .glyphicon-map-marker:before {
-  content: "\e062";
-}
+  content: "\e062"; }
 
 .glyphicon-adjust:before {
-  content: "\e063";
-}
+  content: "\e063"; }
 
 .glyphicon-tint:before {
-  content: "\e064";
-}
+  content: "\e064"; }
 
 .glyphicon-edit:before {
-  content: "\e065";
-}
+  content: "\e065"; }
 
 .glyphicon-share:before {
-  content: "\e066";
-}
+  content: "\e066"; }
 
 .glyphicon-check:before {
-  content: "\e067";
-}
+  content: "\e067"; }
 
 .glyphicon-move:before {
-  content: "\e068";
-}
+  content: "\e068"; }
 
 .glyphicon-step-backward:before {
-  content: "\e069";
-}
+  content: "\e069"; }
 
 .glyphicon-fast-backward:before {
-  content: "\e070";
-}
+  content: "\e070"; }
 
 .glyphicon-backward:before {
-  content: "\e071";
-}
+  content: "\e071"; }
 
 .glyphicon-play:before {
-  content: "\e072";
-}
+  content: "\e072"; }
 
 .glyphicon-pause:before {
-  content: "\e073";
-}
+  content: "\e073"; }
 
 .glyphicon-stop:before {
-  content: "\e074";
-}
+  content: "\e074"; }
 
 .glyphicon-forward:before {
-  content: "\e075";
-}
+  content: "\e075"; }
 
 .glyphicon-fast-forward:before {
-  content: "\e076";
-}
+  content: "\e076"; }
 
 .glyphicon-step-forward:before {
-  content: "\e077";
-}
+  content: "\e077"; }
 
 .glyphicon-eject:before {
-  content: "\e078";
-}
+  content: "\e078"; }
 
 .glyphicon-chevron-left:before {
-  content: "\e079";
-}
+  content: "\e079"; }
 
 .glyphicon-chevron-right:before {
-  content: "\e080";
-}
+  content: "\e080"; }
 
 .glyphicon-plus-sign:before {
-  content: "\e081";
-}
+  content: "\e081"; }
 
 .glyphicon-minus-sign:before {
-  content: "\e082";
-}
+  content: "\e082"; }
 
 .glyphicon-remove-sign:before {
-  content: "\e083";
-}
+  content: "\e083"; }
 
 .glyphicon-ok-sign:before {
-  content: "\e084";
-}
+  content: "\e084"; }
 
 .glyphicon-question-sign:before {
-  content: "\e085";
-}
+  content: "\e085"; }
 
 .glyphicon-info-sign:before {
-  content: "\e086";
-}
+  content: "\e086"; }
 
 .glyphicon-screenshot:before {
-  content: "\e087";
-}
+  content: "\e087"; }
 
 .glyphicon-remove-circle:before {
-  content: "\e088";
-}
+  content: "\e088"; }
 
 .glyphicon-ok-circle:before {
-  content: "\e089";
-}
+  content: "\e089"; }
 
 .glyphicon-ban-circle:before {
-  content: "\e090";
-}
+  content: "\e090"; }
 
 .glyphicon-arrow-left:before {
-  content: "\e091";
-}
+  content: "\e091"; }
 
 .glyphicon-arrow-right:before {
-  content: "\e092";
-}
+  content: "\e092"; }
 
 .glyphicon-arrow-up:before {
-  content: "\e093";
-}
+  content: "\e093"; }
 
 .glyphicon-arrow-down:before {
-  content: "\e094";
-}
+  content: "\e094"; }
 
 .glyphicon-share-alt:before {
-  content: "\e095";
-}
+  content: "\e095"; }
 
 .glyphicon-resize-full:before {
-  content: "\e096";
-}
+  content: "\e096"; }
 
 .glyphicon-resize-small:before {
-  content: "\e097";
-}
+  content: "\e097"; }
 
 .glyphicon-exclamation-sign:before {
-  content: "\e101";
-}
+  content: "\e101"; }
 
 .glyphicon-gift:before {
-  content: "\e102";
-}
+  content: "\e102"; }
 
 .glyphicon-leaf:before {
-  content: "\e103";
-}
+  content: "\e103"; }
 
 .glyphicon-fire:before {
-  content: "\e104";
-}
+  content: "\e104"; }
 
 .glyphicon-eye-open:before {
-  content: "\e105";
-}
+  content: "\e105"; }
 
 .glyphicon-eye-close:before {
-  content: "\e106";
-}
+  content: "\e106"; }
 
 .glyphicon-warning-sign:before {
-  content: "\e107";
-}
+  content: "\e107"; }
 
 .glyphicon-plane:before {
-  content: "\e108";
-}
+  content: "\e108"; }
 
 .glyphicon-calendar:before {
-  content: "\e109";
-}
+  content: "\e109"; }
 
 .glyphicon-random:before {
-  content: "\e110";
-}
+  content: "\e110"; }
 
 .glyphicon-comment:before {
-  content: "\e111";
-}
+  content: "\e111"; }
 
 .glyphicon-magnet:before {
-  content: "\e112";
-}
+  content: "\e112"; }
 
 .glyphicon-chevron-up:before {
-  content: "\e113";
-}
+  content: "\e113"; }
 
 .glyphicon-chevron-down:before {
-  content: "\e114";
-}
+  content: "\e114"; }
 
 .glyphicon-retweet:before {
-  content: "\e115";
-}
+  content: "\e115"; }
 
 .glyphicon-shopping-cart:before {
-  content: "\e116";
-}
+  content: "\e116"; }
 
 .glyphicon-folder-close:before {
-  content: "\e117";
-}
+  content: "\e117"; }
 
 .glyphicon-folder-open:before {
-  content: "\e118";
-}
+  content: "\e118"; }
 
 .glyphicon-resize-vertical:before {
-  content: "\e119";
-}
+  content: "\e119"; }
 
 .glyphicon-resize-horizontal:before {
-  content: "\e120";
-}
+  content: "\e120"; }
 
 .glyphicon-hdd:before {
-  content: "\e121";
-}
+  content: "\e121"; }
 
 .glyphicon-bullhorn:before {
-  content: "\e122";
-}
+  content: "\e122"; }
 
 .glyphicon-bell:before {
-  content: "\e123";
-}
+  content: "\e123"; }
 
 .glyphicon-certificate:before {
-  content: "\e124";
-}
+  content: "\e124"; }
 
 .glyphicon-thumbs-up:before {
-  content: "\e125";
-}
+  content: "\e125"; }
 
 .glyphicon-thumbs-down:before {
-  content: "\e126";
-}
+  content: "\e126"; }
 
 .glyphicon-hand-right:before {
-  content: "\e127";
-}
+  content: "\e127"; }
 
 .glyphicon-hand-left:before {
-  content: "\e128";
-}
+  content: "\e128"; }
 
 .glyphicon-hand-up:before {
-  content: "\e129";
-}
+  content: "\e129"; }
 
 .glyphicon-hand-down:before {
-  content: "\e130";
-}
+  content: "\e130"; }
 
 .glyphicon-circle-arrow-right:before {
-  content: "\e131";
-}
+  content: "\e131"; }
 
 .glyphicon-circle-arrow-left:before {
-  content: "\e132";
-}
+  content: "\e132"; }
 
 .glyphicon-circle-arrow-up:before {
-  content: "\e133";
-}
+  content: "\e133"; }
 
 .glyphicon-circle-arrow-down:before {
-  content: "\e134";
-}
+  content: "\e134"; }
 
 .glyphicon-globe:before {
-  content: "\e135";
-}
+  content: "\e135"; }
 
 .glyphicon-wrench:before {
-  content: "\e136";
-}
+  content: "\e136"; }
 
 .glyphicon-tasks:before {
-  content: "\e137";
-}
+  content: "\e137"; }
 
 .glyphicon-filter:before {
-  content: "\e138";
-}
+  content: "\e138"; }
 
 .glyphicon-briefcase:before {
-  content: "\e139";
-}
+  content: "\e139"; }
 
 .glyphicon-fullscreen:before {
-  content: "\e140";
-}
+  content: "\e140"; }
 
 .glyphicon-dashboard:before {
-  content: "\e141";
-}
+  content: "\e141"; }
 
 .glyphicon-paperclip:before {
-  content: "\e142";
-}
+  content: "\e142"; }
 
 .glyphicon-heart-empty:before {
-  content: "\e143";
-}
+  content: "\e143"; }
 
 .glyphicon-link:before {
-  content: "\e144";
-}
+  content: "\e144"; }
 
 .glyphicon-phone:before {
-  content: "\e145";
-}
+  content: "\e145"; }
 
 .glyphicon-pushpin:before {
-  content: "\e146";
-}
+  content: "\e146"; }
 
 .glyphicon-usd:before {
-  content: "\e148";
-}
+  content: "\e148"; }
 
 .glyphicon-gbp:before {
-  content: "\e149";
-}
+  content: "\e149"; }
 
 .glyphicon-sort:before {
-  content: "\e150";
-}
+  content: "\e150"; }
 
 .glyphicon-sort-by-alphabet:before {
-  content: "\e151";
-}
+  content: "\e151"; }
 
 .glyphicon-sort-by-alphabet-alt:before {
-  content: "\e152";
-}
+  content: "\e152"; }
 
 .glyphicon-sort-by-order:before {
-  content: "\e153";
-}
+  content: "\e153"; }
 
 .glyphicon-sort-by-order-alt:before {
-  content: "\e154";
-}
+  content: "\e154"; }
 
 .glyphicon-sort-by-attributes:before {
-  content: "\e155";
-}
+  content: "\e155"; }
 
 .glyphicon-sort-by-attributes-alt:before {
-  content: "\e156";
-}
+  content: "\e156"; }
 
 .glyphicon-unchecked:before {
-  content: "\e157";
-}
+  content: "\e157"; }
 
 .glyphicon-expand:before {
-  content: "\e158";
-}
+  content: "\e158"; }
 
 .glyphicon-collapse-down:before {
-  content: "\e159";
-}
+  content: "\e159"; }
 
 .glyphicon-collapse-up:before {
-  content: "\e160";
-}
+  content: "\e160"; }
 
 .glyphicon-log-in:before {
-  content: "\e161";
-}
+  content: "\e161"; }
 
 .glyphicon-flash:before {
-  content: "\e162";
-}
+  content: "\e162"; }
 
 .glyphicon-log-out:before {
-  content: "\e163";
-}
+  content: "\e163"; }
 
 .glyphicon-new-window:before {
-  content: "\e164";
-}
+  content: "\e164"; }
 
 .glyphicon-record:before {
-  content: "\e165";
-}
+  content: "\e165"; }
 
 .glyphicon-save:before {
-  content: "\e166";
-}
+  content: "\e166"; }
 
 .glyphicon-open:before {
-  content: "\e167";
-}
+  content: "\e167"; }
 
 .glyphicon-saved:before {
-  content: "\e168";
-}
+  content: "\e168"; }
 
 .glyphicon-import:before {
-  content: "\e169";
-}
+  content: "\e169"; }
 
 .glyphicon-export:before {
-  content: "\e170";
-}
+  content: "\e170"; }
 
 .glyphicon-send:before {
-  content: "\e171";
-}
+  content: "\e171"; }
 
 .glyphicon-floppy-disk:before {
-  content: "\e172";
-}
+  content: "\e172"; }
 
 .glyphicon-floppy-saved:before {
-  content: "\e173";
-}
+  content: "\e173"; }
 
 .glyphicon-floppy-remove:before {
-  content: "\e174";
-}
+  content: "\e174"; }
 
 .glyphicon-floppy-save:before {
-  content: "\e175";
-}
+  content: "\e175"; }
 
 .glyphicon-floppy-open:before {
-  content: "\e176";
-}
+  content: "\e176"; }
 
 .glyphicon-credit-card:before {
-  content: "\e177";
-}
+  content: "\e177"; }
 
 .glyphicon-transfer:before {
-  content: "\e178";
-}
+  content: "\e178"; }
 
 .glyphicon-cutlery:before {
-  content: "\e179";
-}
+  content: "\e179"; }
 
 .glyphicon-header:before {
-  content: "\e180";
-}
+  content: "\e180"; }
 
 .glyphicon-compressed:before {
-  content: "\e181";
-}
+  content: "\e181"; }
 
 .glyphicon-earphone:before {
-  content: "\e182";
-}
+  content: "\e182"; }
 
 .glyphicon-phone-alt:before {
-  content: "\e183";
-}
+  content: "\e183"; }
 
 .glyphicon-tower:before {
-  content: "\e184";
-}
+  content: "\e184"; }
 
 .glyphicon-stats:before {
-  content: "\e185";
-}
+  content: "\e185"; }
 
 .glyphicon-sd-video:before {
-  content: "\e186";
-}
+  content: "\e186"; }
 
 .glyphicon-hd-video:before {
-  content: "\e187";
-}
+  content: "\e187"; }
 
 .glyphicon-subtitles:before {
-  content: "\e188";
-}
+  content: "\e188"; }
 
 .glyphicon-sound-stereo:before {
-  content: "\e189";
-}
+  content: "\e189"; }
 
 .glyphicon-sound-dolby:before {
-  content: "\e190";
-}
+  content: "\e190"; }
 
 .glyphicon-sound-5-1:before {
-  content: "\e191";
-}
+  content: "\e191"; }
 
 .glyphicon-sound-6-1:before {
-  content: "\e192";
-}
+  content: "\e192"; }
 
 .glyphicon-sound-7-1:before {
-  content: "\e193";
-}
+  content: "\e193"; }
 
 .glyphicon-copyright-mark:before {
-  content: "\e194";
-}
+  content: "\e194"; }
 
 .glyphicon-registration-mark:before {
-  content: "\e195";
-}
+  content: "\e195"; }
 
 .glyphicon-cloud-download:before {
-  content: "\e197";
-}
+  content: "\e197"; }
 
 .glyphicon-cloud-upload:before {
-  content: "\e198";
-}
+  content: "\e198"; }
 
 .glyphicon-tree-conifer:before {
-  content: "\e199";
-}
+  content: "\e199"; }
 
 .glyphicon-tree-deciduous:before {
-  content: "\e200";
-}
+  content: "\e200"; }
 
 .glyphicon-cd:before {
-  content: "\e201";
-}
+  content: "\e201"; }
 
 .glyphicon-save-file:before {
-  content: "\e202";
-}
+  content: "\e202"; }
 
 .glyphicon-open-file:before {
-  content: "\e203";
-}
+  content: "\e203"; }
 
 .glyphicon-level-up:before {
-  content: "\e204";
-}
+  content: "\e204"; }
 
 .glyphicon-copy:before {
-  content: "\e205";
-}
+  content: "\e205"; }
 
 .glyphicon-paste:before {
-  content: "\e206";
-}
+  content: "\e206"; }
 
 .glyphicon-alert:before {
-  content: "\e209";
-}
+  content: "\e209"; }
 
 .glyphicon-equalizer:before {
-  content: "\e210";
-}
+  content: "\e210"; }
 
 .glyphicon-king:before {
-  content: "\e211";
-}
+  content: "\e211"; }
 
 .glyphicon-queen:before {
-  content: "\e212";
-}
+  content: "\e212"; }
 
 .glyphicon-pawn:before {
-  content: "\e213";
-}
+  content: "\e213"; }
 
 .glyphicon-bishop:before {
-  content: "\e214";
-}
+  content: "\e214"; }
 
 .glyphicon-knight:before {
-  content: "\e215";
-}
+  content: "\e215"; }
 
 .glyphicon-baby-formula:before {
-  content: "\e216";
-}
+  content: "\e216"; }
 
 .glyphicon-tent:before {
-  content: "\26fa";
-}
+  content: "\26fa"; }
 
 .glyphicon-blackboard:before {
-  content: "\e218";
-}
+  content: "\e218"; }
 
 .glyphicon-bed:before {
-  content: "\e219";
-}
+  content: "\e219"; }
 
 .glyphicon-apple:before {
-  content: "\f8ff";
-}
+  content: "\f8ff"; }
 
 .glyphicon-erase:before {
-  content: "\e221";
-}
+  content: "\e221"; }
 
 .glyphicon-hourglass:before {
-  content: "\231b";
-}
+  content: "\231b"; }
 
 .glyphicon-lamp:before {
-  content: "\e223";
-}
+  content: "\e223"; }
 
 .glyphicon-duplicate:before {
-  content: "\e224";
-}
+  content: "\e224"; }
 
 .glyphicon-piggy-bank:before {
-  content: "\e225";
-}
+  content: "\e225"; }
 
 .glyphicon-scissors:before {
-  content: "\e226";
-}
+  content: "\e226"; }
 
 .glyphicon-bitcoin:before {
-  content: "\e227";
-}
+  content: "\e227"; }
 
 .glyphicon-btc:before {
-  content: "\e227";
-}
+  content: "\e227"; }
 
 .glyphicon-xbt:before {
-  content: "\e227";
-}
+  content: "\e227"; }
 
 .glyphicon-yen:before {
-  content: "\00a5";
-}
+  content: "\00a5"; }
 
 .glyphicon-jpy:before {
-  content: "\00a5";
-}
+  content: "\00a5"; }
 
 .glyphicon-ruble:before {
-  content: "\20bd";
-}
+  content: "\20bd"; }
 
 .glyphicon-rub:before {
-  content: "\20bd";
-}
+  content: "\20bd"; }
 
 .glyphicon-scale:before {
-  content: "\e230";
-}
+  content: "\e230"; }
 
 .glyphicon-ice-lolly:before {
-  content: "\e231";
-}
+  content: "\e231"; }
 
 .glyphicon-ice-lolly-tasted:before {
-  content: "\e232";
-}
+  content: "\e232"; }
 
 .glyphicon-education:before {
-  content: "\e233";
-}
+  content: "\e233"; }
 
 .glyphicon-option-horizontal:before {
-  content: "\e234";
-}
+  content: "\e234"; }
 
 .glyphicon-option-vertical:before {
-  content: "\e235";
-}
+  content: "\e235"; }
 
 .glyphicon-menu-hamburger:before {
-  content: "\e236";
-}
+  content: "\e236"; }
 
 .glyphicon-modal-window:before {
-  content: "\e237";
-}
+  content: "\e237"; }
 
 .glyphicon-oil:before {
-  content: "\e238";
-}
+  content: "\e238"; }
 
 .glyphicon-grain:before {
-  content: "\e239";
-}
+  content: "\e239"; }
 
 .glyphicon-sunglasses:before {
-  content: "\e240";
-}
+  content: "\e240"; }
 
 .glyphicon-text-size:before {
-  content: "\e241";
-}
+  content: "\e241"; }
 
 .glyphicon-text-color:before {
-  content: "\e242";
-}
+  content: "\e242"; }
 
 .glyphicon-text-background:before {
-  content: "\e243";
-}
+  content: "\e243"; }
 
 .glyphicon-object-align-top:before {
-  content: "\e244";
-}
+  content: "\e244"; }
 
 .glyphicon-object-align-bottom:before {
-  content: "\e245";
-}
+  content: "\e245"; }
 
 .glyphicon-object-align-horizontal:before {
-  content: "\e246";
-}
+  content: "\e246"; }
 
 .glyphicon-object-align-left:before {
-  content: "\e247";
-}
+  content: "\e247"; }
 
 .glyphicon-object-align-vertical:before {
-  content: "\e248";
-}
+  content: "\e248"; }
 
 .glyphicon-object-align-right:before {
-  content: "\e249";
-}
+  content: "\e249"; }
 
 .glyphicon-triangle-right:before {
-  content: "\e250";
-}
+  content: "\e250"; }
 
 .glyphicon-triangle-left:before {
-  content: "\e251";
-}
+  content: "\e251"; }
 
 .glyphicon-triangle-bottom:before {
-  content: "\e252";
-}
+  content: "\e252"; }
 
 .glyphicon-triangle-top:before {
-  content: "\e253";
-}
+  content: "\e253"; }
 
 .glyphicon-console:before {
-  content: "\e254";
-}
+  content: "\e254"; }
 
 .glyphicon-superscript:before {
-  content: "\e255";
-}
+  content: "\e255"; }
 
 .glyphicon-subscript:before {
-  content: "\e256";
-}
+  content: "\e256"; }
 
 .glyphicon-menu-left:before {
-  content: "\e257";
-}
+  content: "\e257"; }
 
 .glyphicon-menu-right:before {
-  content: "\e258";
-}
+  content: "\e258"; }
 
 .glyphicon-menu-down:before {
-  content: "\e259";
-}
+  content: "\e259"; }
 
 .glyphicon-menu-up:before {
-  content: "\e260";
-}
+  content: "\e260"; }
 
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 *:before,
 *:after {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 html {
   font-size: 10px;
-  -webkit-tap-highlight-color: transparent;
-}
+  -webkit-tap-highlight-color: transparent; }
 
 body {
   font-family: "Source Sans Pro", Arial, sans-serif;
   font-size: 14px;
   line-height: 1.42857;
   color: #666;
-  background-color: #fff;
-}
+  background-color: #fff; }
 
 input,
 button,
@@ -1511,40 +1170,33 @@ select,
 textarea {
   font-family: inherit;
   font-size: inherit;
-  line-height: inherit;
-}
+  line-height: inherit; }
 
 a {
   color: #2e88be;
-  text-decoration: none;
-}
-a:hover, a:focus {
-  color: #1f5c80;
-  text-decoration: underline;
-}
-a:focus {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}
+  text-decoration: none; }
+  a:hover,
+  a:focus {
+    color: #1f5c80;
+    text-decoration: underline; }
+  a:focus {
+    outline: thin dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px; }
 
 figure {
-  margin: 0;
-}
+  margin: 0; }
 
 img {
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
 .img-responsive {
   display: block;
   max-width: 100%;
-  height: auto;
-}
+  height: auto; }
 
 .img-rounded {
-  border-radius: 6px;
-}
+  border-radius: 6px; }
 
 .img-thumbnail {
   padding: 4px;
@@ -1557,19 +1209,16 @@ img {
   transition: all 0.2s ease-in-out;
   display: inline-block;
   max-width: 100%;
-  height: auto;
-}
+  height: auto; }
 
 .img-circle {
-  border-radius: 50%;
-}
+  border-radius: 50%; }
 
 hr {
   margin-top: 20px;
   margin-bottom: 20px;
   border: 0;
-  border-top: 1px solid #eeeeee;
-}
+  border-top: 1px solid #eeeeee; }
 
 .sr-only {
   position: absolute;
@@ -1579,324 +1228,255 @@ hr {
   padding: 0;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-  border: 0;
-}
+  border: 0; }
 
-.sr-only-focusable:active, .sr-only-focusable:focus {
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
   position: static;
   width: auto;
   height: auto;
   margin: 0;
   overflow: visible;
-  clip: auto;
-}
+  clip: auto; }
 
 [role="button"] {
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: inherit;
   font-weight: 500;
   line-height: 1.1;
-  color: inherit;
-}
-h1 small,
-h1 .small, h2 small,
-h2 .small, h3 small,
-h3 .small, h4 small,
-h4 .small, h5 small,
-h5 .small, h6 small,
-h6 .small,
-.h1 small,
-.h1 .small, .h2 small,
-.h2 .small, .h3 small,
-.h3 .small, .h4 small,
-.h4 .small, .h5 small,
-.h5 .small, .h6 small,
-.h6 .small {
-  font-weight: normal;
-  line-height: 1;
-  color: #999999;
-}
+  color: inherit; }
+  h1 small,
+  h1 .small, h2 small,
+  h2 .small, h3 small,
+  h3 .small, h4 small,
+  h4 .small, h5 small,
+  h5 .small, h6 small,
+  h6 .small,
+  .h1 small,
+  .h1 .small, .h2 small,
+  .h2 .small, .h3 small,
+  .h3 .small, .h4 small,
+  .h4 .small, .h5 small,
+  .h5 .small, .h6 small,
+  .h6 .small {
+    font-weight: normal;
+    line-height: 1;
+    color: #999999; }
 
 h1, .h1,
 h2, .h2,
 h3, .h3 {
   margin-top: 20px;
-  margin-bottom: 10px;
-}
-h1 small,
-h1 .small, .h1 small,
-.h1 .small,
-h2 small,
-h2 .small, .h2 small,
-.h2 .small,
-h3 small,
-h3 .small, .h3 small,
-.h3 .small {
-  font-size: 65%;
-}
+  margin-bottom: 10px; }
+  h1 small,
+  h1 .small, .h1 small,
+  .h1 .small,
+  h2 small,
+  h2 .small, .h2 small,
+  .h2 .small,
+  h3 small,
+  h3 .small, .h3 small,
+  .h3 .small {
+    font-size: 65%; }
 
 h4, .h4,
 h5, .h5,
 h6, .h6 {
   margin-top: 10px;
-  margin-bottom: 10px;
-}
-h4 small,
-h4 .small, .h4 small,
-.h4 .small,
-h5 small,
-h5 .small, .h5 small,
-.h5 .small,
-h6 small,
-h6 .small, .h6 small,
-.h6 .small {
-  font-size: 75%;
-}
+  margin-bottom: 10px; }
+  h4 small,
+  h4 .small, .h4 small,
+  .h4 .small,
+  h5 small,
+  h5 .small, .h5 small,
+  .h5 .small,
+  h6 small,
+  h6 .small, .h6 small,
+  .h6 .small {
+    font-size: 75%; }
 
 h1, .h1 {
-  font-size: 28px;
-}
+  font-size: 28px; }
 
 h2, .h2 {
-  font-size: 30px;
-}
+  font-size: 30px; }
 
 h3, .h3 {
-  font-size: 24px;
-}
+  font-size: 24px; }
 
 h4, .h4 {
-  font-size: 18px;
-}
+  font-size: 18px; }
 
 h5, .h5 {
-  font-size: 14px;
-}
+  font-size: 14px; }
 
 h6, .h6 {
-  font-size: 12px;
-}
+  font-size: 12px; }
 
 p {
-  margin: 0 0 10px;
-}
+  margin: 0 0 10px; }
 
 .lead {
   margin-bottom: 20px;
   font-size: 16px;
   font-weight: 300;
-  line-height: 1.4;
-}
-@media (min-width: 768px) {
-  .lead {
-    font-size: 21px;
-  }
-}
+  line-height: 1.4; }
+  @media (min-width: 768px) {
+    .lead {
+      font-size: 21px; } }
 
 small,
 .small {
-  font-size: 85%;
-}
+  font-size: 85%; }
 
 mark,
 .mark {
   background-color: #fdfde9;
-  padding: .2em;
-}
+  padding: .2em; }
 
 .text-left {
-  text-align: left;
-}
+  text-align: left; }
 
 .text-right {
-  text-align: right;
-}
+  text-align: right; }
 
 .text-center {
-  text-align: center;
-}
+  text-align: center; }
 
 .text-justify {
-  text-align: justify;
-}
+  text-align: justify; }
 
 .text-nowrap {
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
 .text-lowercase {
-  text-transform: lowercase;
-}
+  text-transform: lowercase; }
 
 .text-uppercase, .initialism {
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
 .text-capitalize {
-  text-transform: capitalize;
-}
+  text-transform: capitalize; }
 
 .text-muted {
-  color: #999999;
-}
+  color: #999999; }
 
 .text-primary {
-  color: #f1f1f1;
-}
+  color: #f1f1f1; }
 
-a.text-primary:hover,
-a.text-primary:focus {
-  color: #d7d7d7;
-}
+a.text-primary:hover {
+  color: #d7d7d7; }
 
 .text-success {
-  color: #9bb83a;
-}
+  color: #9bb83a; }
 
-a.text-success:hover,
-a.text-success:focus {
-  color: #7a912e;
-}
+a.text-success:hover {
+  color: #7a912e; }
 
 .text-info {
-  color: #389Bc9;
-}
+  color: #389Bc9; }
 
-a.text-info:hover,
-a.text-info:focus {
-  color: #2c7da2;
-}
+a.text-info:hover {
+  color: #2c7da2; }
 
 .text-warning {
-  color: #e5d321;
-}
+  color: #e5d321; }
 
-a.text-warning:hover,
-a.text-warning:focus {
-  color: #bdae16;
-}
+a.text-warning:hover {
+  color: #bdae16; }
 
 .text-danger {
-  color: #e53221;
-}
+  color: #e53221; }
 
-a.text-danger:hover,
-a.text-danger:focus {
-  color: #bd2516;
-}
+a.text-danger:hover {
+  color: #bd2516; }
 
 .bg-primary {
-  color: #fff;
-}
+  color: #fff; }
 
 .bg-primary {
-  background-color: #f1f1f1;
-}
+  background-color: #f1f1f1; }
 
-a.bg-primary:hover,
-a.bg-primary:focus {
-  background-color: #d7d7d7;
-}
+a.bg-primary:hover {
+  background-color: #d7d7d7; }
 
 .bg-success {
-  background-color: #f5f8eb;
-}
+  background-color: #f5f8eb; }
 
-a.bg-success:hover,
-a.bg-success:focus {
-  background-color: #e2ebc5;
-}
+a.bg-success:hover {
+  background-color: #e2ebc5; }
 
 .bg-info {
-  background-color: #ebf5f9;
-}
+  background-color: #ebf5f9; }
 
-a.bg-info:hover,
-a.bg-info:focus {
-  background-color: #c4e1ed;
-}
+a.bg-info:hover {
+  background-color: #c4e1ed; }
 
 .bg-warning {
-  background-color: #fdfde9;
-}
+  background-color: #fdfde9; }
 
-a.bg-warning:hover,
-a.bg-warning:focus {
-  background-color: #f9f9ba;
-}
+a.bg-warning:hover {
+  background-color: #f9f9ba; }
 
 .bg-danger {
-  background-color: #fceae8;
-}
+  background-color: #fceae8; }
 
-a.bg-danger:hover,
-a.bg-danger:focus {
-  background-color: #f6c1bb;
-}
+a.bg-danger:hover {
+  background-color: #f6c1bb; }
 
 .page-header {
   padding-bottom: 9px;
   margin: 40px 0 20px;
-  border-bottom: 1px solid #eeeeee;
-}
+  border-bottom: 1px solid #eeeeee; }
 
 ul,
 ol {
   margin-top: 0;
-  margin-bottom: 10px;
-}
-ul ul,
-ul ol,
-ol ul,
-ol ol {
-  margin-bottom: 0;
-}
+  margin-bottom: 10px; }
+  ul ul,
+  ul ol,
+  ol ul,
+  ol ol {
+    margin-bottom: 0; }
 
 .list-unstyled {
   padding-left: 0;
-  list-style: none;
-}
+  list-style: none; }
 
 .list-inline {
   padding-left: 0;
   list-style: none;
-  margin-left: -5px;
-}
-.list-inline > li {
-  display: inline-block;
-  padding-left: 5px;
-  padding-right: 5px;
-}
+  margin-left: -5px; }
+  .list-inline > li {
+    display: inline-block;
+    padding-left: 5px;
+    padding-right: 5px; }
 
 dl {
   margin-top: 0;
-  margin-bottom: 20px;
-}
+  margin-bottom: 20px; }
 
 dt,
 dd {
-  line-height: 1.42857;
-}
+  line-height: 1.42857; }
 
 dt {
-  font-weight: bold;
-}
+  font-weight: bold; }
 
 dd {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
-.dl-horizontal dd:before, .dl-horizontal dd:after {
-  content: " ";
-  display: table;
-}
+.dl-horizontal dd:before,
 .dl-horizontal dd:after {
-  clear: both;
-}
+  content: " ";
+  display: table; }
+
+.dl-horizontal dd:after {
+  clear: both; }
+
 @media (min-width: 768px) {
   .dl-horizontal dt {
     float: left;
@@ -1905,47 +1485,38 @@ dd {
     text-align: right;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+    white-space: nowrap; }
   .dl-horizontal dd {
-    margin-left: 180px;
-  }
-}
+    margin-left: 180px; } }
 
 abbr[title],
 abbr[data-original-title] {
   cursor: help;
-  border-bottom: 1px dotted #999999;
-}
+  border-bottom: 1px dotted #999999; }
 
 .initialism {
-  font-size: 90%;
-}
+  font-size: 90%; }
 
 blockquote {
   padding: 10px 20px;
   margin: 0 0 20px;
   font-size: 17.5px;
-  border-left: 5px solid #eeeeee;
-}
-blockquote p:last-child,
-blockquote ul:last-child,
-blockquote ol:last-child {
-  margin-bottom: 0;
-}
-blockquote footer,
-blockquote small,
-blockquote .small {
-  display: block;
-  font-size: 80%;
-  line-height: 1.42857;
-  color: #999999;
-}
-blockquote footer:before,
-blockquote small:before,
-blockquote .small:before {
-  content: '\2014 \00A0';
-}
+  border-left: 5px solid #eeeeee; }
+  blockquote p:last-child,
+  blockquote ul:last-child,
+  blockquote ol:last-child {
+    margin-bottom: 0; }
+  blockquote footer,
+  blockquote small,
+  blockquote .small {
+    display: block;
+    font-size: 80%;
+    line-height: 1.42857;
+    color: #999999; }
+    blockquote footer:before,
+    blockquote small:before,
+    blockquote .small:before {
+      content: '\2014 \00A0'; }
 
 .blockquote-reverse,
 blockquote.pull-right {
@@ -1953,45 +1524,39 @@ blockquote.pull-right {
   padding-left: 0;
   border-right: 5px solid #eeeeee;
   border-left: 0;
-  text-align: right;
-}
-.blockquote-reverse footer:before,
-.blockquote-reverse small:before,
-.blockquote-reverse .small:before,
-blockquote.pull-right footer:before,
-blockquote.pull-right small:before,
-blockquote.pull-right .small:before {
-  content: '';
-}
-.blockquote-reverse footer:after,
-.blockquote-reverse small:after,
-.blockquote-reverse .small:after,
-blockquote.pull-right footer:after,
-blockquote.pull-right small:after,
-blockquote.pull-right .small:after {
-  content: '\00A0 \2014';
-}
+  text-align: right; }
+  .blockquote-reverse footer:before,
+  .blockquote-reverse small:before,
+  .blockquote-reverse .small:before,
+  blockquote.pull-right footer:before,
+  blockquote.pull-right small:before,
+  blockquote.pull-right .small:before {
+    content: ''; }
+  .blockquote-reverse footer:after,
+  .blockquote-reverse small:after,
+  .blockquote-reverse .small:after,
+  blockquote.pull-right footer:after,
+  blockquote.pull-right small:after,
+  blockquote.pull-right .small:after {
+    content: '\00A0 \2014'; }
 
 address {
   margin-bottom: 20px;
   font-style: normal;
-  line-height: 1.42857;
-}
+  line-height: 1.42857; }
 
 code,
 kbd,
 pre,
 samp {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-}
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace; }
 
 code {
   padding: 2px 4px;
   font-size: 90%;
   color: #c7254e;
   background-color: #f9f2f4;
-  border-radius: 4px;
-}
+  border-radius: 4px; }
 
 kbd {
   padding: 2px 4px;
@@ -1999,14 +1564,12 @@ kbd {
   color: #fff;
   background-color: #333;
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
-}
-kbd kbd {
-  padding: 0;
-  font-size: 100%;
-  font-weight: bold;
-  box-shadow: none;
-}
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25); }
+  kbd kbd {
+    padding: 0;
+    font-size: 100%;
+    font-weight: bold;
+    box-shadow: none; }
 
 pre {
   display: block;
@@ -2019,968 +1582,582 @@ pre {
   color: #333333;
   background-color: #f5f5f5;
   border: 1px solid #ccc;
-  border-radius: 4px;
-}
-pre code {
-  padding: 0;
-  font-size: inherit;
-  color: inherit;
-  white-space: pre-wrap;
-  background-color: transparent;
-  border-radius: 0;
-}
+  border-radius: 4px; }
+  pre code {
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+    white-space: pre-wrap;
+    background-color: transparent;
+    border-radius: 0; }
 
 .pre-scrollable {
   max-height: 340px;
-  overflow-y: scroll;
-}
+  overflow-y: scroll; }
 
 .container {
   margin-right: auto;
   margin-left: auto;
   padding-left: 15px;
-  padding-right: 15px;
-}
-.container:before, .container:after {
-  content: " ";
-  display: table;
-}
-.container:after {
-  clear: both;
-}
-@media (min-width: 768px) {
-  .container {
-    width: 750px;
-  }
-}
-@media (min-width: 992px) {
-  .container {
-    width: 970px;
-  }
-}
-@media (min-width: 1200px) {
-  .container {
-    width: 1170px;
-  }
-}
+  padding-right: 15px; }
+  .container:before,
+  .container:after {
+    content: " ";
+    display: table; }
+  .container:after {
+    clear: both; }
+  @media (min-width: 768px) {
+    .container {
+      width: 750px; } }
+  @media (min-width: 992px) {
+    .container {
+      width: 970px; } }
+  @media (min-width: 1200px) {
+    .container {
+      width: 1170px; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-left: 15px;
-  padding-right: 15px;
-}
-.container-fluid:before, .container-fluid:after {
-  content: " ";
-  display: table;
-}
-.container-fluid:after {
-  clear: both;
-}
+  padding-right: 15px; }
+  .container-fluid:before,
+  .container-fluid:after {
+    content: " ";
+    display: table; }
+  .container-fluid:after {
+    clear: both; }
 
 .row {
   margin-left: -15px;
-  margin-right: -15px;
-}
-.row:before, .row:after {
-  content: " ";
-  display: table;
-}
-.row:after {
-  clear: both;
-}
+  margin-right: -15px; }
+  .row:before,
+  .row:after {
+    content: " ";
+    display: table; }
+  .row:after {
+    clear: both; }
 
 .col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
   position: relative;
   min-height: 1px;
   padding-left: 15px;
-  padding-right: 15px;
-}
+  padding-right: 15px; }
 
 .col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
-  float: left;
-}
+  float: left; }
 
 .col-xs-1 {
-  width: 8.33333%;
-}
+  width: 8.33333%; }
 
 .col-xs-2 {
-  width: 16.66667%;
-}
+  width: 16.66667%; }
 
 .col-xs-3 {
-  width: 25%;
-}
+  width: 25%; }
 
 .col-xs-4 {
-  width: 33.33333%;
-}
+  width: 33.33333%; }
 
 .col-xs-5 {
-  width: 41.66667%;
-}
+  width: 41.66667%; }
 
 .col-xs-6 {
-  width: 50%;
-}
+  width: 50%; }
 
 .col-xs-7 {
-  width: 58.33333%;
-}
+  width: 58.33333%; }
 
 .col-xs-8 {
-  width: 66.66667%;
-}
+  width: 66.66667%; }
 
 .col-xs-9 {
-  width: 75%;
-}
+  width: 75%; }
 
 .col-xs-10 {
-  width: 83.33333%;
-}
+  width: 83.33333%; }
 
 .col-xs-11 {
-  width: 91.66667%;
-}
+  width: 91.66667%; }
 
 .col-xs-12 {
-  width: 100%;
-}
+  width: 100%; }
 
 .col-xs-pull-0 {
-  right: auto;
-}
+  right: auto; }
 
 .col-xs-pull-1 {
-  right: 8.33333%;
-}
+  right: 8.33333%; }
 
 .col-xs-pull-2 {
-  right: 16.66667%;
-}
+  right: 16.66667%; }
 
 .col-xs-pull-3 {
-  right: 25%;
-}
+  right: 25%; }
 
 .col-xs-pull-4 {
-  right: 33.33333%;
-}
+  right: 33.33333%; }
 
 .col-xs-pull-5 {
-  right: 41.66667%;
-}
+  right: 41.66667%; }
 
 .col-xs-pull-6 {
-  right: 50%;
-}
+  right: 50%; }
 
 .col-xs-pull-7 {
-  right: 58.33333%;
-}
+  right: 58.33333%; }
 
 .col-xs-pull-8 {
-  right: 66.66667%;
-}
+  right: 66.66667%; }
 
 .col-xs-pull-9 {
-  right: 75%;
-}
+  right: 75%; }
 
 .col-xs-pull-10 {
-  right: 83.33333%;
-}
+  right: 83.33333%; }
 
 .col-xs-pull-11 {
-  right: 91.66667%;
-}
+  right: 91.66667%; }
 
 .col-xs-pull-12 {
-  right: 100%;
-}
+  right: 100%; }
 
 .col-xs-push-0 {
-  left: auto;
-}
+  left: auto; }
 
 .col-xs-push-1 {
-  left: 8.33333%;
-}
+  left: 8.33333%; }
 
 .col-xs-push-2 {
-  left: 16.66667%;
-}
+  left: 16.66667%; }
 
 .col-xs-push-3 {
-  left: 25%;
-}
+  left: 25%; }
 
 .col-xs-push-4 {
-  left: 33.33333%;
-}
+  left: 33.33333%; }
 
 .col-xs-push-5 {
-  left: 41.66667%;
-}
+  left: 41.66667%; }
 
 .col-xs-push-6 {
-  left: 50%;
-}
+  left: 50%; }
 
 .col-xs-push-7 {
-  left: 58.33333%;
-}
+  left: 58.33333%; }
 
 .col-xs-push-8 {
-  left: 66.66667%;
-}
+  left: 66.66667%; }
 
 .col-xs-push-9 {
-  left: 75%;
-}
+  left: 75%; }
 
 .col-xs-push-10 {
-  left: 83.33333%;
-}
+  left: 83.33333%; }
 
 .col-xs-push-11 {
-  left: 91.66667%;
-}
+  left: 91.66667%; }
 
 .col-xs-push-12 {
-  left: 100%;
-}
+  left: 100%; }
 
 .col-xs-offset-0 {
-  margin-left: 0%;
-}
+  margin-left: 0%; }
 
 .col-xs-offset-1 {
-  margin-left: 8.33333%;
-}
+  margin-left: 8.33333%; }
 
 .col-xs-offset-2 {
-  margin-left: 16.66667%;
-}
+  margin-left: 16.66667%; }
 
 .col-xs-offset-3 {
-  margin-left: 25%;
-}
+  margin-left: 25%; }
 
 .col-xs-offset-4 {
-  margin-left: 33.33333%;
-}
+  margin-left: 33.33333%; }
 
 .col-xs-offset-5 {
-  margin-left: 41.66667%;
-}
+  margin-left: 41.66667%; }
 
 .col-xs-offset-6 {
-  margin-left: 50%;
-}
+  margin-left: 50%; }
 
 .col-xs-offset-7 {
-  margin-left: 58.33333%;
-}
+  margin-left: 58.33333%; }
 
 .col-xs-offset-8 {
-  margin-left: 66.66667%;
-}
+  margin-left: 66.66667%; }
 
 .col-xs-offset-9 {
-  margin-left: 75%;
-}
+  margin-left: 75%; }
 
 .col-xs-offset-10 {
-  margin-left: 83.33333%;
-}
+  margin-left: 83.33333%; }
 
 .col-xs-offset-11 {
-  margin-left: 91.66667%;
-}
+  margin-left: 91.66667%; }
 
 .col-xs-offset-12 {
-  margin-left: 100%;
-}
+  margin-left: 100%; }
 
 @media (min-width: 768px) {
   .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
-    float: left;
-  }
-
+    float: left; }
   .col-sm-1 {
-    width: 8.33333%;
-  }
-
+    width: 8.33333%; }
   .col-sm-2 {
-    width: 16.66667%;
-  }
-
+    width: 16.66667%; }
   .col-sm-3 {
-    width: 25%;
-  }
-
+    width: 25%; }
   .col-sm-4 {
-    width: 33.33333%;
-  }
-
+    width: 33.33333%; }
   .col-sm-5 {
-    width: 41.66667%;
-  }
-
+    width: 41.66667%; }
   .col-sm-6 {
-    width: 50%;
-  }
-
+    width: 50%; }
   .col-sm-7 {
-    width: 58.33333%;
-  }
-
+    width: 58.33333%; }
   .col-sm-8 {
-    width: 66.66667%;
-  }
-
+    width: 66.66667%; }
   .col-sm-9 {
-    width: 75%;
-  }
-
+    width: 75%; }
   .col-sm-10 {
-    width: 83.33333%;
-  }
-
+    width: 83.33333%; }
   .col-sm-11 {
-    width: 91.66667%;
-  }
-
+    width: 91.66667%; }
   .col-sm-12 {
-    width: 100%;
-  }
-
+    width: 100%; }
   .col-sm-pull-0 {
-    right: auto;
-  }
-
+    right: auto; }
   .col-sm-pull-1 {
-    right: 8.33333%;
-  }
-
+    right: 8.33333%; }
   .col-sm-pull-2 {
-    right: 16.66667%;
-  }
-
+    right: 16.66667%; }
   .col-sm-pull-3 {
-    right: 25%;
-  }
-
+    right: 25%; }
   .col-sm-pull-4 {
-    right: 33.33333%;
-  }
-
+    right: 33.33333%; }
   .col-sm-pull-5 {
-    right: 41.66667%;
-  }
-
+    right: 41.66667%; }
   .col-sm-pull-6 {
-    right: 50%;
-  }
-
+    right: 50%; }
   .col-sm-pull-7 {
-    right: 58.33333%;
-  }
-
+    right: 58.33333%; }
   .col-sm-pull-8 {
-    right: 66.66667%;
-  }
-
+    right: 66.66667%; }
   .col-sm-pull-9 {
-    right: 75%;
-  }
-
+    right: 75%; }
   .col-sm-pull-10 {
-    right: 83.33333%;
-  }
-
+    right: 83.33333%; }
   .col-sm-pull-11 {
-    right: 91.66667%;
-  }
-
+    right: 91.66667%; }
   .col-sm-pull-12 {
-    right: 100%;
-  }
-
+    right: 100%; }
   .col-sm-push-0 {
-    left: auto;
-  }
-
+    left: auto; }
   .col-sm-push-1 {
-    left: 8.33333%;
-  }
-
+    left: 8.33333%; }
   .col-sm-push-2 {
-    left: 16.66667%;
-  }
-
+    left: 16.66667%; }
   .col-sm-push-3 {
-    left: 25%;
-  }
-
+    left: 25%; }
   .col-sm-push-4 {
-    left: 33.33333%;
-  }
-
+    left: 33.33333%; }
   .col-sm-push-5 {
-    left: 41.66667%;
-  }
-
+    left: 41.66667%; }
   .col-sm-push-6 {
-    left: 50%;
-  }
-
+    left: 50%; }
   .col-sm-push-7 {
-    left: 58.33333%;
-  }
-
+    left: 58.33333%; }
   .col-sm-push-8 {
-    left: 66.66667%;
-  }
-
+    left: 66.66667%; }
   .col-sm-push-9 {
-    left: 75%;
-  }
-
+    left: 75%; }
   .col-sm-push-10 {
-    left: 83.33333%;
-  }
-
+    left: 83.33333%; }
   .col-sm-push-11 {
-    left: 91.66667%;
-  }
-
+    left: 91.66667%; }
   .col-sm-push-12 {
-    left: 100%;
-  }
-
+    left: 100%; }
   .col-sm-offset-0 {
-    margin-left: 0%;
-  }
-
+    margin-left: 0%; }
   .col-sm-offset-1 {
-    margin-left: 8.33333%;
-  }
-
+    margin-left: 8.33333%; }
   .col-sm-offset-2 {
-    margin-left: 16.66667%;
-  }
-
+    margin-left: 16.66667%; }
   .col-sm-offset-3 {
-    margin-left: 25%;
-  }
-
+    margin-left: 25%; }
   .col-sm-offset-4 {
-    margin-left: 33.33333%;
-  }
-
+    margin-left: 33.33333%; }
   .col-sm-offset-5 {
-    margin-left: 41.66667%;
-  }
-
+    margin-left: 41.66667%; }
   .col-sm-offset-6 {
-    margin-left: 50%;
-  }
-
+    margin-left: 50%; }
   .col-sm-offset-7 {
-    margin-left: 58.33333%;
-  }
-
+    margin-left: 58.33333%; }
   .col-sm-offset-8 {
-    margin-left: 66.66667%;
-  }
-
+    margin-left: 66.66667%; }
   .col-sm-offset-9 {
-    margin-left: 75%;
-  }
-
+    margin-left: 75%; }
   .col-sm-offset-10 {
-    margin-left: 83.33333%;
-  }
-
+    margin-left: 83.33333%; }
   .col-sm-offset-11 {
-    margin-left: 91.66667%;
-  }
-
+    margin-left: 91.66667%; }
   .col-sm-offset-12 {
-    margin-left: 100%;
-  }
-}
+    margin-left: 100%; } }
+
 @media (min-width: 992px) {
   .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
-    float: left;
-  }
-
+    float: left; }
   .col-md-1 {
-    width: 8.33333%;
-  }
-
+    width: 8.33333%; }
   .col-md-2 {
-    width: 16.66667%;
-  }
-
+    width: 16.66667%; }
   .col-md-3 {
-    width: 25%;
-  }
-
+    width: 25%; }
   .col-md-4 {
-    width: 33.33333%;
-  }
-
+    width: 33.33333%; }
   .col-md-5 {
-    width: 41.66667%;
-  }
-
+    width: 41.66667%; }
   .col-md-6 {
-    width: 50%;
-  }
-
+    width: 50%; }
   .col-md-7 {
-    width: 58.33333%;
-  }
-
+    width: 58.33333%; }
   .col-md-8 {
-    width: 66.66667%;
-  }
-
+    width: 66.66667%; }
   .col-md-9 {
-    width: 75%;
-  }
-
+    width: 75%; }
   .col-md-10 {
-    width: 83.33333%;
-  }
-
+    width: 83.33333%; }
   .col-md-11 {
-    width: 91.66667%;
-  }
-
+    width: 91.66667%; }
   .col-md-12 {
-    width: 100%;
-  }
-
+    width: 100%; }
   .col-md-pull-0 {
-    right: auto;
-  }
-
+    right: auto; }
   .col-md-pull-1 {
-    right: 8.33333%;
-  }
-
+    right: 8.33333%; }
   .col-md-pull-2 {
-    right: 16.66667%;
-  }
-
+    right: 16.66667%; }
   .col-md-pull-3 {
-    right: 25%;
-  }
-
+    right: 25%; }
   .col-md-pull-4 {
-    right: 33.33333%;
-  }
-
+    right: 33.33333%; }
   .col-md-pull-5 {
-    right: 41.66667%;
-  }
-
+    right: 41.66667%; }
   .col-md-pull-6 {
-    right: 50%;
-  }
-
+    right: 50%; }
   .col-md-pull-7 {
-    right: 58.33333%;
-  }
-
+    right: 58.33333%; }
   .col-md-pull-8 {
-    right: 66.66667%;
-  }
-
+    right: 66.66667%; }
   .col-md-pull-9 {
-    right: 75%;
-  }
-
+    right: 75%; }
   .col-md-pull-10 {
-    right: 83.33333%;
-  }
-
+    right: 83.33333%; }
   .col-md-pull-11 {
-    right: 91.66667%;
-  }
-
+    right: 91.66667%; }
   .col-md-pull-12 {
-    right: 100%;
-  }
-
+    right: 100%; }
   .col-md-push-0 {
-    left: auto;
-  }
-
+    left: auto; }
   .col-md-push-1 {
-    left: 8.33333%;
-  }
-
+    left: 8.33333%; }
   .col-md-push-2 {
-    left: 16.66667%;
-  }
-
+    left: 16.66667%; }
   .col-md-push-3 {
-    left: 25%;
-  }
-
+    left: 25%; }
   .col-md-push-4 {
-    left: 33.33333%;
-  }
-
+    left: 33.33333%; }
   .col-md-push-5 {
-    left: 41.66667%;
-  }
-
+    left: 41.66667%; }
   .col-md-push-6 {
-    left: 50%;
-  }
-
+    left: 50%; }
   .col-md-push-7 {
-    left: 58.33333%;
-  }
-
+    left: 58.33333%; }
   .col-md-push-8 {
-    left: 66.66667%;
-  }
-
+    left: 66.66667%; }
   .col-md-push-9 {
-    left: 75%;
-  }
-
+    left: 75%; }
   .col-md-push-10 {
-    left: 83.33333%;
-  }
-
+    left: 83.33333%; }
   .col-md-push-11 {
-    left: 91.66667%;
-  }
-
+    left: 91.66667%; }
   .col-md-push-12 {
-    left: 100%;
-  }
-
+    left: 100%; }
   .col-md-offset-0 {
-    margin-left: 0%;
-  }
-
+    margin-left: 0%; }
   .col-md-offset-1 {
-    margin-left: 8.33333%;
-  }
-
+    margin-left: 8.33333%; }
   .col-md-offset-2 {
-    margin-left: 16.66667%;
-  }
-
+    margin-left: 16.66667%; }
   .col-md-offset-3 {
-    margin-left: 25%;
-  }
-
+    margin-left: 25%; }
   .col-md-offset-4 {
-    margin-left: 33.33333%;
-  }
-
+    margin-left: 33.33333%; }
   .col-md-offset-5 {
-    margin-left: 41.66667%;
-  }
-
+    margin-left: 41.66667%; }
   .col-md-offset-6 {
-    margin-left: 50%;
-  }
-
+    margin-left: 50%; }
   .col-md-offset-7 {
-    margin-left: 58.33333%;
-  }
-
+    margin-left: 58.33333%; }
   .col-md-offset-8 {
-    margin-left: 66.66667%;
-  }
-
+    margin-left: 66.66667%; }
   .col-md-offset-9 {
-    margin-left: 75%;
-  }
-
+    margin-left: 75%; }
   .col-md-offset-10 {
-    margin-left: 83.33333%;
-  }
-
+    margin-left: 83.33333%; }
   .col-md-offset-11 {
-    margin-left: 91.66667%;
-  }
-
+    margin-left: 91.66667%; }
   .col-md-offset-12 {
-    margin-left: 100%;
-  }
-}
+    margin-left: 100%; } }
+
 @media (min-width: 1200px) {
   .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
-    float: left;
-  }
-
+    float: left; }
   .col-lg-1 {
-    width: 8.33333%;
-  }
-
+    width: 8.33333%; }
   .col-lg-2 {
-    width: 16.66667%;
-  }
-
+    width: 16.66667%; }
   .col-lg-3 {
-    width: 25%;
-  }
-
+    width: 25%; }
   .col-lg-4 {
-    width: 33.33333%;
-  }
-
+    width: 33.33333%; }
   .col-lg-5 {
-    width: 41.66667%;
-  }
-
+    width: 41.66667%; }
   .col-lg-6 {
-    width: 50%;
-  }
-
+    width: 50%; }
   .col-lg-7 {
-    width: 58.33333%;
-  }
-
+    width: 58.33333%; }
   .col-lg-8 {
-    width: 66.66667%;
-  }
-
+    width: 66.66667%; }
   .col-lg-9 {
-    width: 75%;
-  }
-
+    width: 75%; }
   .col-lg-10 {
-    width: 83.33333%;
-  }
-
+    width: 83.33333%; }
   .col-lg-11 {
-    width: 91.66667%;
-  }
-
+    width: 91.66667%; }
   .col-lg-12 {
-    width: 100%;
-  }
-
+    width: 100%; }
   .col-lg-pull-0 {
-    right: auto;
-  }
-
+    right: auto; }
   .col-lg-pull-1 {
-    right: 8.33333%;
-  }
-
+    right: 8.33333%; }
   .col-lg-pull-2 {
-    right: 16.66667%;
-  }
-
+    right: 16.66667%; }
   .col-lg-pull-3 {
-    right: 25%;
-  }
-
+    right: 25%; }
   .col-lg-pull-4 {
-    right: 33.33333%;
-  }
-
+    right: 33.33333%; }
   .col-lg-pull-5 {
-    right: 41.66667%;
-  }
-
+    right: 41.66667%; }
   .col-lg-pull-6 {
-    right: 50%;
-  }
-
+    right: 50%; }
   .col-lg-pull-7 {
-    right: 58.33333%;
-  }
-
+    right: 58.33333%; }
   .col-lg-pull-8 {
-    right: 66.66667%;
-  }
-
+    right: 66.66667%; }
   .col-lg-pull-9 {
-    right: 75%;
-  }
-
+    right: 75%; }
   .col-lg-pull-10 {
-    right: 83.33333%;
-  }
-
+    right: 83.33333%; }
   .col-lg-pull-11 {
-    right: 91.66667%;
-  }
-
+    right: 91.66667%; }
   .col-lg-pull-12 {
-    right: 100%;
-  }
-
+    right: 100%; }
   .col-lg-push-0 {
-    left: auto;
-  }
-
+    left: auto; }
   .col-lg-push-1 {
-    left: 8.33333%;
-  }
-
+    left: 8.33333%; }
   .col-lg-push-2 {
-    left: 16.66667%;
-  }
-
+    left: 16.66667%; }
   .col-lg-push-3 {
-    left: 25%;
-  }
-
+    left: 25%; }
   .col-lg-push-4 {
-    left: 33.33333%;
-  }
-
+    left: 33.33333%; }
   .col-lg-push-5 {
-    left: 41.66667%;
-  }
-
+    left: 41.66667%; }
   .col-lg-push-6 {
-    left: 50%;
-  }
-
+    left: 50%; }
   .col-lg-push-7 {
-    left: 58.33333%;
-  }
-
+    left: 58.33333%; }
   .col-lg-push-8 {
-    left: 66.66667%;
-  }
-
+    left: 66.66667%; }
   .col-lg-push-9 {
-    left: 75%;
-  }
-
+    left: 75%; }
   .col-lg-push-10 {
-    left: 83.33333%;
-  }
-
+    left: 83.33333%; }
   .col-lg-push-11 {
-    left: 91.66667%;
-  }
-
+    left: 91.66667%; }
   .col-lg-push-12 {
-    left: 100%;
-  }
-
+    left: 100%; }
   .col-lg-offset-0 {
-    margin-left: 0%;
-  }
-
+    margin-left: 0%; }
   .col-lg-offset-1 {
-    margin-left: 8.33333%;
-  }
-
+    margin-left: 8.33333%; }
   .col-lg-offset-2 {
-    margin-left: 16.66667%;
-  }
-
+    margin-left: 16.66667%; }
   .col-lg-offset-3 {
-    margin-left: 25%;
-  }
-
+    margin-left: 25%; }
   .col-lg-offset-4 {
-    margin-left: 33.33333%;
-  }
-
+    margin-left: 33.33333%; }
   .col-lg-offset-5 {
-    margin-left: 41.66667%;
-  }
-
+    margin-left: 41.66667%; }
   .col-lg-offset-6 {
-    margin-left: 50%;
-  }
-
+    margin-left: 50%; }
   .col-lg-offset-7 {
-    margin-left: 58.33333%;
-  }
-
+    margin-left: 58.33333%; }
   .col-lg-offset-8 {
-    margin-left: 66.66667%;
-  }
-
+    margin-left: 66.66667%; }
   .col-lg-offset-9 {
-    margin-left: 75%;
-  }
-
+    margin-left: 75%; }
   .col-lg-offset-10 {
-    margin-left: 83.33333%;
-  }
-
+    margin-left: 83.33333%; }
   .col-lg-offset-11 {
-    margin-left: 91.66667%;
-  }
-
+    margin-left: 91.66667%; }
   .col-lg-offset-12 {
-    margin-left: 100%;
-  }
-}
+    margin-left: 100%; } }
+
 table {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
 caption {
   padding-top: 20px;
   padding-bottom: 20px;
   color: #999999;
-  text-align: left;
-}
+  text-align: left; }
 
 th {
-  text-align: left;
-}
+  text-align: left; }
 
 .table {
   width: 100%;
   max-width: 100%;
-  margin-bottom: 20px;
-}
-.table > thead > tr > th,
-.table > thead > tr > td,
-.table > tbody > tr > th,
-.table > tbody > tr > td,
-.table > tfoot > tr > th,
-.table > tfoot > tr > td {
-  padding: 20px;
-  line-height: 1.42857;
-  vertical-align: top;
-  border-top: 1px solid #ddd;
-}
-.table > thead > tr > th {
-  vertical-align: bottom;
-  border-bottom: 2px solid #ddd;
-}
-.table > caption + thead > tr:first-child > th,
-.table > caption + thead > tr:first-child > td,
-.table > colgroup + thead > tr:first-child > th,
-.table > colgroup + thead > tr:first-child > td,
-.table > thead:first-child > tr:first-child > th,
-.table > thead:first-child > tr:first-child > td {
-  border-top: 0;
-}
-.table > tbody + tbody {
-  border-top: 2px solid #ddd;
-}
-.table .table {
-  background-color: #fff;
-}
+  margin-bottom: 20px; }
+  .table > thead > tr > th,
+  .table > thead > tr > td,
+  .table > tbody > tr > th,
+  .table > tbody > tr > td,
+  .table > tfoot > tr > th,
+  .table > tfoot > tr > td {
+    padding: 20px;
+    line-height: 1.42857;
+    vertical-align: top;
+    border-top: 1px solid #ddd; }
+  .table > thead > tr > th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #ddd; }
+  .table > caption + thead > tr:first-child > th,
+  .table > caption + thead > tr:first-child > td,
+  .table > colgroup + thead > tr:first-child > th,
+  .table > colgroup + thead > tr:first-child > td,
+  .table > thead:first-child > tr:first-child > th,
+  .table > thead:first-child > tr:first-child > td {
+    border-top: 0; }
+  .table > tbody + tbody {
+    border-top: 2px solid #ddd; }
+  .table .table {
+    background-color: #fff; }
 
 .table-condensed > thead > tr > th,
 .table-condensed > thead > tr > td,
@@ -2988,48 +2165,42 @@ th {
 .table-condensed > tbody > tr > td,
 .table-condensed > tfoot > tr > th,
 .table-condensed > tfoot > tr > td {
-  padding: 5px;
-}
+  padding: 5px; }
 
 .table-bordered {
-  border: 1px solid #ddd;
-}
-.table-bordered > thead > tr > th,
-.table-bordered > thead > tr > td,
-.table-bordered > tbody > tr > th,
-.table-bordered > tbody > tr > td,
-.table-bordered > tfoot > tr > th,
-.table-bordered > tfoot > tr > td {
-  border: 1px solid #ddd;
-}
-.table-bordered > thead > tr > th,
-.table-bordered > thead > tr > td {
-  border-bottom-width: 2px;
-}
+  border: 1px solid #ddd; }
+  .table-bordered > thead > tr > th,
+  .table-bordered > thead > tr > td,
+  .table-bordered > tbody > tr > th,
+  .table-bordered > tbody > tr > td,
+  .table-bordered > tfoot > tr > th,
+  .table-bordered > tfoot > tr > td {
+    border: 1px solid #ddd; }
+  .table-bordered > thead > tr > th,
+  .table-bordered > thead > tr > td {
+    border-bottom-width: 2px; }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: #f1f8fb;
-}
+  background-color: #f1f8fb; }
 
 .table-hover > tbody > tr:hover {
-  background-color: #f5f5f5;
-}
+  background-color: #f5f5f5; }
 
 table col[class*="col-"] {
   position: static;
   float: none;
-  display: table-column;
-}
+  display: table-column; }
 
 table td[class*="col-"],
 table th[class*="col-"] {
   position: static;
   float: none;
-  display: table-cell;
-}
+  display: table-cell; }
 
 .table > thead > tr > td.active,
-.table > thead > tr > th.active, .table > thead > tr.active > td, .table > thead > tr.active > th,
+.table > thead > tr > th.active,
+.table > thead > tr.active > td,
+.table > thead > tr.active > th,
 .table > tbody > tr > td.active,
 .table > tbody > tr > th.active,
 .table > tbody > tr.active > td,
@@ -3038,16 +2209,19 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.active,
 .table > tfoot > tr.active > td,
 .table > tfoot > tr.active > th {
-  background-color: #f5f5f5;
-}
+  background-color: #f5f5f5; }
 
 .table-hover > tbody > tr > td.active:hover,
-.table-hover > tbody > tr > th.active:hover, .table-hover > tbody > tr.active:hover > td, .table-hover > tbody > tr:hover > .active, .table-hover > tbody > tr.active:hover > th {
-  background-color: #e8e8e8;
-}
+.table-hover > tbody > tr > th.active:hover,
+.table-hover > tbody > tr.active:hover > td,
+.table-hover > tbody > tr:hover > .active,
+.table-hover > tbody > tr.active:hover > th {
+  background-color: #e8e8e8; }
 
 .table > thead > tr > td.success,
-.table > thead > tr > th.success, .table > thead > tr.success > td, .table > thead > tr.success > th,
+.table > thead > tr > th.success,
+.table > thead > tr.success > td,
+.table > thead > tr.success > th,
 .table > tbody > tr > td.success,
 .table > tbody > tr > th.success,
 .table > tbody > tr.success > td,
@@ -3056,16 +2230,19 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.success,
 .table > tfoot > tr.success > td,
 .table > tfoot > tr.success > th {
-  background-color: #f5f8eb;
-}
+  background-color: #f5f8eb; }
 
 .table-hover > tbody > tr > td.success:hover,
-.table-hover > tbody > tr > th.success:hover, .table-hover > tbody > tr.success:hover > td, .table-hover > tbody > tr:hover > .success, .table-hover > tbody > tr.success:hover > th {
-  background-color: #ecf1d8;
-}
+.table-hover > tbody > tr > th.success:hover,
+.table-hover > tbody > tr.success:hover > td,
+.table-hover > tbody > tr:hover > .success,
+.table-hover > tbody > tr.success:hover > th {
+  background-color: #ecf1d8; }
 
 .table > thead > tr > td.info,
-.table > thead > tr > th.info, .table > thead > tr.info > td, .table > thead > tr.info > th,
+.table > thead > tr > th.info,
+.table > thead > tr.info > td,
+.table > thead > tr.info > th,
 .table > tbody > tr > td.info,
 .table > tbody > tr > th.info,
 .table > tbody > tr.info > td,
@@ -3074,16 +2251,19 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.info,
 .table > tfoot > tr.info > td,
 .table > tfoot > tr.info > th {
-  background-color: #ebf5f9;
-}
+  background-color: #ebf5f9; }
 
 .table-hover > tbody > tr > td.info:hover,
-.table-hover > tbody > tr > th.info:hover, .table-hover > tbody > tr.info:hover > td, .table-hover > tbody > tr:hover > .info, .table-hover > tbody > tr.info:hover > th {
-  background-color: #d7ebf3;
-}
+.table-hover > tbody > tr > th.info:hover,
+.table-hover > tbody > tr.info:hover > td,
+.table-hover > tbody > tr:hover > .info,
+.table-hover > tbody > tr.info:hover > th {
+  background-color: #d7ebf3; }
 
 .table > thead > tr > td.warning,
-.table > thead > tr > th.warning, .table > thead > tr.warning > td, .table > thead > tr.warning > th,
+.table > thead > tr > th.warning,
+.table > thead > tr.warning > td,
+.table > thead > tr.warning > th,
 .table > tbody > tr > td.warning,
 .table > tbody > tr > th.warning,
 .table > tbody > tr.warning > td,
@@ -3092,16 +2272,19 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.warning,
 .table > tfoot > tr.warning > td,
 .table > tfoot > tr.warning > th {
-  background-color: #fdfde9;
-}
+  background-color: #fdfde9; }
 
 .table-hover > tbody > tr > td.warning:hover,
-.table-hover > tbody > tr > th.warning:hover, .table-hover > tbody > tr.warning:hover > td, .table-hover > tbody > tr:hover > .warning, .table-hover > tbody > tr.warning:hover > th {
-  background-color: #fbfbd2;
-}
+.table-hover > tbody > tr > th.warning:hover,
+.table-hover > tbody > tr.warning:hover > td,
+.table-hover > tbody > tr:hover > .warning,
+.table-hover > tbody > tr.warning:hover > th {
+  background-color: #fbfbd2; }
 
 .table > thead > tr > td.danger,
-.table > thead > tr > th.danger, .table > thead > tr.danger > td, .table > thead > tr.danger > th,
+.table > thead > tr > th.danger,
+.table > thead > tr.danger > td,
+.table > thead > tr.danger > th,
 .table > tbody > tr > td.danger,
 .table > tbody > tr > th.danger,
 .table > tbody > tr.danger > td,
@@ -3110,70 +2293,61 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.danger,
 .table > tfoot > tr.danger > td,
 .table > tfoot > tr.danger > th {
-  background-color: #fceae8;
-}
+  background-color: #fceae8; }
 
 .table-hover > tbody > tr > td.danger:hover,
-.table-hover > tbody > tr > th.danger:hover, .table-hover > tbody > tr.danger:hover > td, .table-hover > tbody > tr:hover > .danger, .table-hover > tbody > tr.danger:hover > th {
-  background-color: #f9d5d1;
-}
+.table-hover > tbody > tr > th.danger:hover,
+.table-hover > tbody > tr.danger:hover > td,
+.table-hover > tbody > tr:hover > .danger,
+.table-hover > tbody > tr.danger:hover > th {
+  background-color: #f9d5d1; }
 
 .table-responsive {
   overflow-x: auto;
-  min-height: 0.01%;
-}
-@media screen and (max-width: 767px) {
-  .table-responsive {
-    width: 100%;
-    margin-bottom: 15px;
-    overflow-y: hidden;
-    -ms-overflow-style: -ms-autohiding-scrollbar;
-    border: 1px solid #ddd;
-  }
-  .table-responsive > .table {
-    margin-bottom: 0;
-  }
-  .table-responsive > .table > thead > tr > th,
-  .table-responsive > .table > thead > tr > td,
-  .table-responsive > .table > tbody > tr > th,
-  .table-responsive > .table > tbody > tr > td,
-  .table-responsive > .table > tfoot > tr > th,
-  .table-responsive > .table > tfoot > tr > td {
-    white-space: nowrap;
-  }
-  .table-responsive > .table-bordered {
-    border: 0;
-  }
-  .table-responsive > .table-bordered > thead > tr > th:first-child,
-  .table-responsive > .table-bordered > thead > tr > td:first-child,
-  .table-responsive > .table-bordered > tbody > tr > th:first-child,
-  .table-responsive > .table-bordered > tbody > tr > td:first-child,
-  .table-responsive > .table-bordered > tfoot > tr > th:first-child,
-  .table-responsive > .table-bordered > tfoot > tr > td:first-child {
-    border-left: 0;
-  }
-  .table-responsive > .table-bordered > thead > tr > th:last-child,
-  .table-responsive > .table-bordered > thead > tr > td:last-child,
-  .table-responsive > .table-bordered > tbody > tr > th:last-child,
-  .table-responsive > .table-bordered > tbody > tr > td:last-child,
-  .table-responsive > .table-bordered > tfoot > tr > th:last-child,
-  .table-responsive > .table-bordered > tfoot > tr > td:last-child {
-    border-right: 0;
-  }
-  .table-responsive > .table-bordered > tbody > tr:last-child > th,
-  .table-responsive > .table-bordered > tbody > tr:last-child > td,
-  .table-responsive > .table-bordered > tfoot > tr:last-child > th,
-  .table-responsive > .table-bordered > tfoot > tr:last-child > td {
-    border-bottom: 0;
-  }
-}
+  min-height: 0.01%; }
+  @media screen and (max-width: 767px) {
+    .table-responsive {
+      width: 100%;
+      margin-bottom: 15px;
+      overflow-y: hidden;
+      -ms-overflow-style: -ms-autohiding-scrollbar;
+      border: 1px solid #ddd; }
+      .table-responsive > .table {
+        margin-bottom: 0; }
+        .table-responsive > .table > thead > tr > th,
+        .table-responsive > .table > thead > tr > td,
+        .table-responsive > .table > tbody > tr > th,
+        .table-responsive > .table > tbody > tr > td,
+        .table-responsive > .table > tfoot > tr > th,
+        .table-responsive > .table > tfoot > tr > td {
+          white-space: nowrap; }
+      .table-responsive > .table-bordered {
+        border: 0; }
+        .table-responsive > .table-bordered > thead > tr > th:first-child,
+        .table-responsive > .table-bordered > thead > tr > td:first-child,
+        .table-responsive > .table-bordered > tbody > tr > th:first-child,
+        .table-responsive > .table-bordered > tbody > tr > td:first-child,
+        .table-responsive > .table-bordered > tfoot > tr > th:first-child,
+        .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+          border-left: 0; }
+        .table-responsive > .table-bordered > thead > tr > th:last-child,
+        .table-responsive > .table-bordered > thead > tr > td:last-child,
+        .table-responsive > .table-bordered > tbody > tr > th:last-child,
+        .table-responsive > .table-bordered > tbody > tr > td:last-child,
+        .table-responsive > .table-bordered > tfoot > tr > th:last-child,
+        .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+          border-right: 0; }
+        .table-responsive > .table-bordered > tbody > tr:last-child > th,
+        .table-responsive > .table-bordered > tbody > tr:last-child > td,
+        .table-responsive > .table-bordered > tfoot > tr:last-child > th,
+        .table-responsive > .table-bordered > tfoot > tr:last-child > td {
+          border-bottom: 0; } }
 
 fieldset {
   padding: 0;
   margin: 0;
   border: 0;
-  min-width: 0;
-}
+  min-width: 0; }
 
 legend {
   display: block;
@@ -3184,58 +2358,49 @@ legend {
   line-height: inherit;
   color: #333333;
   border: 0;
-  border-bottom: 1px solid #e5e5e5;
-}
+  border-bottom: 1px solid #e5e5e5; }
 
 label {
   display: inline-block;
   max-width: 100%;
   margin-bottom: 5px;
-  font-weight: bold;
-}
+  font-weight: bold; }
 
 input[type="search"] {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 input[type="radio"],
 input[type="checkbox"] {
   margin: 4px 0 0;
   margin-top: 1px \9;
-  line-height: normal;
-}
+  line-height: normal; }
 
 input[type="file"] {
-  display: block;
-}
+  display: block; }
 
 input[type="range"] {
   display: block;
-  width: 100%;
-}
+  width: 100%; }
 
 select[multiple],
 select[size] {
-  height: auto;
-}
+  height: auto; }
 
 input[type="file"]:focus,
 input[type="radio"]:focus,
 input[type="checkbox"]:focus {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}
+  outline-offset: -2px; }
 
 output {
   display: block;
   padding-top: 7px;
   font-size: 14px;
   line-height: 1.42857;
-  color: #666;
-}
+  color: #666; }
 
 .form-control {
   display: block;
@@ -3253,115 +2418,107 @@ output {
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-}
-.form-control:focus {
-  border-color: #66afe9;
-  outline: 0;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-}
-.form-control::-moz-placeholder {
-  color: #999999;
-  opacity: 1;
-}
-.form-control:-ms-input-placeholder {
-  color: #999999;
-}
-.form-control::-webkit-input-placeholder {
-  color: #999999;
-}
-.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
-  background-color: #eeeeee;
-  opacity: 1;
-}
-.form-control[disabled], fieldset[disabled] .form-control {
-  cursor: not-allowed;
-}
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s; }
+  .form-control:focus {
+    border-color: #66afe9;
+    outline: 0;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6); }
+  .form-control::-moz-placeholder {
+    color: #999999;
+    opacity: 1; }
+  .form-control:-ms-input-placeholder {
+    color: #999999; }
+  .form-control::-webkit-input-placeholder {
+    color: #999999; }
+  .form-control[disabled],
+  .form-control[readonly],
+  fieldset[disabled] .form-control {
+    background-color: #eeeeee;
+    opacity: 1; }
+  .form-control[disabled],
+  fieldset[disabled] .form-control {
+    cursor: not-allowed; }
 
 textarea.form-control {
-  height: auto;
-}
+  height: auto; }
 
 input[type="search"] {
-  -webkit-appearance: none;
-}
+  -webkit-appearance: none; }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  input[type="date"].form-control,
-  input[type="time"].form-control,
-  input[type="datetime-local"].form-control,
-  input[type="month"].form-control {
-    line-height: 34px;
-  }
-  input[type="date"].input-sm, .input-group-sm > input[type="date"].form-control,
-  .input-group-sm > input[type="date"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="date"].btn,
-  .input-group-sm > .input-group-btn > input[type="date"].btn-ghost, .input-group-sm input[type="date"],
-  input[type="time"].input-sm,
-  .input-group-sm > input[type="time"].form-control,
-  .input-group-sm > input[type="time"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="time"].btn,
-  .input-group-sm > .input-group-btn > input[type="time"].btn-ghost, .input-group-sm
+  input[type="date"],
   input[type="time"],
-  input[type="datetime-local"].input-sm,
-  .input-group-sm > input[type="datetime-local"].form-control,
-  .input-group-sm > input[type="datetime-local"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="datetime-local"].btn,
-  .input-group-sm > .input-group-btn > input[type="datetime-local"].btn-ghost, .input-group-sm
   input[type="datetime-local"],
-  input[type="month"].input-sm,
-  .input-group-sm > input[type="month"].form-control,
-  .input-group-sm > input[type="month"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="month"].btn,
-  .input-group-sm > .input-group-btn > input[type="month"].btn-ghost, .input-group-sm
   input[type="month"] {
-    line-height: 30px;
-  }
-  input[type="date"].input-lg, .input-group-lg > input[type="date"].form-control,
-  .input-group-lg > input[type="date"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="date"].btn,
-  .input-group-lg > .input-group-btn > input[type="date"].btn-ghost, .input-group-lg input[type="date"],
-  input[type="time"].input-lg,
-  .input-group-lg > input[type="time"].form-control,
-  .input-group-lg > input[type="time"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="time"].btn,
-  .input-group-lg > .input-group-btn > input[type="time"].btn-ghost, .input-group-lg
-  input[type="time"],
-  input[type="datetime-local"].input-lg,
-  .input-group-lg > input[type="datetime-local"].form-control,
-  .input-group-lg > input[type="datetime-local"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="datetime-local"].btn,
-  .input-group-lg > .input-group-btn > input[type="datetime-local"].btn-ghost, .input-group-lg
-  input[type="datetime-local"],
-  input[type="month"].input-lg,
-  .input-group-lg > input[type="month"].form-control,
-  .input-group-lg > input[type="month"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="month"].btn,
-  .input-group-lg > .input-group-btn > input[type="month"].btn-ghost, .input-group-lg
-  input[type="month"] {
-    line-height: 46px;
-  }
-}
+    line-height: 34px; }
+    input[type="date"].input-sm,
+    .input-group-sm > input[type="date"].form-control,
+    .input-group-sm > input[type="date"].input-group-addon,
+    .input-group-sm > .input-group-btn > input[type="date"].btn,
+    .input-group-sm > .input-group-btn > input[type="date"].btn-ghost,
+    .input-group-sm input[type="date"],
+    input[type="time"].input-sm,
+    .input-group-sm > input[type="time"].form-control,
+    .input-group-sm > input[type="time"].input-group-addon,
+    .input-group-sm > .input-group-btn > input[type="time"].btn,
+    .input-group-sm > .input-group-btn > input[type="time"].btn-ghost,
+    .input-group-sm input[type="time"],
+    input[type="datetime-local"].input-sm,
+    .input-group-sm > input[type="datetime-local"].form-control,
+    .input-group-sm > input[type="datetime-local"].input-group-addon,
+    .input-group-sm > .input-group-btn > input[type="datetime-local"].btn,
+    .input-group-sm > .input-group-btn > input[type="datetime-local"].btn-ghost,
+    .input-group-sm input[type="datetime-local"],
+    input[type="month"].input-sm,
+    .input-group-sm > input[type="month"].form-control,
+    .input-group-sm > input[type="month"].input-group-addon,
+    .input-group-sm > .input-group-btn > input[type="month"].btn,
+    .input-group-sm > .input-group-btn > input[type="month"].btn-ghost,
+    .input-group-sm input[type="month"] {
+      line-height: 30px; }
+    input[type="date"].input-lg,
+    .input-group-lg > input[type="date"].form-control,
+    .input-group-lg > input[type="date"].input-group-addon,
+    .input-group-lg > .input-group-btn > input[type="date"].btn,
+    .input-group-lg > .input-group-btn > input[type="date"].btn-ghost,
+    .input-group-lg input[type="date"],
+    input[type="time"].input-lg,
+    .input-group-lg > input[type="time"].form-control,
+    .input-group-lg > input[type="time"].input-group-addon,
+    .input-group-lg > .input-group-btn > input[type="time"].btn,
+    .input-group-lg > .input-group-btn > input[type="time"].btn-ghost,
+    .input-group-lg input[type="time"],
+    input[type="datetime-local"].input-lg,
+    .input-group-lg > input[type="datetime-local"].form-control,
+    .input-group-lg > input[type="datetime-local"].input-group-addon,
+    .input-group-lg > .input-group-btn > input[type="datetime-local"].btn,
+    .input-group-lg > .input-group-btn > input[type="datetime-local"].btn-ghost,
+    .input-group-lg input[type="datetime-local"],
+    input[type="month"].input-lg,
+    .input-group-lg > input[type="month"].form-control,
+    .input-group-lg > input[type="month"].input-group-addon,
+    .input-group-lg > .input-group-btn > input[type="month"].btn,
+    .input-group-lg > .input-group-btn > input[type="month"].btn-ghost,
+    .input-group-lg input[type="month"] {
+      line-height: 46px; } }
+
 .form-group {
-  margin-bottom: 15px;
-}
+  margin-bottom: 15px; }
 
 .radio,
 .checkbox {
   position: relative;
   display: block;
   margin-top: 10px;
-  margin-bottom: 10px;
-}
-.radio label,
-.checkbox label {
-  min-height: 20px;
-  padding-left: 20px;
-  margin-bottom: 0;
-  font-weight: normal;
-  cursor: pointer;
-}
+  margin-bottom: 10px; }
+  .radio label,
+  .checkbox label {
+    min-height: 20px;
+    padding-left: 20px;
+    margin-bottom: 0;
+    font-weight: normal;
+    cursor: pointer; }
 
 .radio input[type="radio"],
 .radio-inline input[type="radio"],
@@ -3369,13 +2526,11 @@ input[type="search"] {
 .checkbox-inline input[type="checkbox"] {
   position: absolute;
   margin-left: -20px;
-  margin-top: 4px \9;
-}
+  margin-top: 4px \9; }
 
 .radio + .radio,
 .checkbox + .checkbox {
-  margin-top: -5px;
-}
+  margin-top: -5px; }
 
 .radio-inline,
 .checkbox-inline {
@@ -3385,165 +2540,147 @@ input[type="search"] {
   margin-bottom: 0;
   vertical-align: middle;
   font-weight: normal;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 .radio-inline + .radio-inline,
 .checkbox-inline + .checkbox-inline {
   margin-top: 0;
-  margin-left: 10px;
-}
+  margin-left: 10px; }
 
-input[type="radio"][disabled], input[type="radio"].disabled, fieldset[disabled] input[type="radio"],
+input[type="radio"][disabled],
+input[type="radio"].disabled,
+fieldset[disabled] input[type="radio"],
 input[type="checkbox"][disabled],
-input[type="checkbox"].disabled, fieldset[disabled]
-input[type="checkbox"] {
-  cursor: not-allowed;
-}
+input[type="checkbox"].disabled,
+fieldset[disabled] input[type="checkbox"] {
+  cursor: not-allowed; }
 
-.radio-inline.disabled, fieldset[disabled] .radio-inline,
-.checkbox-inline.disabled, fieldset[disabled]
-.checkbox-inline {
-  cursor: not-allowed;
-}
+.radio-inline.disabled,
+fieldset[disabled] .radio-inline,
+.checkbox-inline.disabled,
+fieldset[disabled] .checkbox-inline {
+  cursor: not-allowed; }
 
-.radio.disabled label, fieldset[disabled] .radio label,
-.checkbox.disabled label, fieldset[disabled]
-.checkbox label {
-  cursor: not-allowed;
-}
+.radio.disabled label,
+fieldset[disabled] .radio label,
+.checkbox.disabled label,
+fieldset[disabled] .checkbox label {
+  cursor: not-allowed; }
 
 .form-control-static {
   padding-top: 7px;
   padding-bottom: 7px;
   margin-bottom: 0;
-  min-height: 34px;
-}
-.form-control-static.input-lg, .input-group-lg > .form-control-static.form-control,
-.input-group-lg > .form-control-static.input-group-addon,
-.input-group-lg > .input-group-btn > .form-control-static.btn,
-.input-group-lg > .input-group-btn > .form-control-static.btn-ghost, .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control,
-.input-group-sm > .form-control-static.input-group-addon,
-.input-group-sm > .input-group-btn > .form-control-static.btn,
-.input-group-sm > .input-group-btn > .form-control-static.btn-ghost {
-  padding-left: 0;
-  padding-right: 0;
-}
+  min-height: 34px; }
+  .form-control-static.input-lg,
+  .input-group-lg > .form-control-static.form-control,
+  .input-group-lg > .form-control-static.input-group-addon,
+  .input-group-lg > .input-group-btn > .form-control-static.btn,
+  .input-group-lg > .input-group-btn > .form-control-static.btn-ghost,
+  .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control,
+  .input-group-sm > .form-control-static.input-group-addon,
+  .input-group-sm > .input-group-btn > .form-control-static.btn, .input-group-sm > .input-group-btn > .form-control-static.btn-ghost {
+    padding-left: 0;
+    padding-right: 0; }
 
 .input-sm, .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
-.input-group-sm > .input-group-btn > .btn,
-.input-group-sm > .input-group-btn > .btn-ghost {
+.input-group-sm > .input-group-btn > .btn, .input-group-sm > .input-group-btn > .btn-ghost {
   height: 30px;
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
 select.input-sm, .input-group-sm > select.form-control,
 .input-group-sm > select.input-group-addon,
-.input-group-sm > .input-group-btn > select.btn,
-.input-group-sm > .input-group-btn > select.btn-ghost {
+.input-group-sm > .input-group-btn > select.btn, .input-group-sm > .input-group-btn > select.btn-ghost {
   height: 30px;
-  line-height: 30px;
-}
+  line-height: 30px; }
 
-textarea.input-sm, .input-group-sm > textarea.form-control,
+textarea.input-sm,
+.input-group-sm > textarea.form-control,
 .input-group-sm > textarea.input-group-addon,
 .input-group-sm > .input-group-btn > textarea.btn,
 .input-group-sm > .input-group-btn > textarea.btn-ghost,
-select[multiple].input-sm,
-.input-group-sm > select[multiple].form-control,
+select[multiple].input-sm, .input-group-sm > select[multiple].form-control,
 .input-group-sm > select[multiple].input-group-addon,
-.input-group-sm > .input-group-btn > select[multiple].btn,
-.input-group-sm > .input-group-btn > select[multiple].btn-ghost {
-  height: auto;
-}
+.input-group-sm > .input-group-btn > select[multiple].btn, .input-group-sm > .input-group-btn > select[multiple].btn-ghost {
+  height: auto; }
 
 .form-group-sm .form-control {
   height: 30px;
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
+
 .form-group-sm select.form-control {
   height: 30px;
-  line-height: 30px;
-}
+  line-height: 30px; }
+
 .form-group-sm textarea.form-control,
 .form-group-sm select[multiple].form-control {
-  height: auto;
-}
+  height: auto; }
+
 .form-group-sm .form-control-static {
   height: 30px;
-  min-height: 32px;
-  padding: 6px 10px;
+  padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
-}
+  min-height: 32px; }
 
 .input-lg, .input-group-lg > .form-control,
 .input-group-lg > .input-group-addon,
-.input-group-lg > .input-group-btn > .btn,
-.input-group-lg > .input-group-btn > .btn-ghost {
+.input-group-lg > .input-group-btn > .btn, .input-group-lg > .input-group-btn > .btn-ghost {
   height: 46px;
   padding: 10px 16px;
   font-size: 18px;
   line-height: 1.33;
-  border-radius: 6px;
-}
+  border-radius: 6px; }
 
 select.input-lg, .input-group-lg > select.form-control,
 .input-group-lg > select.input-group-addon,
-.input-group-lg > .input-group-btn > select.btn,
-.input-group-lg > .input-group-btn > select.btn-ghost {
+.input-group-lg > .input-group-btn > select.btn, .input-group-lg > .input-group-btn > select.btn-ghost {
   height: 46px;
-  line-height: 46px;
-}
+  line-height: 46px; }
 
-textarea.input-lg, .input-group-lg > textarea.form-control,
+textarea.input-lg,
+.input-group-lg > textarea.form-control,
 .input-group-lg > textarea.input-group-addon,
 .input-group-lg > .input-group-btn > textarea.btn,
 .input-group-lg > .input-group-btn > textarea.btn-ghost,
-select[multiple].input-lg,
-.input-group-lg > select[multiple].form-control,
+select[multiple].input-lg, .input-group-lg > select[multiple].form-control,
 .input-group-lg > select[multiple].input-group-addon,
-.input-group-lg > .input-group-btn > select[multiple].btn,
-.input-group-lg > .input-group-btn > select[multiple].btn-ghost {
-  height: auto;
-}
+.input-group-lg > .input-group-btn > select[multiple].btn, .input-group-lg > .input-group-btn > select[multiple].btn-ghost {
+  height: auto; }
 
 .form-group-lg .form-control {
   height: 46px;
   padding: 10px 16px;
   font-size: 18px;
   line-height: 1.33;
-  border-radius: 6px;
-}
+  border-radius: 6px; }
+
 .form-group-lg select.form-control {
   height: 46px;
-  line-height: 46px;
-}
+  line-height: 46px; }
+
 .form-group-lg textarea.form-control,
 .form-group-lg select[multiple].form-control {
-  height: auto;
-}
+  height: auto; }
+
 .form-group-lg .form-control-static {
   height: 46px;
-  min-height: 38px;
-  padding: 11px 16px;
+  padding: 10px 16px;
   font-size: 18px;
   line-height: 1.33;
-}
+  min-height: 38px; }
 
 .has-feedback {
-  position: relative;
-}
-.has-feedback .form-control {
-  padding-right: 42.5px;
-}
+  position: relative; }
+  .has-feedback .form-control {
+    padding-right: 42.5px; }
 
 .form-control-feedback {
   position: absolute;
@@ -3555,176 +2692,159 @@ select[multiple].input-lg,
   height: 34px;
   line-height: 34px;
   text-align: center;
-  pointer-events: none;
-}
+  pointer-events: none; }
 
 .input-lg + .form-control-feedback, .input-group-lg > .form-control + .form-control-feedback,
 .input-group-lg > .input-group-addon + .form-control-feedback,
-.input-group-lg > .input-group-btn > .btn + .form-control-feedback,
-.input-group-lg > .input-group-btn > .btn-ghost + .form-control-feedback,
-.input-group-lg + .form-control-feedback,
-.form-group-lg .form-control + .form-control-feedback {
+.input-group-lg > .input-group-btn > .btn + .form-control-feedback, .input-group-lg > .input-group-btn > .btn-ghost + .form-control-feedback {
   width: 46px;
   height: 46px;
-  line-height: 46px;
-}
+  line-height: 46px; }
 
 .input-sm + .form-control-feedback, .input-group-sm > .form-control + .form-control-feedback,
 .input-group-sm > .input-group-addon + .form-control-feedback,
-.input-group-sm > .input-group-btn > .btn + .form-control-feedback,
-.input-group-sm > .input-group-btn > .btn-ghost + .form-control-feedback,
-.input-group-sm + .form-control-feedback,
-.form-group-sm .form-control + .form-control-feedback {
+.input-group-sm > .input-group-btn > .btn + .form-control-feedback, .input-group-sm > .input-group-btn > .btn-ghost + .form-control-feedback {
   width: 30px;
   height: 30px;
-  line-height: 30px;
-}
+  line-height: 30px; }
 
 .has-success .help-block,
 .has-success .control-label,
 .has-success .radio,
 .has-success .checkbox,
 .has-success .radio-inline,
-.has-success .checkbox-inline, .has-success.radio label, .has-success.checkbox label, .has-success.radio-inline label, .has-success.checkbox-inline label {
-  color: #9bb83a;
-}
+.has-success .checkbox-inline,
+.has-success.radio label,
+.has-success.checkbox label,
+.has-success.radio-inline label,
+.has-success.checkbox-inline label {
+  color: #9bb83a; }
+
 .has-success .form-control {
   border-color: #9bb83a;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-}
-.has-success .form-control:focus {
-  border-color: #7a912e;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781;
-}
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
+  .has-success .form-control:focus {
+    border-color: #7a912e;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781; }
+
 .has-success .input-group-addon {
   color: #9bb83a;
   border-color: #9bb83a;
-  background-color: #f5f8eb;
-}
+  background-color: #f5f8eb; }
+
 .has-success .form-control-feedback {
-  color: #9bb83a;
-}
+  color: #9bb83a; }
 
 .has-warning .help-block,
 .has-warning .control-label,
 .has-warning .radio,
 .has-warning .checkbox,
 .has-warning .radio-inline,
-.has-warning .checkbox-inline, .has-warning.radio label, .has-warning.checkbox label, .has-warning.radio-inline label, .has-warning.checkbox-inline label {
-  color: #e5d321;
-}
+.has-warning .checkbox-inline,
+.has-warning.radio label,
+.has-warning.checkbox label,
+.has-warning.radio-inline label,
+.has-warning.checkbox-inline label {
+  color: #e5d321; }
+
 .has-warning .form-control {
   border-color: #e5d321;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-}
-.has-warning .form-control:focus {
-  border-color: #bdae16;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c;
-}
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
+  .has-warning .form-control:focus {
+    border-color: #bdae16;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c; }
+
 .has-warning .input-group-addon {
   color: #e5d321;
   border-color: #e5d321;
-  background-color: #fdfde9;
-}
+  background-color: #fdfde9; }
+
 .has-warning .form-control-feedback {
-  color: #e5d321;
-}
+  color: #e5d321; }
 
 .has-error .help-block,
 .has-error .control-label,
 .has-error .radio,
 .has-error .checkbox,
 .has-error .radio-inline,
-.has-error .checkbox-inline, .has-error.radio label, .has-error.checkbox label, .has-error.radio-inline label, .has-error.checkbox-inline label {
-  color: #e53221;
-}
+.has-error .checkbox-inline,
+.has-error.radio label,
+.has-error.checkbox label,
+.has-error.radio-inline label,
+.has-error.checkbox-inline label {
+  color: #e53221; }
+
 .has-error .form-control {
   border-color: #e53221;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-}
-.has-error .form-control:focus {
-  border-color: #bd2516;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c;
-}
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
+  .has-error .form-control:focus {
+    border-color: #bd2516;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c; }
+
 .has-error .input-group-addon {
   color: #e53221;
   border-color: #e53221;
-  background-color: #fceae8;
-}
+  background-color: #fceae8; }
+
 .has-error .form-control-feedback {
-  color: #e53221;
-}
+  color: #e53221; }
 
 .has-feedback label ~ .form-control-feedback {
-  top: 25px;
-}
+  top: 25px; }
+
 .has-feedback label.sr-only ~ .form-control-feedback {
-  top: 0;
-}
+  top: 0; }
 
 .help-block {
   display: block;
   margin-top: 5px;
   margin-bottom: 10px;
-  color: #a6a6a6;
-}
+  color: #a6a6a6; }
 
 @media (min-width: 768px) {
   .form-inline .form-group {
     display: inline-block;
     margin-bottom: 0;
-    vertical-align: middle;
-  }
+    vertical-align: middle; }
   .form-inline .form-control {
     display: inline-block;
     width: auto;
-    vertical-align: middle;
-  }
+    vertical-align: middle; }
   .form-inline .form-control-static {
-    display: inline-block;
-  }
+    display: inline-block; }
   .form-inline .input-group {
     display: inline-table;
-    vertical-align: middle;
-  }
-  .form-inline .input-group .input-group-addon,
-  .form-inline .input-group .input-group-btn,
-  .form-inline .input-group .form-control {
-    width: auto;
-  }
+    vertical-align: middle; }
+    .form-inline .input-group .input-group-addon,
+    .form-inline .input-group .input-group-btn,
+    .form-inline .input-group .form-control {
+      width: auto; }
   .form-inline .input-group > .form-control {
-    width: 100%;
-  }
+    width: 100%; }
   .form-inline .control-label {
     margin-bottom: 0;
-    vertical-align: middle;
-  }
+    vertical-align: middle; }
   .form-inline .radio,
   .form-inline .checkbox {
     display: inline-block;
     margin-top: 0;
     margin-bottom: 0;
-    vertical-align: middle;
-  }
-  .form-inline .radio label,
-  .form-inline .checkbox label {
-    padding-left: 0;
-  }
+    vertical-align: middle; }
+    .form-inline .radio label,
+    .form-inline .checkbox label {
+      padding-left: 0; }
   .form-inline .radio input[type="radio"],
   .form-inline .checkbox input[type="checkbox"] {
     position: relative;
-    margin-left: 0;
-  }
+    margin-left: 0; }
   .form-inline .has-feedback .form-control-feedback {
-    top: 0;
-  }
-}
+    top: 0; } }
 
 .form-horizontal .radio,
 .form-horizontal .checkbox,
@@ -3732,45 +2852,38 @@ select[multiple].input-lg,
 .form-horizontal .checkbox-inline {
   margin-top: 0;
   margin-bottom: 0;
-  padding-top: 7px;
-}
+  padding-top: 7px; }
+
 .form-horizontal .radio,
 .form-horizontal .checkbox {
-  min-height: 27px;
-}
+  min-height: 27px; }
+
 .form-horizontal .form-group {
   margin-left: -15px;
-  margin-right: -15px;
-}
-.form-horizontal .form-group:before, .form-horizontal .form-group:after {
-  content: " ";
-  display: table;
-}
-.form-horizontal .form-group:after {
-  clear: both;
-}
+  margin-right: -15px; }
+  .form-horizontal .form-group:before,
+  .form-horizontal .form-group:after {
+    content: " ";
+    display: table; }
+  .form-horizontal .form-group:after {
+    clear: both; }
+
 @media (min-width: 768px) {
   .form-horizontal .control-label {
     text-align: right;
     margin-bottom: 0;
-    padding-top: 7px;
-  }
-}
+    padding-top: 7px; } }
+
 .form-horizontal .has-feedback .form-control-feedback {
-  right: 15px;
-}
+  right: 15px; }
+
 @media (min-width: 768px) {
   .form-horizontal .form-group-lg .control-label {
-    padding-top: 14.3px;
-    font-size: 18px;
-  }
-}
+    padding-top: 14.3px; } }
+
 @media (min-width: 768px) {
   .form-horizontal .form-group-sm .control-label {
-    padding-top: 6px;
-    font-size: 12px;
-  }
-}
+    padding-top: 6px; } }
 
 .btn, .btn-ghost {
   display: inline-block;
@@ -3790,340 +2903,405 @@ select[multiple].input-lg,
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;
-}
-.btn:focus, .btn-ghost:focus, .btn.focus, .focus.btn-ghost, .btn:active:focus, .btn-ghost:active:focus, .btn:active.focus, .btn-ghost:active.focus, .btn.active:focus, .active.btn-ghost:focus, .btn.active.focus, .active.focus.btn-ghost {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}
-.btn:hover, .btn-ghost:hover, .btn:focus, .btn-ghost:focus, .btn.focus, .focus.btn-ghost {
-  color: #555;
-  text-decoration: none;
-}
-.btn:active, .btn-ghost:active, .btn.active, .active.btn-ghost {
-  outline: 0;
-  background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-}
-.btn.disabled, .disabled.btn-ghost, .btn[disabled], [disabled].btn-ghost, fieldset[disabled] .btn, fieldset[disabled] .btn-ghost {
-  cursor: not-allowed;
-  opacity: 0.65;
-  filter: alpha(opacity=65);
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-
-a.btn.disabled, a.disabled.btn-ghost, fieldset[disabled] a.btn, fieldset[disabled] a.btn-ghost {
-  pointer-events: none;
-}
+  user-select: none; }
+  .btn:focus,
+  .btn-ghost:focus,
+  .btn.focus,
+  .focus.btn-ghost,
+  .btn:active:focus,
+  .btn-ghost:active:focus,
+  .btn:active.focus,
+  .btn-ghost:active.focus,
+  .btn.active:focus,
+  .active.btn-ghost:focus,
+  .btn.active.focus, .active.focus.btn-ghost {
+    outline: thin dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px; }
+  .btn:hover,
+  .btn-ghost:hover,
+  .btn:focus,
+  .btn-ghost:focus,
+  .btn.focus, .focus.btn-ghost {
+    color: #555;
+    text-decoration: none; }
+  .btn:active,
+  .btn-ghost:active,
+  .btn.active, .active.btn-ghost {
+    outline: 0;
+    background-image: none;
+    -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
+  .btn.disabled,
+  .disabled.btn-ghost,
+  .btn[disabled],
+  [disabled].btn-ghost,
+  fieldset[disabled] .btn, fieldset[disabled] .btn-ghost {
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.65;
+    filter: alpha(opacity=65);
+    -webkit-box-shadow: none;
+    box-shadow: none; }
 
 .btn-default {
   color: #555;
   background-color: #f4f5f6;
-  border-color: #b1b6bf;
-}
-.btn-default:focus, .btn-default.focus {
-  color: #555;
-  background-color: #d8dcdf;
-  border-color: #6c7584;
-}
-.btn-default:hover {
-  color: #555;
-  background-color: #d8dcdf;
-  border-color: #8f97a3;
-}
-.btn-default:active, .btn-default.active, .open > .btn-default.dropdown-toggle {
-  color: #555;
-  background-color: #d8dcdf;
-  border-color: #8f97a3;
-}
-.btn-default:active:hover, .btn-default:active:focus, .btn-default:active.focus, .btn-default.active:hover, .btn-default.active:focus, .btn-default.active.focus, .open > .btn-default.dropdown-toggle:hover, .open > .btn-default.dropdown-toggle:focus, .open > .btn-default.dropdown-toggle.focus {
-  color: #555;
-  background-color: #c4cacf;
-  border-color: #6c7584;
-}
-.btn-default:active, .btn-default.active, .open > .btn-default.dropdown-toggle {
-  background-image: none;
-}
-.btn-default.disabled, .btn-default.disabled:hover, .btn-default.disabled:focus, .btn-default.disabled.focus, .btn-default.disabled:active, .btn-default.disabled.active, .btn-default[disabled], .btn-default[disabled]:hover, .btn-default[disabled]:focus, .btn-default[disabled].focus, .btn-default[disabled]:active, .btn-default[disabled].active, fieldset[disabled] .btn-default, fieldset[disabled] .btn-default:hover, fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default.focus, fieldset[disabled] .btn-default:active, fieldset[disabled] .btn-default.active {
-  background-color: #f4f5f6;
-  border-color: #b1b6bf;
-}
-.btn-default .badge {
-  color: #f4f5f6;
-  background-color: #555;
-}
+  border-color: #b1b6bf; }
+  .btn-default:hover,
+  .btn-default:focus,
+  .btn-default.focus,
+  .btn-default:active,
+  .btn-default.active,
+  .open > .btn-default.dropdown-toggle {
+    color: #555;
+    background-color: #d8dcdf;
+    border-color: #8f97a3; }
+  .btn-default:active,
+  .btn-default.active,
+  .open > .btn-default.dropdown-toggle {
+    background-image: none; }
+  .btn-default.disabled,
+  .btn-default.disabled:hover,
+  .btn-default.disabled:focus,
+  .btn-default.disabled.focus,
+  .btn-default.disabled:active,
+  .btn-default.disabled.active,
+  .btn-default[disabled],
+  .btn-default[disabled]:hover,
+  .btn-default[disabled]:focus,
+  .btn-default[disabled].focus,
+  .btn-default[disabled]:active,
+  .btn-default[disabled].active,
+  fieldset[disabled] .btn-default,
+  fieldset[disabled] .btn-default:hover,
+  fieldset[disabled] .btn-default:focus,
+  fieldset[disabled] .btn-default.focus,
+  fieldset[disabled] .btn-default:active,
+  fieldset[disabled] .btn-default.active {
+    background-color: #f4f5f6;
+    border-color: #b1b6bf; }
+  .btn-default .badge {
+    color: #f4f5f6;
+    background-color: #555; }
 
 .btn-primary {
   color: #fff;
   background-color: #9bb83a;
-  border-color: #70842a;
-}
-.btn-primary:focus, .btn-primary.focus {
-  color: #fff;
-  background-color: #7a912e;
-  border-color: #1e230b;
-}
-.btn-primary:hover {
-  color: #fff;
-  background-color: #7a912e;
-  border-color: #48561b;
-}
-.btn-primary:active, .btn-primary.active, .open > .btn-primary.dropdown-toggle {
-  color: #fff;
-  background-color: #7a912e;
-  border-color: #48561b;
-}
-.btn-primary:active:hover, .btn-primary:active:focus, .btn-primary:active.focus, .btn-primary.active:hover, .btn-primary.active:focus, .btn-primary.active.focus, .open > .btn-primary.dropdown-toggle:hover, .open > .btn-primary.dropdown-toggle:focus, .open > .btn-primary.dropdown-toggle.focus {
-  color: #fff;
-  background-color: #637625;
-  border-color: #1e230b;
-}
-.btn-primary:active, .btn-primary.active, .open > .btn-primary.dropdown-toggle {
-  background-image: none;
-}
-.btn-primary.disabled, .btn-primary.disabled:hover, .btn-primary.disabled:focus, .btn-primary.disabled.focus, .btn-primary.disabled:active, .btn-primary.disabled.active, .btn-primary[disabled], .btn-primary[disabled]:hover, .btn-primary[disabled]:focus, .btn-primary[disabled].focus, .btn-primary[disabled]:active, .btn-primary[disabled].active, fieldset[disabled] .btn-primary, fieldset[disabled] .btn-primary:hover, fieldset[disabled] .btn-primary:focus, fieldset[disabled] .btn-primary.focus, fieldset[disabled] .btn-primary:active, fieldset[disabled] .btn-primary.active {
-  background-color: #9bb83a;
-  border-color: #70842a;
-}
-.btn-primary .badge {
-  color: #9bb83a;
-  background-color: #fff;
-}
+  border-color: #70842a; }
+  .btn-primary:hover,
+  .btn-primary:focus,
+  .btn-primary.focus,
+  .btn-primary:active,
+  .btn-primary.active,
+  .open > .btn-primary.dropdown-toggle {
+    color: #fff;
+    background-color: #7a912e;
+    border-color: #48561b; }
+  .btn-primary:active,
+  .btn-primary.active,
+  .open > .btn-primary.dropdown-toggle {
+    background-image: none; }
+  .btn-primary.disabled,
+  .btn-primary.disabled:hover,
+  .btn-primary.disabled:focus,
+  .btn-primary.disabled.focus,
+  .btn-primary.disabled:active,
+  .btn-primary.disabled.active,
+  .btn-primary[disabled],
+  .btn-primary[disabled]:hover,
+  .btn-primary[disabled]:focus,
+  .btn-primary[disabled].focus,
+  .btn-primary[disabled]:active,
+  .btn-primary[disabled].active,
+  fieldset[disabled] .btn-primary,
+  fieldset[disabled] .btn-primary:hover,
+  fieldset[disabled] .btn-primary:focus,
+  fieldset[disabled] .btn-primary.focus,
+  fieldset[disabled] .btn-primary:active,
+  fieldset[disabled] .btn-primary.active {
+    background-color: #9bb83a;
+    border-color: #70842a; }
+  .btn-primary .badge {
+    color: #9bb83a;
+    background-color: #fff; }
 
 .btn-success {
   color: #fff;
   background-color: #9bb83a;
-  border-color: #5a6a22;
-}
-.btn-success:focus, .btn-success.focus {
-  color: #fff;
-  background-color: #7a912e;
-  border-color: #080a03;
-}
-.btn-success:hover {
-  color: #fff;
-  background-color: #7a912e;
-  border-color: #323c13;
-}
-.btn-success:active, .btn-success.active, .open > .btn-success.dropdown-toggle {
-  color: #fff;
-  background-color: #7a912e;
-  border-color: #323c13;
-}
-.btn-success:active:hover, .btn-success:active:focus, .btn-success:active.focus, .btn-success.active:hover, .btn-success.active:focus, .btn-success.active.focus, .open > .btn-success.dropdown-toggle:hover, .open > .btn-success.dropdown-toggle:focus, .open > .btn-success.dropdown-toggle.focus {
-  color: #fff;
-  background-color: #637625;
-  border-color: #080a03;
-}
-.btn-success:active, .btn-success.active, .open > .btn-success.dropdown-toggle {
-  background-image: none;
-}
-.btn-success.disabled, .btn-success.disabled:hover, .btn-success.disabled:focus, .btn-success.disabled.focus, .btn-success.disabled:active, .btn-success.disabled.active, .btn-success[disabled], .btn-success[disabled]:hover, .btn-success[disabled]:focus, .btn-success[disabled].focus, .btn-success[disabled]:active, .btn-success[disabled].active, fieldset[disabled] .btn-success, fieldset[disabled] .btn-success:hover, fieldset[disabled] .btn-success:focus, fieldset[disabled] .btn-success.focus, fieldset[disabled] .btn-success:active, fieldset[disabled] .btn-success.active {
-  background-color: #9bb83a;
-  border-color: #5a6a22;
-}
-.btn-success .badge {
-  color: #9bb83a;
-  background-color: #fff;
-}
+  border-color: #5a6a22; }
+  .btn-success:hover,
+  .btn-success:focus,
+  .btn-success.focus,
+  .btn-success:active,
+  .btn-success.active,
+  .open > .btn-success.dropdown-toggle {
+    color: #fff;
+    background-color: #7a912e;
+    border-color: #323c13; }
+  .btn-success:active,
+  .btn-success.active,
+  .open > .btn-success.dropdown-toggle {
+    background-image: none; }
+  .btn-success.disabled,
+  .btn-success.disabled:hover,
+  .btn-success.disabled:focus,
+  .btn-success.disabled.focus,
+  .btn-success.disabled:active,
+  .btn-success.disabled.active,
+  .btn-success[disabled],
+  .btn-success[disabled]:hover,
+  .btn-success[disabled]:focus,
+  .btn-success[disabled].focus,
+  .btn-success[disabled]:active,
+  .btn-success[disabled].active,
+  fieldset[disabled] .btn-success,
+  fieldset[disabled] .btn-success:hover,
+  fieldset[disabled] .btn-success:focus,
+  fieldset[disabled] .btn-success.focus,
+  fieldset[disabled] .btn-success:active,
+  fieldset[disabled] .btn-success.active {
+    background-color: #9bb83a;
+    border-color: #5a6a22; }
+  .btn-success .badge {
+    color: #9bb83a;
+    background-color: #fff; }
 
 .btn-info {
   color: #fff;
   background-color: #389Bc9;
-  border-color: #215e7a;
-}
-.btn-info:focus, .btn-info.focus {
-  color: #fff;
-  background-color: #2c7da2;
-  border-color: #061116;
-}
-.btn-info:hover {
-  color: #fff;
-  background-color: #2c7da2;
-  border-color: #14394a;
-}
-.btn-info:active, .btn-info.active, .open > .btn-info.dropdown-toggle {
-  color: #fff;
-  background-color: #2c7da2;
-  border-color: #14394a;
-}
-.btn-info:active:hover, .btn-info:active:focus, .btn-info:active.focus, .btn-info.active:hover, .btn-info.active:focus, .btn-info.active.focus, .open > .btn-info.dropdown-toggle:hover, .open > .btn-info.dropdown-toggle:focus, .open > .btn-info.dropdown-toggle.focus {
-  color: #fff;
-  background-color: #246786;
-  border-color: #061116;
-}
-.btn-info:active, .btn-info.active, .open > .btn-info.dropdown-toggle {
-  background-image: none;
-}
-.btn-info.disabled, .btn-info.disabled:hover, .btn-info.disabled:focus, .btn-info.disabled.focus, .btn-info.disabled:active, .btn-info.disabled.active, .btn-info[disabled], .btn-info[disabled]:hover, .btn-info[disabled]:focus, .btn-info[disabled].focus, .btn-info[disabled]:active, .btn-info[disabled].active, fieldset[disabled] .btn-info, fieldset[disabled] .btn-info:hover, fieldset[disabled] .btn-info:focus, fieldset[disabled] .btn-info.focus, fieldset[disabled] .btn-info:active, fieldset[disabled] .btn-info.active {
-  background-color: #389Bc9;
-  border-color: #215e7a;
-}
-.btn-info .badge {
-  color: #389Bc9;
-  background-color: #fff;
-}
+  border-color: #215e7a; }
+  .btn-info:hover,
+  .btn-info:focus,
+  .btn-info.focus,
+  .btn-info:active,
+  .btn-info.active,
+  .open > .btn-info.dropdown-toggle {
+    color: #fff;
+    background-color: #2c7da2;
+    border-color: #14394a; }
+  .btn-info:active,
+  .btn-info.active,
+  .open > .btn-info.dropdown-toggle {
+    background-image: none; }
+  .btn-info.disabled,
+  .btn-info.disabled:hover,
+  .btn-info.disabled:focus,
+  .btn-info.disabled.focus,
+  .btn-info.disabled:active,
+  .btn-info.disabled.active,
+  .btn-info[disabled],
+  .btn-info[disabled]:hover,
+  .btn-info[disabled]:focus,
+  .btn-info[disabled].focus,
+  .btn-info[disabled]:active,
+  .btn-info[disabled].active,
+  fieldset[disabled] .btn-info,
+  fieldset[disabled] .btn-info:hover,
+  fieldset[disabled] .btn-info:focus,
+  fieldset[disabled] .btn-info.focus,
+  fieldset[disabled] .btn-info:active,
+  fieldset[disabled] .btn-info.active {
+    background-color: #389Bc9;
+    border-color: #215e7a; }
+  .btn-info .badge {
+    color: #389Bc9;
+    background-color: #fff; }
 
 .btn-warning {
   color: #fff;
   background-color: #e5d321;
-  border-color: #8f8411;
-}
-.btn-warning:focus, .btn-warning.focus {
-  color: #fff;
-  background-color: #bdae16;
-  border-color: #1d1b03;
-}
-.btn-warning:hover {
-  color: #fff;
-  background-color: #bdae16;
-  border-color: #58510a;
-}
-.btn-warning:active, .btn-warning.active, .open > .btn-warning.dropdown-toggle {
-  color: #fff;
-  background-color: #bdae16;
-  border-color: #58510a;
-}
-.btn-warning:active:hover, .btn-warning:active:focus, .btn-warning:active.focus, .btn-warning.active:hover, .btn-warning.active:focus, .btn-warning.active.focus, .open > .btn-warning.dropdown-toggle:hover, .open > .btn-warning.dropdown-toggle:focus, .open > .btn-warning.dropdown-toggle.focus {
-  color: #fff;
-  background-color: #9d9012;
-  border-color: #1d1b03;
-}
-.btn-warning:active, .btn-warning.active, .open > .btn-warning.dropdown-toggle {
-  background-image: none;
-}
-.btn-warning.disabled, .btn-warning.disabled:hover, .btn-warning.disabled:focus, .btn-warning.disabled.focus, .btn-warning.disabled:active, .btn-warning.disabled.active, .btn-warning[disabled], .btn-warning[disabled]:hover, .btn-warning[disabled]:focus, .btn-warning[disabled].focus, .btn-warning[disabled]:active, .btn-warning[disabled].active, fieldset[disabled] .btn-warning, fieldset[disabled] .btn-warning:hover, fieldset[disabled] .btn-warning:focus, fieldset[disabled] .btn-warning.focus, fieldset[disabled] .btn-warning:active, fieldset[disabled] .btn-warning.active {
-  background-color: #e5d321;
-  border-color: #8f8411;
-}
-.btn-warning .badge {
-  color: #e5d321;
-  background-color: #fff;
-}
+  border-color: #8f8411; }
+  .btn-warning:hover,
+  .btn-warning:focus,
+  .btn-warning.focus,
+  .btn-warning:active,
+  .btn-warning.active,
+  .open > .btn-warning.dropdown-toggle {
+    color: #fff;
+    background-color: #bdae16;
+    border-color: #58510a; }
+  .btn-warning:active,
+  .btn-warning.active,
+  .open > .btn-warning.dropdown-toggle {
+    background-image: none; }
+  .btn-warning.disabled,
+  .btn-warning.disabled:hover,
+  .btn-warning.disabled:focus,
+  .btn-warning.disabled.focus,
+  .btn-warning.disabled:active,
+  .btn-warning.disabled.active,
+  .btn-warning[disabled],
+  .btn-warning[disabled]:hover,
+  .btn-warning[disabled]:focus,
+  .btn-warning[disabled].focus,
+  .btn-warning[disabled]:active,
+  .btn-warning[disabled].active,
+  fieldset[disabled] .btn-warning,
+  fieldset[disabled] .btn-warning:hover,
+  fieldset[disabled] .btn-warning:focus,
+  fieldset[disabled] .btn-warning.focus,
+  fieldset[disabled] .btn-warning:active,
+  fieldset[disabled] .btn-warning.active {
+    background-color: #e5d321;
+    border-color: #8f8411; }
+  .btn-warning .badge {
+    color: #e5d321;
+    background-color: #fff; }
 
 .btn-danger, .btn-primary-alt {
   color: #fff;
   background-color: #e53221;
-  border-color: #8f1c11;
-}
-.btn-danger:focus, .btn-primary-alt:focus, .btn-danger.focus, .focus.btn-primary-alt {
-  color: #fff;
-  background-color: #bd2516;
-  border-color: #1d0603;
-}
-.btn-danger:hover, .btn-primary-alt:hover {
-  color: #fff;
-  background-color: #bd2516;
-  border-color: #58110a;
-}
-.btn-danger:active, .btn-primary-alt:active, .btn-danger.active, .active.btn-primary-alt, .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt {
-  color: #fff;
-  background-color: #bd2516;
-  border-color: #58110a;
-}
-.btn-danger:active:hover, .btn-primary-alt:active:hover, .btn-danger:active:focus, .btn-primary-alt:active:focus, .btn-danger:active.focus, .btn-primary-alt:active.focus, .btn-danger.active:hover, .active.btn-primary-alt:hover, .btn-danger.active:focus, .active.btn-primary-alt:focus, .btn-danger.active.focus, .active.focus.btn-primary-alt, .open > .btn-danger.dropdown-toggle:hover, .open > .dropdown-toggle.btn-primary-alt:hover, .open > .btn-danger.dropdown-toggle:focus, .open > .dropdown-toggle.btn-primary-alt:focus, .open > .btn-danger.dropdown-toggle.focus, .open > .dropdown-toggle.focus.btn-primary-alt {
-  color: #fff;
-  background-color: #9d1e12;
-  border-color: #1d0603;
-}
-.btn-danger:active, .btn-primary-alt:active, .btn-danger.active, .active.btn-primary-alt, .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt {
-  background-image: none;
-}
-.btn-danger.disabled, .disabled.btn-primary-alt, .btn-danger.disabled:hover, .disabled.btn-primary-alt:hover, .btn-danger.disabled:focus, .disabled.btn-primary-alt:focus, .btn-danger.disabled.focus, .disabled.focus.btn-primary-alt, .btn-danger.disabled:active, .disabled.btn-primary-alt:active, .btn-danger.disabled.active, .disabled.active.btn-primary-alt, .btn-danger[disabled], [disabled].btn-primary-alt, .btn-danger[disabled]:hover, [disabled].btn-primary-alt:hover, .btn-danger[disabled]:focus, [disabled].btn-primary-alt:focus, .btn-danger[disabled].focus, [disabled].focus.btn-primary-alt, .btn-danger[disabled]:active, [disabled].btn-primary-alt:active, .btn-danger[disabled].active, [disabled].active.btn-primary-alt, fieldset[disabled] .btn-danger, fieldset[disabled] .btn-primary-alt, fieldset[disabled] .btn-danger:hover, fieldset[disabled] .btn-primary-alt:hover, fieldset[disabled] .btn-danger:focus, fieldset[disabled] .btn-primary-alt:focus, fieldset[disabled] .btn-danger.focus, fieldset[disabled] .focus.btn-primary-alt, fieldset[disabled] .btn-danger:active, fieldset[disabled] .btn-primary-alt:active, fieldset[disabled] .btn-danger.active, fieldset[disabled] .active.btn-primary-alt {
-  background-color: #e53221;
-  border-color: #8f1c11;
-}
-.btn-danger .badge, .btn-primary-alt .badge {
-  color: #e53221;
-  background-color: #fff;
-}
+  border-color: #8f1c11; }
+  .btn-danger:hover,
+  .btn-primary-alt:hover,
+  .btn-danger:focus,
+  .btn-primary-alt:focus,
+  .btn-danger.focus,
+  .focus.btn-primary-alt,
+  .btn-danger:active,
+  .btn-primary-alt:active,
+  .btn-danger.active,
+  .active.btn-primary-alt,
+  .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt {
+    color: #fff;
+    background-color: #bd2516;
+    border-color: #58110a; }
+  .btn-danger:active,
+  .btn-primary-alt:active,
+  .btn-danger.active,
+  .active.btn-primary-alt,
+  .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt {
+    background-image: none; }
+  .btn-danger.disabled,
+  .disabled.btn-primary-alt,
+  .btn-danger.disabled:hover,
+  .disabled.btn-primary-alt:hover,
+  .btn-danger.disabled:focus,
+  .disabled.btn-primary-alt:focus,
+  .btn-danger.disabled.focus,
+  .disabled.focus.btn-primary-alt,
+  .btn-danger.disabled:active,
+  .disabled.btn-primary-alt:active,
+  .btn-danger.disabled.active,
+  .disabled.active.btn-primary-alt,
+  .btn-danger[disabled],
+  [disabled].btn-primary-alt,
+  .btn-danger[disabled]:hover,
+  [disabled].btn-primary-alt:hover,
+  .btn-danger[disabled]:focus,
+  [disabled].btn-primary-alt:focus,
+  .btn-danger[disabled].focus,
+  [disabled].focus.btn-primary-alt,
+  .btn-danger[disabled]:active,
+  [disabled].btn-primary-alt:active,
+  .btn-danger[disabled].active,
+  [disabled].active.btn-primary-alt,
+  fieldset[disabled] .btn-danger,
+  fieldset[disabled] .btn-primary-alt,
+  fieldset[disabled] .btn-danger:hover,
+  fieldset[disabled] .btn-primary-alt:hover,
+  fieldset[disabled] .btn-danger:focus,
+  fieldset[disabled] .btn-primary-alt:focus,
+  fieldset[disabled] .btn-danger.focus,
+  fieldset[disabled] .focus.btn-primary-alt,
+  fieldset[disabled] .btn-danger:active,
+  fieldset[disabled] .btn-primary-alt:active,
+  fieldset[disabled] .btn-danger.active, fieldset[disabled] .active.btn-primary-alt {
+    background-color: #e53221;
+    border-color: #8f1c11; }
+  .btn-danger .badge, .btn-primary-alt .badge {
+    color: #e53221;
+    background-color: #fff; }
 
 .btn-link, .btn-secondary {
   color: #2e88be;
   font-weight: normal;
-  border-radius: 0;
-}
-.btn-link, .btn-secondary, .btn-link:active, .btn-secondary:active, .btn-link.active, .active.btn-secondary, .btn-link[disabled], [disabled].btn-secondary, fieldset[disabled] .btn-link, fieldset[disabled] .btn-secondary {
-  background-color: transparent;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-.btn-link, .btn-secondary, .btn-link:hover, .btn-secondary:hover, .btn-link:focus, .btn-secondary:focus, .btn-link:active, .btn-secondary:active {
-  border-color: transparent;
-}
-.btn-link:hover, .btn-secondary:hover, .btn-link:focus, .btn-secondary:focus {
-  color: #1f5c80;
-  text-decoration: underline;
-  background-color: transparent;
-}
-.btn-link[disabled]:hover, [disabled].btn-secondary:hover, .btn-link[disabled]:focus, [disabled].btn-secondary:focus, fieldset[disabled] .btn-link:hover, fieldset[disabled] .btn-secondary:hover, fieldset[disabled] .btn-link:focus, fieldset[disabled] .btn-secondary:focus {
-  color: #999999;
-  text-decoration: none;
-}
+  border-radius: 0; }
+  .btn-link,
+  .btn-secondary,
+  .btn-link:active,
+  .btn-secondary:active,
+  .btn-link.active,
+  .active.btn-secondary,
+  .btn-link[disabled],
+  [disabled].btn-secondary,
+  fieldset[disabled] .btn-link, fieldset[disabled] .btn-secondary {
+    background-color: transparent;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+  .btn-link,
+  .btn-secondary,
+  .btn-link:hover,
+  .btn-secondary:hover,
+  .btn-link:focus,
+  .btn-secondary:focus,
+  .btn-link:active, .btn-secondary:active {
+    border-color: transparent; }
+  .btn-link:hover,
+  .btn-secondary:hover,
+  .btn-link:focus, .btn-secondary:focus {
+    color: #1f5c80;
+    text-decoration: underline;
+    background-color: transparent; }
+  .btn-link[disabled]:hover,
+  [disabled].btn-secondary:hover,
+  .btn-link[disabled]:focus,
+  [disabled].btn-secondary:focus,
+  fieldset[disabled] .btn-link:hover,
+  fieldset[disabled] .btn-secondary:hover,
+  fieldset[disabled] .btn-link:focus, fieldset[disabled] .btn-secondary:focus {
+    color: #999999;
+    text-decoration: none; }
 
 .btn-lg, .btn-group-lg > .btn, .btn-group-lg > .btn-ghost {
   padding: 10px 16px;
   font-size: 18px;
   line-height: 1.33;
-  border-radius: 6px;
-}
+  border-radius: 6px; }
 
 .btn-sm, .btn-group-sm > .btn, .btn-group-sm > .btn-ghost {
   padding: 5px 10px;
   font-size: 12px;
   line-height: 1.5;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
 .btn-xs, .btn-group-xs > .btn, .btn-group-xs > .btn-ghost {
   padding: 1px 5px;
   font-size: 12px;
   line-height: 1.5;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
 .btn-block {
   display: block;
-  width: 100%;
-}
+  width: 100%; }
 
 .btn-block + .btn-block {
-  margin-top: 5px;
-}
+  margin-top: 5px; }
 
 input[type="submit"].btn-block,
 input[type="reset"].btn-block,
 input[type="button"].btn-block {
-  width: 100%;
-}
+  width: 100%; }
 
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
   -o-transition: opacity 0.15s linear;
-  transition: opacity 0.15s linear;
-}
-.fade.in {
-  opacity: 1;
-}
+  transition: opacity 0.15s linear; }
+  .fade.in {
+    opacity: 1; }
 
 .collapse {
-  display: none;
-}
-.collapse.in {
-  display: block;
-}
+  display: none; }
+  .collapse.in {
+    display: block; }
 
 tr.collapse.in {
-  display: table-row;
-}
+  display: table-row; }
 
 tbody.collapse.in {
-  display: table-row-group;
-}
+  display: table-row-group; }
 
 .collapsing {
   position: relative;
@@ -4134,8 +3312,7 @@ tbody.collapse.in {
   -webkit-transition-duration: 0.35s;
   transition-duration: 0.35s;
   -webkit-transition-timing-function: ease;
-  transition-timing-function: ease;
-}
+  transition-timing-function: ease; }
 
 .caret {
   display: inline-block;
@@ -4144,19 +3321,15 @@ tbody.collapse.in {
   margin-left: 2px;
   vertical-align: middle;
   border-top: 4px dashed;
-  border-top: 4px solid \9;
   border-right: 4px solid transparent;
-  border-left: 4px solid transparent;
-}
+  border-left: 4px solid transparent; }
 
 .dropup,
 .dropdown {
-  position: relative;
-}
+  position: relative; }
 
 .dropdown-toggle:focus {
-  outline: 0;
-}
+  outline: 0; }
 
 .dropdown-menu {
   position: absolute;
@@ -4177,68 +3350,64 @@ tbody.collapse.in {
   border-radius: 4px;
   -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  background-clip: padding-box;
-}
-.dropdown-menu.pull-right {
-  right: 0;
-  left: auto;
-}
-.dropdown-menu .divider {
-  height: 1px;
-  margin: 9px 0;
-  overflow: hidden;
-  background-color: #e5e5e5;
-}
-.dropdown-menu > li > a {
-  display: block;
-  padding: 3px 20px;
-  clear: both;
-  font-weight: normal;
-  line-height: 1.42857;
-  color: #333333;
-  white-space: nowrap;
-}
+  background-clip: padding-box; }
+  .dropdown-menu.pull-right {
+    right: 0;
+    left: auto; }
+  .dropdown-menu .divider {
+    height: 1px;
+    margin: 9px 0;
+    overflow: hidden;
+    background-color: #e5e5e5; }
+  .dropdown-menu > li > a {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 1.42857;
+    color: #333333;
+    white-space: nowrap; }
 
-.dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus {
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
   text-decoration: none;
   color: #262626;
-  background-color: #f1f1f1;
-}
+  background-color: #f1f1f1; }
 
-.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
+.dropdown-menu > .active > a,
+.dropdown-menu > .active > a:hover,
+.dropdown-menu > .active > a:focus {
   color: #666;
   text-decoration: none;
   outline: 0;
-  background-color: #f1f1f1;
-}
+  background-color: #f1f1f1; }
 
-.dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus {
-  color: #999999;
-}
-.dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus {
+.dropdown-menu > .disabled > a,
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  color: #999999; }
+
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
   text-decoration: none;
   background-color: transparent;
   background-image: none;
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-  cursor: not-allowed;
-}
+  cursor: not-allowed; }
 
 .open > .dropdown-menu {
-  display: block;
-}
+  display: block; }
+
 .open > a {
-  outline: 0;
-}
+  outline: 0; }
 
 .dropdown-menu-right {
   left: auto;
-  right: 0;
-}
+  right: 0; }
 
 .dropdown-menu-left {
   left: 0;
-  right: auto;
-}
+  right: auto; }
 
 .dropdown-header {
   display: block;
@@ -4246,8 +3415,7 @@ tbody.collapse.in {
   font-size: 12px;
   line-height: 1.42857;
   color: #999999;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
 .dropdown-backdrop {
   position: fixed;
@@ -4255,290 +3423,261 @@ tbody.collapse.in {
   right: 0;
   bottom: 0;
   top: 0;
-  z-index: 990;
-}
+  z-index: 990; }
 
 .pull-right > .dropdown-menu {
   right: 0;
-  left: auto;
-}
+  left: auto; }
 
 .dropup .caret,
 .navbar-fixed-bottom .dropdown .caret {
   border-top: 0;
-  border-bottom: 4px dashed;
-  border-bottom: 4px solid \9;
-  content: "";
-}
+  border-bottom: 4px solid;
+  content: ""; }
+
 .dropup .dropdown-menu,
 .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
   bottom: 100%;
-  margin-bottom: 2px;
-}
+  margin-bottom: 2px; }
 
 @media (min-width: 768px) {
   .navbar-right .dropdown-menu {
     right: 0;
-    left: auto;
-  }
+    left: auto; }
   .navbar-right .dropdown-menu-left {
     left: 0;
-    right: auto;
-  }
-}
+    right: auto; } }
+
 .btn-group,
 .btn-group-vertical {
   position: relative;
   display: inline-block;
-  vertical-align: middle;
-}
-.btn-group > .btn, .btn-group > .btn-ghost,
-.btn-group-vertical > .btn,
-.btn-group-vertical > .btn-ghost {
-  position: relative;
-  float: left;
-}
-.btn-group > .btn:hover, .btn-group > .btn-ghost:hover, .btn-group > .btn:focus, .btn-group > .btn-ghost:focus, .btn-group > .btn:active, .btn-group > .btn-ghost:active, .btn-group > .btn.active, .btn-group > .active.btn-ghost,
-.btn-group-vertical > .btn:hover,
-.btn-group-vertical > .btn-ghost:hover,
-.btn-group-vertical > .btn:focus,
-.btn-group-vertical > .btn-ghost:focus,
-.btn-group-vertical > .btn:active,
-.btn-group-vertical > .btn-ghost:active,
-.btn-group-vertical > .btn.active,
-.btn-group-vertical > .active.btn-ghost {
-  z-index: 2;
-}
+  vertical-align: middle; }
+  .btn-group > .btn,
+  .btn-group > .btn-ghost,
+  .btn-group-vertical > .btn, .btn-group-vertical > .btn-ghost {
+    position: relative;
+    float: left; }
+    .btn-group > .btn:hover,
+    .btn-group > .btn-ghost:hover,
+    .btn-group > .btn:focus,
+    .btn-group > .btn-ghost:focus,
+    .btn-group > .btn:active,
+    .btn-group > .btn-ghost:active,
+    .btn-group > .btn.active,
+    .btn-group > .active.btn-ghost,
+    .btn-group-vertical > .btn:hover,
+    .btn-group-vertical > .btn-ghost:hover,
+    .btn-group-vertical > .btn:focus,
+    .btn-group-vertical > .btn-ghost:focus,
+    .btn-group-vertical > .btn:active,
+    .btn-group-vertical > .btn-ghost:active,
+    .btn-group-vertical > .btn.active, .btn-group-vertical > .active.btn-ghost {
+      z-index: 2; }
 
-.btn-group .btn + .btn, .btn-group .btn-ghost + .btn, .btn-group .btn + .btn-ghost, .btn-group .btn-ghost + .btn-ghost,
+.btn-group .btn + .btn,
+.btn-group .btn-ghost + .btn,
+.btn-group .btn + .btn-ghost,
+.btn-group .btn-ghost + .btn-ghost,
 .btn-group .btn + .btn-group,
 .btn-group .btn-ghost + .btn-group,
 .btn-group .btn-group + .btn,
 .btn-group .btn-group + .btn-ghost,
 .btn-group .btn-group + .btn-group {
-  margin-left: -1px;
-}
+  margin-left: -1px; }
 
 .btn-toolbar {
-  margin-left: -5px;
-}
-.btn-toolbar:before, .btn-toolbar:after {
-  content: " ";
-  display: table;
-}
-.btn-toolbar:after {
-  clear: both;
-}
-.btn-toolbar .btn, .btn-toolbar .btn-ghost,
-.btn-toolbar .btn-group,
-.btn-toolbar .input-group {
-  float: left;
-}
-.btn-toolbar > .btn, .btn-toolbar > .btn-ghost,
-.btn-toolbar > .btn-group,
-.btn-toolbar > .input-group {
-  margin-left: 5px;
-}
+  margin-left: -5px; }
+  .btn-toolbar:before,
+  .btn-toolbar:after {
+    content: " ";
+    display: table; }
+  .btn-toolbar:after {
+    clear: both; }
+  .btn-toolbar .btn-group,
+  .btn-toolbar .input-group {
+    float: left; }
+  .btn-toolbar > .btn,
+  .btn-toolbar > .btn-ghost,
+  .btn-toolbar > .btn-group,
+  .btn-toolbar > .input-group {
+    margin-left: 5px; }
 
 .btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:not(:first-child):not(:last-child):not(.dropdown-toggle) {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
 .btn-group > .btn:first-child, .btn-group > .btn-ghost:first-child {
-  margin-left: 0;
-}
-.btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:first-child:not(:last-child):not(.dropdown-toggle) {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
+  margin-left: 0; }
+  .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:first-child:not(:last-child):not(.dropdown-toggle) {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0; }
 
-.btn-group > .btn:last-child:not(:first-child), .btn-group > .btn-ghost:last-child:not(:first-child),
+.btn-group > .btn:last-child:not(:first-child),
+.btn-group > .btn-ghost:last-child:not(:first-child),
 .btn-group > .dropdown-toggle:not(:first-child) {
   border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .btn-group > .btn-group {
-  float: left;
-}
+  float: left; }
 
 .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn, .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn-ghost {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
-.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child, .btn-group > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child,
+.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child,
+.btn-group > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child,
 .btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
   border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
+  border-top-right-radius: 0; }
 
 .btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child, .btn-group > .btn-group:last-child:not(:first-child) > .btn-ghost:first-child {
   border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .btn-group .dropdown-toggle:active,
 .btn-group.open .dropdown-toggle {
-  outline: 0;
-}
+  outline: 0; }
 
 .btn-group > .btn + .dropdown-toggle, .btn-group > .btn-ghost + .dropdown-toggle {
   padding-left: 8px;
-  padding-right: 8px;
-}
+  padding-right: 8px; }
 
 .btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle, .btn-group-lg.btn-group > .btn-ghost + .dropdown-toggle {
   padding-left: 12px;
-  padding-right: 12px;
-}
+  padding-right: 12px; }
 
 .btn-group.open .dropdown-toggle {
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-}
-.btn-group.open .dropdown-toggle.btn-link, .btn-group.open .dropdown-toggle.btn-secondary {
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
+  .btn-group.open .dropdown-toggle.btn-link, .btn-group.open .dropdown-toggle.btn-secondary {
+    -webkit-box-shadow: none;
+    box-shadow: none; }
 
 .btn .caret, .btn-ghost .caret {
-  margin-left: 0;
-}
+  margin-left: 0; }
 
 .btn-lg .caret, .btn-group-lg > .btn .caret, .btn-group-lg > .btn-ghost .caret {
   border-width: 5px 5px 0;
-  border-bottom-width: 0;
-}
+  border-bottom-width: 0; }
 
 .dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .btn-group-lg > .btn-ghost .caret {
-  border-width: 0 5px 5px;
-}
+  border-width: 0 5px 5px; }
 
-.btn-group-vertical > .btn, .btn-group-vertical > .btn-ghost,
+.btn-group-vertical > .btn,
+.btn-group-vertical > .btn-ghost,
 .btn-group-vertical > .btn-group,
-.btn-group-vertical > .btn-group > .btn,
-.btn-group-vertical > .btn-group > .btn-ghost {
+.btn-group-vertical > .btn-group > .btn, .btn-group-vertical > .btn-group > .btn-ghost {
   display: block;
   float: none;
   width: 100%;
-  max-width: 100%;
-}
-.btn-group-vertical > .btn-group:before, .btn-group-vertical > .btn-group:after {
-  content: " ";
-  display: table;
-}
+  max-width: 100%; }
+
+.btn-group-vertical > .btn-group:before,
 .btn-group-vertical > .btn-group:after {
-  clear: both;
-}
+  content: " ";
+  display: table; }
+
+.btn-group-vertical > .btn-group:after {
+  clear: both; }
+
 .btn-group-vertical > .btn-group > .btn, .btn-group-vertical > .btn-group > .btn-ghost {
-  float: none;
-}
-.btn-group-vertical > .btn + .btn, .btn-group-vertical > .btn-ghost + .btn, .btn-group-vertical > .btn + .btn-ghost, .btn-group-vertical > .btn-ghost + .btn-ghost,
+  float: none; }
+
+.btn-group-vertical > .btn + .btn,
+.btn-group-vertical > .btn-ghost + .btn,
+.btn-group-vertical > .btn + .btn-ghost,
+.btn-group-vertical > .btn-ghost + .btn-ghost,
 .btn-group-vertical > .btn + .btn-group,
 .btn-group-vertical > .btn-ghost + .btn-group,
 .btn-group-vertical > .btn-group + .btn,
 .btn-group-vertical > .btn-group + .btn-ghost,
 .btn-group-vertical > .btn-group + .btn-group {
   margin-top: -1px;
-  margin-left: 0;
-}
+  margin-left: 0; }
 
 .btn-group-vertical > .btn:not(:first-child):not(:last-child), .btn-group-vertical > .btn-ghost:not(:first-child):not(:last-child) {
-  border-radius: 0;
-}
+  border-radius: 0; }
+
 .btn-group-vertical > .btn:first-child:not(:last-child), .btn-group-vertical > .btn-ghost:first-child:not(:last-child) {
   border-top-right-radius: 4px;
   border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
+  border-bottom-left-radius: 0; }
+
 .btn-group-vertical > .btn:last-child:not(:first-child), .btn-group-vertical > .btn-ghost:last-child:not(:first-child) {
   border-bottom-left-radius: 4px;
   border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn, .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn-ghost {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
-.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child, .btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child,
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child,
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child,
 .btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
   border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
+  border-bottom-left-radius: 0; }
 
 .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child, .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn-ghost:first-child {
   border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .btn-group-justified {
   display: table;
   width: 100%;
   table-layout: fixed;
-  border-collapse: separate;
-}
-.btn-group-justified > .btn, .btn-group-justified > .btn-ghost,
-.btn-group-justified > .btn-group {
-  float: none;
-  display: table-cell;
-  width: 1%;
-}
-.btn-group-justified > .btn-group .btn, .btn-group-justified > .btn-group .btn-ghost {
-  width: 100%;
-}
-.btn-group-justified > .btn-group .dropdown-menu {
-  left: auto;
-}
+  border-collapse: separate; }
+  .btn-group-justified > .btn,
+  .btn-group-justified > .btn-ghost,
+  .btn-group-justified > .btn-group {
+    float: none;
+    display: table-cell;
+    width: 1%; }
+  .btn-group-justified > .btn-group .btn, .btn-group-justified > .btn-group .btn-ghost {
+    width: 100%; }
+  .btn-group-justified > .btn-group .dropdown-menu {
+    left: auto; }
 
-[data-toggle="buttons"] > .btn input[type="radio"], [data-toggle="buttons"] > .btn-ghost input[type="radio"],
+[data-toggle="buttons"] > .btn input[type="radio"],
+[data-toggle="buttons"] > .btn-ghost input[type="radio"],
 [data-toggle="buttons"] > .btn input[type="checkbox"],
 [data-toggle="buttons"] > .btn-ghost input[type="checkbox"],
 [data-toggle="buttons"] > .btn-group > .btn input[type="radio"],
 [data-toggle="buttons"] > .btn-group > .btn-ghost input[type="radio"],
-[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"],
-[data-toggle="buttons"] > .btn-group > .btn-ghost input[type="checkbox"] {
+[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"], [data-toggle="buttons"] > .btn-group > .btn-ghost input[type="checkbox"] {
   position: absolute;
   clip: rect(0, 0, 0, 0);
-  pointer-events: none;
-}
+  pointer-events: none; }
 
 .input-group {
   position: relative;
   display: table;
-  border-collapse: separate;
-}
-.input-group[class*="col-"] {
-  float: none;
-  padding-left: 0;
-  padding-right: 0;
-}
-.input-group .form-control {
-  position: relative;
-  z-index: 2;
-  float: left;
-  width: 100%;
-  margin-bottom: 0;
-}
+  border-collapse: separate; }
+  .input-group[class*="col-"] {
+    float: none;
+    padding-left: 0;
+    padding-right: 0; }
+  .input-group .form-control {
+    position: relative;
+    z-index: 2;
+    float: left;
+    width: 100%;
+    margin-bottom: 0; }
 
 .input-group-addon,
 .input-group-btn,
 .input-group .form-control {
-  display: table-cell;
-}
-.input-group-addon:not(:first-child):not(:last-child),
-.input-group-btn:not(:first-child):not(:last-child),
-.input-group .form-control:not(:first-child):not(:last-child) {
-  border-radius: 0;
-}
+  display: table-cell; }
+  .input-group-addon:not(:first-child):not(:last-child),
+  .input-group-btn:not(:first-child):not(:last-child),
+  .input-group .form-control:not(:first-child):not(:last-child) {
+    border-radius: 0; }
 
 .input-group-addon,
 .input-group-btn {
   width: 1%;
   white-space: nowrap;
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
 .input-group-addon {
   padding: 6px 12px;
@@ -4549,28 +3688,20 @@ tbody.collapse.in {
   text-align: center;
   background-color: #eeeeee;
   border: 1px solid #ccc;
-  border-radius: 4px;
-}
-.input-group-addon.input-sm,
-.input-group-sm > .input-group-addon,
-.input-group-sm > .input-group-btn > .input-group-addon.btn,
-.input-group-sm > .input-group-btn > .input-group-addon.btn-ghost {
-  padding: 5px 10px;
-  font-size: 12px;
-  border-radius: 3px;
-}
-.input-group-addon.input-lg,
-.input-group-lg > .input-group-addon,
-.input-group-lg > .input-group-btn > .input-group-addon.btn,
-.input-group-lg > .input-group-btn > .input-group-addon.btn-ghost {
-  padding: 10px 16px;
-  font-size: 18px;
-  border-radius: 6px;
-}
-.input-group-addon input[type="radio"],
-.input-group-addon input[type="checkbox"] {
-  margin-top: 0;
-}
+  border-radius: 4px; }
+  .input-group-addon.input-sm, .input-group-sm > .input-group-addon,
+  .input-group-sm > .input-group-btn > .input-group-addon.btn, .input-group-sm > .input-group-btn > .input-group-addon.btn-ghost {
+    padding: 5px 10px;
+    font-size: 12px;
+    border-radius: 3px; }
+  .input-group-addon.input-lg, .input-group-lg > .input-group-addon,
+  .input-group-lg > .input-group-btn > .input-group-addon.btn, .input-group-lg > .input-group-btn > .input-group-addon.btn-ghost {
+    padding: 10px 16px;
+    font-size: 18px;
+    border-radius: 6px; }
+  .input-group-addon input[type="radio"],
+  .input-group-addon input[type="checkbox"] {
+    margin-top: 0; }
 
 .input-group .form-control:first-child,
 .input-group-addon:first-child,
@@ -4581,15 +3712,12 @@ tbody.collapse.in {
 .input-group-btn:first-child > .dropdown-toggle,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group-btn:last-child > .btn-ghost:not(:last-child):not(.dropdown-toggle),
-.input-group-btn:last-child > .btn-group:not(:last-child) > .btn,
-.input-group-btn:last-child > .btn-group:not(:last-child) > .btn-ghost {
+.input-group-btn:last-child > .btn-group:not(:last-child) > .btn, .input-group-btn:last-child > .btn-group:not(:last-child) > .btn-ghost {
   border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
+  border-top-right-radius: 0; }
 
 .input-group-addon:first-child {
-  border-right: 0;
-}
+  border-right: 0; }
 
 .input-group .form-control:last-child,
 .input-group-addon:last-child,
@@ -4600,230 +3728,189 @@ tbody.collapse.in {
 .input-group-btn:last-child > .dropdown-toggle,
 .input-group-btn:first-child > .btn:not(:first-child),
 .input-group-btn:first-child > .btn-ghost:not(:first-child),
-.input-group-btn:first-child > .btn-group:not(:first-child) > .btn,
-.input-group-btn:first-child > .btn-group:not(:first-child) > .btn-ghost {
+.input-group-btn:first-child > .btn-group:not(:first-child) > .btn, .input-group-btn:first-child > .btn-group:not(:first-child) > .btn-ghost {
   border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .input-group-addon:last-child {
-  border-left: 0;
-}
+  border-left: 0; }
 
 .input-group-btn {
   position: relative;
   font-size: 0;
-  white-space: nowrap;
-}
-.input-group-btn > .btn, .input-group-btn > .btn-ghost {
-  position: relative;
-}
-.input-group-btn > .btn + .btn, .input-group-btn > .btn-ghost + .btn, .input-group-btn > .btn + .btn-ghost, .input-group-btn > .btn-ghost + .btn-ghost {
-  margin-left: -1px;
-}
-.input-group-btn > .btn:hover, .input-group-btn > .btn-ghost:hover, .input-group-btn > .btn:focus, .input-group-btn > .btn-ghost:focus, .input-group-btn > .btn:active, .input-group-btn > .btn-ghost:active {
-  z-index: 2;
-}
-.input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-ghost,
-.input-group-btn:first-child > .btn-group {
-  margin-right: -1px;
-}
-.input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-ghost,
-.input-group-btn:last-child > .btn-group {
-  z-index: 2;
-  margin-left: -1px;
-}
+  white-space: nowrap; }
+  .input-group-btn > .btn, .input-group-btn > .btn-ghost {
+    position: relative; }
+    .input-group-btn > .btn + .btn, .input-group-btn > .btn-ghost + .btn, .input-group-btn > .btn + .btn-ghost, .input-group-btn > .btn-ghost + .btn-ghost {
+      margin-left: -1px; }
+    .input-group-btn > .btn:hover,
+    .input-group-btn > .btn-ghost:hover,
+    .input-group-btn > .btn:focus,
+    .input-group-btn > .btn-ghost:focus,
+    .input-group-btn > .btn:active, .input-group-btn > .btn-ghost:active {
+      z-index: 2; }
+  .input-group-btn:first-child > .btn,
+  .input-group-btn:first-child > .btn-ghost,
+  .input-group-btn:first-child > .btn-group {
+    margin-right: -1px; }
+  .input-group-btn:last-child > .btn,
+  .input-group-btn:last-child > .btn-ghost,
+  .input-group-btn:last-child > .btn-group {
+    margin-left: -1px; }
 
 .nav {
   margin-bottom: 0;
   padding-left: 0;
-  list-style: none;
-}
-.nav:before, .nav:after {
-  content: " ";
-  display: table;
-}
-.nav:after {
-  clear: both;
-}
-.nav > li {
-  position: relative;
-  display: block;
-}
-.nav > li > a {
-  position: relative;
-  display: block;
-  padding: 10px 15px;
-}
-.nav > li > a:hover, .nav > li > a:focus {
-  text-decoration: none;
-  background-color: #eeeeee;
-}
-.nav > li.disabled > a {
-  color: #999999;
-}
-.nav > li.disabled > a:hover, .nav > li.disabled > a:focus {
-  color: #999999;
-  text-decoration: none;
-  background-color: transparent;
-  cursor: not-allowed;
-}
-.nav .open > a, .nav .open > a:hover, .nav .open > a:focus {
-  background-color: #eeeeee;
-  border-color: #2e88be;
-}
-.nav .nav-divider {
-  height: 1px;
-  margin: 9px 0;
-  overflow: hidden;
-  background-color: #e5e5e5;
-}
-.nav > li > a > img {
-  max-width: none;
-}
+  list-style: none; }
+  .nav:before,
+  .nav:after {
+    content: " ";
+    display: table; }
+  .nav:after {
+    clear: both; }
+  .nav > li {
+    position: relative;
+    display: block; }
+    .nav > li > a {
+      position: relative;
+      display: block;
+      padding: 10px 15px; }
+      .nav > li > a:hover,
+      .nav > li > a:focus {
+        text-decoration: none;
+        background-color: #eeeeee; }
+    .nav > li.disabled > a {
+      color: #999999; }
+      .nav > li.disabled > a:hover,
+      .nav > li.disabled > a:focus {
+        color: #999999;
+        text-decoration: none;
+        background-color: transparent;
+        cursor: not-allowed; }
+  .nav .open > a,
+  .nav .open > a:hover,
+  .nav .open > a:focus {
+    background-color: #eeeeee;
+    border-color: #2e88be; }
+  .nav .nav-divider {
+    height: 1px;
+    margin: 9px 0;
+    overflow: hidden;
+    background-color: #e5e5e5; }
+  .nav > li > a > img {
+    max-width: none; }
 
 .nav-tabs {
-  border-bottom: 1px solid #ddd;
-}
-.nav-tabs > li {
-  float: left;
-  margin-bottom: -1px;
-}
-.nav-tabs > li > a {
-  margin-right: 2px;
-  line-height: 1.42857;
-  border: 1px solid transparent;
-  border-radius: 4px 4px 0 0;
-}
-.nav-tabs > li > a:hover {
-  border-color: #eeeeee #eeeeee #ddd;
-}
-.nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
-  color: #666;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-bottom-color: transparent;
-  cursor: default;
-}
+  border-bottom: 1px solid #ddd; }
+  .nav-tabs > li {
+    float: left;
+    margin-bottom: -1px; }
+    .nav-tabs > li > a {
+      margin-right: 2px;
+      line-height: 1.42857;
+      border: 1px solid transparent;
+      border-radius: 4px 4px 0 0; }
+      .nav-tabs > li > a:hover {
+        border-color: #eeeeee #eeeeee #ddd; }
+    .nav-tabs > li.active > a,
+    .nav-tabs > li.active > a:hover,
+    .nav-tabs > li.active > a:focus {
+      color: #666;
+      background-color: #fff;
+      border: 1px solid #ddd;
+      border-bottom-color: transparent;
+      cursor: default; }
 
 .nav-pills > li {
-  float: left;
-}
-.nav-pills > li > a {
-  border-radius: 4px;
-}
-.nav-pills > li + li {
-  margin-left: 2px;
-}
-.nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus {
-  color: #666;
-  background-color: #f1f1f1;
-}
+  float: left; }
+  .nav-pills > li > a {
+    border-radius: 4px; }
+  .nav-pills > li + li {
+    margin-left: 2px; }
+  .nav-pills > li.active > a,
+  .nav-pills > li.active > a:hover,
+  .nav-pills > li.active > a:focus {
+    color: #666;
+    background-color: #f1f1f1; }
 
 .nav-stacked > li {
-  float: none;
-}
-.nav-stacked > li + li {
-  margin-top: 2px;
-  margin-left: 0;
-}
+  float: none; }
+  .nav-stacked > li + li {
+    margin-top: 2px;
+    margin-left: 0; }
 
 .nav-justified, .nav-tabs.nav-justified {
-  width: 100%;
-}
-.nav-justified > li, .nav-tabs.nav-justified > li {
-  float: none;
-}
-.nav-justified > li > a, .nav-tabs.nav-justified > li > a {
-  text-align: center;
-  margin-bottom: 5px;
-}
-.nav-justified > .dropdown .dropdown-menu {
-  top: auto;
-  left: auto;
-}
-@media (min-width: 768px) {
+  width: 100%; }
   .nav-justified > li, .nav-tabs.nav-justified > li {
-    display: table-cell;
-    width: 1%;
-  }
-  .nav-justified > li > a, .nav-tabs.nav-justified > li > a {
-    margin-bottom: 0;
-  }
-}
+    float: none; }
+    .nav-justified > li > a, .nav-tabs.nav-justified > li > a {
+      text-align: center;
+      margin-bottom: 5px; }
+  .nav-justified > .dropdown .dropdown-menu {
+    top: auto;
+    left: auto; }
+  @media (min-width: 768px) {
+    .nav-justified > li, .nav-tabs.nav-justified > li {
+      display: table-cell;
+      width: 1%; }
+      .nav-justified > li > a, .nav-tabs.nav-justified > li > a {
+        margin-bottom: 0; } }
 
 .nav-tabs-justified, .nav-tabs.nav-justified {
-  border-bottom: 0;
-}
-.nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a {
-  margin-right: 0;
-  border-radius: 4px;
-}
-.nav-tabs-justified > .active > a, .nav-tabs.nav-justified > .active > a,
-.nav-tabs-justified > .active > a:hover,
-.nav-tabs.nav-justified > .active > a:hover,
-.nav-tabs-justified > .active > a:focus,
-.nav-tabs.nav-justified > .active > a:focus {
-  border: 1px solid #ddd;
-}
-@media (min-width: 768px) {
+  border-bottom: 0; }
   .nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a {
-    border-bottom: 1px solid #ddd;
-    border-radius: 4px 4px 0 0;
-  }
-  .nav-tabs-justified > .active > a, .nav-tabs.nav-justified > .active > a,
-  .nav-tabs-justified > .active > a:hover,
-  .nav-tabs.nav-justified > .active > a:hover,
-  .nav-tabs-justified > .active > a:focus,
-  .nav-tabs.nav-justified > .active > a:focus {
-    border-bottom-color: #fff;
-  }
-}
+    margin-right: 0;
+    border-radius: 4px; }
+  .nav-tabs-justified > .active > a,
+  .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover,
+  .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus {
+    border: 1px solid #ddd; }
+  @media (min-width: 768px) {
+    .nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a {
+      border-bottom: 1px solid #ddd;
+      border-radius: 4px 4px 0 0; }
+    .nav-tabs-justified > .active > a,
+    .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover,
+    .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus {
+      border-bottom-color: #fff; } }
 
 .tab-content > .tab-pane {
-  display: none;
-}
+  display: none; }
+
 .tab-content > .active {
-  display: block;
-}
+  display: block; }
 
 .nav-tabs .dropdown-menu {
   margin-top: -1px;
   border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .navbar {
   position: relative;
   min-height: 50px;
   margin-bottom: 20px;
-  border: 1px solid transparent;
-}
-.navbar:before, .navbar:after {
-  content: " ";
-  display: table;
-}
-.navbar:after {
-  clear: both;
-}
-@media (min-width: 768px) {
-  .navbar {
-    border-radius: 4px;
-  }
-}
+  border: 1px solid transparent; }
+  .navbar:before,
+  .navbar:after {
+    content: " ";
+    display: table; }
+  .navbar:after {
+    clear: both; }
+  @media (min-width: 768px) {
+    .navbar {
+      border-radius: 4px; } }
 
-.navbar-header:before, .navbar-header:after {
-  content: " ";
-  display: table;
-}
+.navbar-header:before,
 .navbar-header:after {
-  clear: both;
-}
+  content: " ";
+  display: table; }
+
+.navbar-header:after {
+  clear: both; }
+
 @media (min-width: 768px) {
   .navbar-header {
-    float: left;
-  }
-}
+    float: left; } }
 
 .navbar-collapse {
   overflow-x: visible;
@@ -4831,120 +3918,97 @@ tbody.collapse.in {
   padding-left: 15px;
   border-top: 1px solid transparent;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  -webkit-overflow-scrolling: touch;
-}
-.navbar-collapse:before, .navbar-collapse:after {
-  content: " ";
-  display: table;
-}
-.navbar-collapse:after {
-  clear: both;
-}
-.navbar-collapse.in {
-  overflow-y: auto;
-}
-@media (min-width: 768px) {
-  .navbar-collapse {
-    width: auto;
-    border-top: 0;
-    box-shadow: none;
-  }
-  .navbar-collapse.collapse {
-    display: block !important;
-    height: auto !important;
-    padding-bottom: 0;
-    overflow: visible !important;
-  }
+  -webkit-overflow-scrolling: touch; }
+  .navbar-collapse:before,
+  .navbar-collapse:after {
+    content: " ";
+    display: table; }
+  .navbar-collapse:after {
+    clear: both; }
   .navbar-collapse.in {
-    overflow-y: visible;
-  }
-  .navbar-fixed-top .navbar-collapse, .navbar-static-top .navbar-collapse, .navbar-fixed-bottom .navbar-collapse {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
+    overflow-y: auto; }
+  @media (min-width: 768px) {
+    .navbar-collapse {
+      width: auto;
+      border-top: 0;
+      box-shadow: none; }
+      .navbar-collapse.collapse {
+        display: block !important;
+        height: auto !important;
+        padding-bottom: 0;
+        overflow: visible !important; }
+      .navbar-collapse.in {
+        overflow-y: visible; }
+      .navbar-fixed-top .navbar-collapse,
+      .navbar-static-top .navbar-collapse,
+      .navbar-fixed-bottom .navbar-collapse {
+        padding-left: 0;
+        padding-right: 0; } }
 
 .navbar-fixed-top .navbar-collapse,
 .navbar-fixed-bottom .navbar-collapse {
-  max-height: 340px;
-}
-@media (max-device-width: 480px) and (orientation: landscape) {
-  .navbar-fixed-top .navbar-collapse,
-  .navbar-fixed-bottom .navbar-collapse {
-    max-height: 200px;
-  }
-}
+  max-height: 340px; }
+  @media (max-device-width: 480px) and (orientation: landscape) {
+    .navbar-fixed-top .navbar-collapse,
+    .navbar-fixed-bottom .navbar-collapse {
+      max-height: 200px; } }
 
 .container > .navbar-header,
 .container > .navbar-collapse,
 .container-fluid > .navbar-header,
 .container-fluid > .navbar-collapse {
   margin-right: -15px;
-  margin-left: -15px;
-}
-@media (min-width: 768px) {
-  .container > .navbar-header,
-  .container > .navbar-collapse,
-  .container-fluid > .navbar-header,
-  .container-fluid > .navbar-collapse {
-    margin-right: 0;
-    margin-left: 0;
-  }
-}
+  margin-left: -15px; }
+  @media (min-width: 768px) {
+    .container > .navbar-header,
+    .container > .navbar-collapse,
+    .container-fluid > .navbar-header,
+    .container-fluid > .navbar-collapse {
+      margin-right: 0;
+      margin-left: 0; } }
 
 .navbar-static-top {
   z-index: 1000;
-  border-width: 0 0 1px;
-}
-@media (min-width: 768px) {
-  .navbar-static-top {
-    border-radius: 0;
-  }
-}
+  border-width: 0 0 1px; }
+  @media (min-width: 768px) {
+    .navbar-static-top {
+      border-radius: 0; } }
 
 .navbar-fixed-top,
 .navbar-fixed-bottom {
   position: fixed;
   right: 0;
   left: 0;
-  z-index: 1030;
-}
-@media (min-width: 768px) {
-  .navbar-fixed-top,
-  .navbar-fixed-bottom {
-    border-radius: 0;
-  }
-}
+  z-index: 1030; }
+  @media (min-width: 768px) {
+    .navbar-fixed-top,
+    .navbar-fixed-bottom {
+      border-radius: 0; } }
 
 .navbar-fixed-top {
   top: 0;
-  border-width: 0 0 1px;
-}
+  border-width: 0 0 1px; }
 
 .navbar-fixed-bottom {
   bottom: 0;
   margin-bottom: 0;
-  border-width: 1px 0 0;
-}
+  border-width: 1px 0 0; }
 
 .navbar-brand {
   float: left;
   padding: 15px 15px;
   font-size: 18px;
   line-height: 20px;
-  height: 50px;
-}
-.navbar-brand:hover, .navbar-brand:focus {
-  text-decoration: none;
-}
-.navbar-brand > img {
-  display: block;
-}
-@media (min-width: 768px) {
-  .navbar > .container .navbar-brand, .navbar > .container-fluid .navbar-brand {
-    margin-left: -15px;
-  }
-}
+  height: 50px; }
+  .navbar-brand:hover,
+  .navbar-brand:focus {
+    text-decoration: none; }
+  .navbar-brand > img {
+    display: block; }
+  @media (min-width: 768px) {
+    .navbar > .container .navbar-brand,
+    .navbar > .container-fluid .navbar-brand {
+      margin-left: -15px; } }
 
 .navbar-toggle {
   position: relative;
@@ -4956,68 +4020,52 @@ tbody.collapse.in {
   background-color: transparent;
   background-image: none;
   border: 1px solid transparent;
-  border-radius: 4px;
-}
-.navbar-toggle:focus {
-  outline: 0;
-}
-.navbar-toggle .icon-bar {
-  display: block;
-  width: 22px;
-  height: 2px;
-  border-radius: 1px;
-}
-.navbar-toggle .icon-bar + .icon-bar {
-  margin-top: 4px;
-}
-@media (min-width: 768px) {
-  .navbar-toggle {
-    display: none;
-  }
-}
+  border-radius: 4px; }
+  .navbar-toggle:focus {
+    outline: 0; }
+  .navbar-toggle .icon-bar {
+    display: block;
+    width: 22px;
+    height: 2px;
+    border-radius: 1px; }
+  .navbar-toggle .icon-bar + .icon-bar {
+    margin-top: 4px; }
+  @media (min-width: 768px) {
+    .navbar-toggle {
+      display: none; } }
 
 .navbar-nav {
-  margin: 7.5px -15px;
-}
-.navbar-nav > li > a {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  line-height: 20px;
-}
-@media (max-width: 767px) {
-  .navbar-nav .open .dropdown-menu {
-    position: static;
-    float: none;
-    width: auto;
-    margin-top: 0;
-    background-color: transparent;
-    border: 0;
-    box-shadow: none;
-  }
-  .navbar-nav .open .dropdown-menu > li > a,
-  .navbar-nav .open .dropdown-menu .dropdown-header {
-    padding: 5px 15px 5px 25px;
-  }
-  .navbar-nav .open .dropdown-menu > li > a {
-    line-height: 20px;
-  }
-  .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-nav .open .dropdown-menu > li > a:focus {
-    background-image: none;
-  }
-}
-@media (min-width: 768px) {
-  .navbar-nav {
-    float: left;
-    margin: 0;
-  }
-  .navbar-nav > li {
-    float: left;
-  }
+  margin: 7.5px -15px; }
   .navbar-nav > li > a {
-    padding-top: 15px;
-    padding-bottom: 15px;
-  }
-}
+    padding-top: 10px;
+    padding-bottom: 10px;
+    line-height: 20px; }
+  @media (max-width: 767px) {
+    .navbar-nav .open .dropdown-menu {
+      position: static;
+      float: none;
+      width: auto;
+      margin-top: 0;
+      background-color: transparent;
+      border: 0;
+      box-shadow: none; }
+      .navbar-nav .open .dropdown-menu > li > a,
+      .navbar-nav .open .dropdown-menu .dropdown-header {
+        padding: 5px 15px 5px 25px; }
+      .navbar-nav .open .dropdown-menu > li > a {
+        line-height: 20px; }
+        .navbar-nav .open .dropdown-menu > li > a:hover,
+        .navbar-nav .open .dropdown-menu > li > a:focus {
+          background-image: none; } }
+  @media (min-width: 768px) {
+    .navbar-nav {
+      float: left;
+      margin: 0; }
+      .navbar-nav > li {
+        float: left; }
+        .navbar-nav > li > a {
+          padding-top: 15px;
+          padding-bottom: 15px; } }
 
 .navbar-form {
   margin-left: -15px;
@@ -5028,459 +4076,403 @@ tbody.collapse.in {
   -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
   margin-top: 8px;
-  margin-bottom: 8px;
-}
-@media (min-width: 768px) {
-  .navbar-form .form-group {
-    display: inline-block;
-    margin-bottom: 0;
-    vertical-align: middle;
-  }
-  .navbar-form .form-control {
-    display: inline-block;
-    width: auto;
-    vertical-align: middle;
-  }
-  .navbar-form .form-control-static {
-    display: inline-block;
-  }
-  .navbar-form .input-group {
-    display: inline-table;
-    vertical-align: middle;
-  }
-  .navbar-form .input-group .input-group-addon,
-  .navbar-form .input-group .input-group-btn,
-  .navbar-form .input-group .form-control {
-    width: auto;
-  }
-  .navbar-form .input-group > .form-control {
-    width: 100%;
-  }
-  .navbar-form .control-label {
-    margin-bottom: 0;
-    vertical-align: middle;
-  }
-  .navbar-form .radio,
-  .navbar-form .checkbox {
-    display: inline-block;
-    margin-top: 0;
-    margin-bottom: 0;
-    vertical-align: middle;
-  }
-  .navbar-form .radio label,
-  .navbar-form .checkbox label {
-    padding-left: 0;
-  }
-  .navbar-form .radio input[type="radio"],
-  .navbar-form .checkbox input[type="checkbox"] {
-    position: relative;
-    margin-left: 0;
-  }
-  .navbar-form .has-feedback .form-control-feedback {
-    top: 0;
-  }
-}
-@media (max-width: 767px) {
-  .navbar-form .form-group {
-    margin-bottom: 5px;
-  }
-  .navbar-form .form-group:last-child {
-    margin-bottom: 0;
-  }
-}
-@media (min-width: 768px) {
-  .navbar-form {
-    width: auto;
-    border: 0;
-    margin-left: 0;
-    margin-right: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-  }
-}
+  margin-bottom: 8px; }
+  @media (min-width: 768px) {
+    .navbar-form .form-group {
+      display: inline-block;
+      margin-bottom: 0;
+      vertical-align: middle; }
+    .navbar-form .form-control {
+      display: inline-block;
+      width: auto;
+      vertical-align: middle; }
+    .navbar-form .form-control-static {
+      display: inline-block; }
+    .navbar-form .input-group {
+      display: inline-table;
+      vertical-align: middle; }
+      .navbar-form .input-group .input-group-addon,
+      .navbar-form .input-group .input-group-btn,
+      .navbar-form .input-group .form-control {
+        width: auto; }
+    .navbar-form .input-group > .form-control {
+      width: 100%; }
+    .navbar-form .control-label {
+      margin-bottom: 0;
+      vertical-align: middle; }
+    .navbar-form .radio,
+    .navbar-form .checkbox {
+      display: inline-block;
+      margin-top: 0;
+      margin-bottom: 0;
+      vertical-align: middle; }
+      .navbar-form .radio label,
+      .navbar-form .checkbox label {
+        padding-left: 0; }
+    .navbar-form .radio input[type="radio"],
+    .navbar-form .checkbox input[type="checkbox"] {
+      position: relative;
+      margin-left: 0; }
+    .navbar-form .has-feedback .form-control-feedback {
+      top: 0; } }
+  @media (max-width: 767px) {
+    .navbar-form .form-group {
+      margin-bottom: 5px; }
+      .navbar-form .form-group:last-child {
+        margin-bottom: 0; } }
+  @media (min-width: 768px) {
+    .navbar-form {
+      width: auto;
+      border: 0;
+      margin-left: 0;
+      margin-right: 0;
+      padding-top: 0;
+      padding-bottom: 0;
+      -webkit-box-shadow: none;
+      box-shadow: none; } }
 
 .navbar-nav > li > .dropdown-menu {
   margin-top: 0;
   border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
+  border-top-left-radius: 0; }
 
 .navbar-fixed-bottom .navbar-nav > li > .dropdown-menu {
   margin-bottom: 0;
   border-top-right-radius: 4px;
   border-top-left-radius: 4px;
   border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
+  border-bottom-left-radius: 0; }
 
 .navbar-btn {
   margin-top: 8px;
-  margin-bottom: 8px;
-}
-.navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn, .btn-group-sm > .navbar-btn.btn-ghost {
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-.navbar-btn.btn-xs, .btn-group-xs > .navbar-btn.btn, .btn-group-xs > .navbar-btn.btn-ghost {
-  margin-top: 14px;
-  margin-bottom: 14px;
-}
+  margin-bottom: 8px; }
+  .navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn, .btn-group-sm > .navbar-btn.btn-ghost {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .navbar-btn.btn-xs, .btn-group-xs > .navbar-btn.btn, .btn-group-xs > .navbar-btn.btn-ghost {
+    margin-top: 14px;
+    margin-bottom: 14px; }
 
 .navbar-text {
   margin-top: 15px;
-  margin-bottom: 15px;
-}
-@media (min-width: 768px) {
-  .navbar-text {
-    float: left;
-    margin-left: 15px;
-    margin-right: 15px;
-  }
-}
+  margin-bottom: 15px; }
+  @media (min-width: 768px) {
+    .navbar-text {
+      float: left;
+      margin-left: 15px;
+      margin-right: 15px; } }
 
 @media (min-width: 768px) {
   .navbar-left {
-    float: left !important;
-  }
-
+    float: left !important; }
   .navbar-right {
     float: right !important;
-    margin-right: -15px;
-  }
-  .navbar-right ~ .navbar-right {
-    margin-right: 0;
-  }
-}
+    margin-right: -15px; }
+    .navbar-right ~ .navbar-right {
+      margin-right: 0; } }
+
 .navbar-default {
   background-color: #fff;
-  border-color: #eeeeee;
-}
-.navbar-default .navbar-brand {
-  color: #666;
-}
-.navbar-default .navbar-brand:hover, .navbar-default .navbar-brand:focus {
-  color: #4d4d4d;
-  background-color: transparent;
-}
-.navbar-default .navbar-text {
-  color: #666;
-}
-.navbar-default .navbar-nav > li > a {
-  color: #666;
-}
-.navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus {
-  color: #333;
-  background-color: transparent;
-}
-.navbar-default .navbar-nav > .active > a, .navbar-default .navbar-nav > .active > a:hover, .navbar-default .navbar-nav > .active > a:focus {
-  color: #e53221;
-  background-color: #f9f9f9;
-}
-.navbar-default .navbar-nav > .disabled > a, .navbar-default .navbar-nav > .disabled > a:hover, .navbar-default .navbar-nav > .disabled > a:focus {
-  color: #ccc;
-  background-color: transparent;
-}
-.navbar-default .navbar-toggle {
-  border-color: #ddd;
-}
-.navbar-default .navbar-toggle:hover, .navbar-default .navbar-toggle:focus {
-  background-color: #eee;
-}
-.navbar-default .navbar-toggle .icon-bar {
-  background-color: #999;
-}
-.navbar-default .navbar-collapse,
-.navbar-default .navbar-form {
-  border-color: #eeeeee;
-}
-.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus {
-  background-color: #f9f9f9;
-  color: #e53221;
-}
-@media (max-width: 767px) {
-  .navbar-default .navbar-nav .open .dropdown-menu > li > a {
-    color: #666;
-  }
-  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
-    color: #333;
-    background-color: transparent;
-  }
-  .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+  border-color: #eeeeee; }
+  .navbar-default .navbar-brand {
+    color: #666; }
+    .navbar-default .navbar-brand:hover,
+    .navbar-default .navbar-brand:focus {
+      color: #4d4d4d;
+      background-color: transparent; }
+  .navbar-default .navbar-text {
+    color: #666; }
+  .navbar-default .navbar-nav > li > a {
+    color: #666; }
+    .navbar-default .navbar-nav > li > a:hover,
+    .navbar-default .navbar-nav > li > a:focus {
+      color: #333;
+      background-color: transparent; }
+  .navbar-default .navbar-nav > .active > a,
+  .navbar-default .navbar-nav > .active > a:hover,
+  .navbar-default .navbar-nav > .active > a:focus {
     color: #e53221;
-    background-color: #f9f9f9;
-  }
-  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    background-color: #f9f9f9; }
+  .navbar-default .navbar-nav > .disabled > a,
+  .navbar-default .navbar-nav > .disabled > a:hover,
+  .navbar-default .navbar-nav > .disabled > a:focus {
     color: #ccc;
-    background-color: transparent;
-  }
-}
-.navbar-default .navbar-link {
-  color: #666;
-}
-.navbar-default .navbar-link:hover {
-  color: #333;
-}
-.navbar-default .btn-link, .navbar-default .btn-secondary {
-  color: #666;
-}
-.navbar-default .btn-link:hover, .navbar-default .btn-secondary:hover, .navbar-default .btn-link:focus, .navbar-default .btn-secondary:focus {
-  color: #333;
-}
-.navbar-default .btn-link[disabled]:hover, .navbar-default [disabled].btn-secondary:hover, .navbar-default .btn-link[disabled]:focus, .navbar-default [disabled].btn-secondary:focus, fieldset[disabled] .navbar-default .btn-link:hover, fieldset[disabled] .navbar-default .btn-secondary:hover, fieldset[disabled] .navbar-default .btn-link:focus, fieldset[disabled] .navbar-default .btn-secondary:focus {
-  color: #ccc;
-}
+    background-color: transparent; }
+  .navbar-default .navbar-toggle {
+    border-color: #ddd; }
+    .navbar-default .navbar-toggle:hover,
+    .navbar-default .navbar-toggle:focus {
+      background-color: #eee; }
+    .navbar-default .navbar-toggle .icon-bar {
+      background-color: #999; }
+  .navbar-default .navbar-collapse,
+  .navbar-default .navbar-form {
+    border-color: #eeeeee; }
+  .navbar-default .navbar-nav > .open > a,
+  .navbar-default .navbar-nav > .open > a:hover,
+  .navbar-default .navbar-nav > .open > a:focus {
+    background-color: #f9f9f9;
+    color: #e53221; }
+  @media (max-width: 767px) {
+    .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+      color: #666; }
+      .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
+      .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
+        color: #333;
+        background-color: transparent; }
+    .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
+    .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
+    .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+      color: #e53221;
+      background-color: #f9f9f9; }
+    .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
+    .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+    .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+      color: #ccc;
+      background-color: transparent; } }
+  .navbar-default .navbar-link {
+    color: #666; }
+    .navbar-default .navbar-link:hover {
+      color: #333; }
+  .navbar-default .btn-link, .navbar-default .btn-secondary {
+    color: #666; }
+    .navbar-default .btn-link:hover,
+    .navbar-default .btn-secondary:hover,
+    .navbar-default .btn-link:focus, .navbar-default .btn-secondary:focus {
+      color: #333; }
+    .navbar-default .btn-link[disabled]:hover,
+    .navbar-default [disabled].btn-secondary:hover,
+    .navbar-default .btn-link[disabled]:focus,
+    .navbar-default [disabled].btn-secondary:focus,
+    fieldset[disabled] .navbar-default .btn-link:hover,
+    fieldset[disabled] .navbar-default .btn-secondary:hover,
+    fieldset[disabled] .navbar-default .btn-link:focus, fieldset[disabled] .navbar-default .btn-secondary:focus {
+      color: #ccc; }
 
 .navbar-inverse {
   background-color: #222;
-  border-color: #090909;
-}
-.navbar-inverse .navbar-brand {
-  color: #999999;
-}
-.navbar-inverse .navbar-brand:hover, .navbar-inverse .navbar-brand:focus {
-  color: #fff;
-  background-color: transparent;
-}
-.navbar-inverse .navbar-text {
-  color: #999999;
-}
-.navbar-inverse .navbar-nav > li > a {
-  color: #999999;
-}
-.navbar-inverse .navbar-nav > li > a:hover, .navbar-inverse .navbar-nav > li > a:focus {
-  color: #fff;
-  background-color: transparent;
-}
-.navbar-inverse .navbar-nav > .active > a, .navbar-inverse .navbar-nav > .active > a:hover, .navbar-inverse .navbar-nav > .active > a:focus {
-  color: #fff;
-  background-color: #090909;
-}
-.navbar-inverse .navbar-nav > .disabled > a, .navbar-inverse .navbar-nav > .disabled > a:hover, .navbar-inverse .navbar-nav > .disabled > a:focus {
-  color: #444;
-  background-color: transparent;
-}
-.navbar-inverse .navbar-toggle {
-  border-color: #333;
-}
-.navbar-inverse .navbar-toggle:hover, .navbar-inverse .navbar-toggle:focus {
-  background-color: #333;
-}
-.navbar-inverse .navbar-toggle .icon-bar {
-  background-color: #fff;
-}
-.navbar-inverse .navbar-collapse,
-.navbar-inverse .navbar-form {
-  border-color: #101010;
-}
-.navbar-inverse .navbar-nav > .open > a, .navbar-inverse .navbar-nav > .open > a:hover, .navbar-inverse .navbar-nav > .open > a:focus {
-  background-color: #090909;
-  color: #fff;
-}
-@media (max-width: 767px) {
-  .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
-    border-color: #090909;
-  }
-  .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
-    background-color: #090909;
-  }
-  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
-    color: #999999;
-  }
-  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
+  border-color: #090909; }
+  .navbar-inverse .navbar-brand {
+    color: #999999; }
+    .navbar-inverse .navbar-brand:hover,
+    .navbar-inverse .navbar-brand:focus {
+      color: #fff;
+      background-color: transparent; }
+  .navbar-inverse .navbar-text {
+    color: #999999; }
+  .navbar-inverse .navbar-nav > li > a {
+    color: #999999; }
+    .navbar-inverse .navbar-nav > li > a:hover,
+    .navbar-inverse .navbar-nav > li > a:focus {
+      color: #fff;
+      background-color: transparent; }
+  .navbar-inverse .navbar-nav > .active > a,
+  .navbar-inverse .navbar-nav > .active > a:hover,
+  .navbar-inverse .navbar-nav > .active > a:focus {
     color: #fff;
-    background-color: transparent;
-  }
-  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a, .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
-    color: #fff;
-    background-color: #090909;
-  }
-  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    background-color: #090909; }
+  .navbar-inverse .navbar-nav > .disabled > a,
+  .navbar-inverse .navbar-nav > .disabled > a:hover,
+  .navbar-inverse .navbar-nav > .disabled > a:focus {
     color: #444;
-    background-color: transparent;
-  }
-}
-.navbar-inverse .navbar-link {
-  color: #999999;
-}
-.navbar-inverse .navbar-link:hover {
-  color: #fff;
-}
-.navbar-inverse .btn-link, .navbar-inverse .btn-secondary {
-  color: #999999;
-}
-.navbar-inverse .btn-link:hover, .navbar-inverse .btn-secondary:hover, .navbar-inverse .btn-link:focus, .navbar-inverse .btn-secondary:focus {
-  color: #fff;
-}
-.navbar-inverse .btn-link[disabled]:hover, .navbar-inverse [disabled].btn-secondary:hover, .navbar-inverse .btn-link[disabled]:focus, .navbar-inverse [disabled].btn-secondary:focus, fieldset[disabled] .navbar-inverse .btn-link:hover, fieldset[disabled] .navbar-inverse .btn-secondary:hover, fieldset[disabled] .navbar-inverse .btn-link:focus, fieldset[disabled] .navbar-inverse .btn-secondary:focus {
-  color: #444;
-}
+    background-color: transparent; }
+  .navbar-inverse .navbar-toggle {
+    border-color: #333; }
+    .navbar-inverse .navbar-toggle:hover,
+    .navbar-inverse .navbar-toggle:focus {
+      background-color: #333; }
+    .navbar-inverse .navbar-toggle .icon-bar {
+      background-color: #fff; }
+  .navbar-inverse .navbar-collapse,
+  .navbar-inverse .navbar-form {
+    border-color: #101010; }
+  .navbar-inverse .navbar-nav > .open > a,
+  .navbar-inverse .navbar-nav > .open > a:hover,
+  .navbar-inverse .navbar-nav > .open > a:focus {
+    background-color: #090909;
+    color: #fff; }
+  @media (max-width: 767px) {
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
+      border-color: #090909; }
+    .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
+      background-color: #090909; }
+    .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
+      color: #999999; }
+      .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
+      .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
+        color: #fff;
+        background-color: transparent; }
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a,
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover,
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
+      color: #fff;
+      background-color: #090909; }
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a,
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+    .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+      color: #444;
+      background-color: transparent; } }
+  .navbar-inverse .navbar-link {
+    color: #999999; }
+    .navbar-inverse .navbar-link:hover {
+      color: #fff; }
+  .navbar-inverse .btn-link, .navbar-inverse .btn-secondary {
+    color: #999999; }
+    .navbar-inverse .btn-link:hover,
+    .navbar-inverse .btn-secondary:hover,
+    .navbar-inverse .btn-link:focus, .navbar-inverse .btn-secondary:focus {
+      color: #fff; }
+    .navbar-inverse .btn-link[disabled]:hover,
+    .navbar-inverse [disabled].btn-secondary:hover,
+    .navbar-inverse .btn-link[disabled]:focus,
+    .navbar-inverse [disabled].btn-secondary:focus,
+    fieldset[disabled] .navbar-inverse .btn-link:hover,
+    fieldset[disabled] .navbar-inverse .btn-secondary:hover,
+    fieldset[disabled] .navbar-inverse .btn-link:focus, fieldset[disabled] .navbar-inverse .btn-secondary:focus {
+      color: #444; }
 
 .breadcrumb {
   padding: 8px 15px;
   margin-bottom: 20px;
   list-style: none;
   background-color: #f5f5f5;
-  border-radius: 4px;
-}
-.breadcrumb > li {
-  display: inline-block;
-}
-.breadcrumb > li + li:before {
-  content: "/ ";
-  padding: 0 5px;
-  color: #ccc;
-}
-.breadcrumb > .active {
-  color: #999999;
-}
+  border-radius: 4px; }
+  .breadcrumb > li {
+    display: inline-block; }
+    .breadcrumb > li + li:before {
+      content: "/\\00a0";
+      padding: 0 5px;
+      color: #ccc; }
+  .breadcrumb > .active {
+    color: #999999; }
 
 .pagination {
   display: inline-block;
   padding-left: 0;
   margin: 20px 0;
-  border-radius: 4px;
-}
-.pagination > li {
-  display: inline;
-}
-.pagination > li > a,
-.pagination > li > span {
-  position: relative;
-  float: left;
-  padding: 6px 12px;
-  line-height: 1.42857;
-  text-decoration: none;
-  color: #2e88be;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  margin-left: -1px;
-}
-.pagination > li:first-child > a,
-.pagination > li:first-child > span {
-  margin-left: 0;
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
-}
-.pagination > li:last-child > a,
-.pagination > li:last-child > span {
-  border-bottom-right-radius: 4px;
-  border-top-right-radius: 4px;
-}
-.pagination > li > a:hover, .pagination > li > a:focus,
-.pagination > li > span:hover,
-.pagination > li > span:focus {
-  z-index: 3;
-  color: #1f5c80;
-  background-color: #eeeeee;
-  border-color: #ddd;
-}
-.pagination > .active > a, .pagination > .active > a:hover, .pagination > .active > a:focus,
-.pagination > .active > span,
-.pagination > .active > span:hover,
-.pagination > .active > span:focus {
-  z-index: 2;
-  color: #fff;
-  background-color: #f1f1f1;
-  border-color: #f1f1f1;
-  cursor: default;
-}
-.pagination > .disabled > span,
-.pagination > .disabled > span:hover,
-.pagination > .disabled > span:focus,
-.pagination > .disabled > a,
-.pagination > .disabled > a:hover,
-.pagination > .disabled > a:focus {
-  color: #999999;
-  background-color: #fff;
-  border-color: #ddd;
-  cursor: not-allowed;
-}
+  border-radius: 4px; }
+  .pagination > li {
+    display: inline; }
+    .pagination > li > a,
+    .pagination > li > span {
+      position: relative;
+      float: left;
+      padding: 6px 12px;
+      line-height: 1.42857;
+      text-decoration: none;
+      color: #2e88be;
+      background-color: #fff;
+      border: 1px solid #ddd;
+      margin-left: -1px; }
+    .pagination > li:first-child > a,
+    .pagination > li:first-child > span {
+      margin-left: 0;
+      border-bottom-left-radius: 4px;
+      border-top-left-radius: 4px; }
+    .pagination > li:last-child > a,
+    .pagination > li:last-child > span {
+      border-bottom-right-radius: 4px;
+      border-top-right-radius: 4px; }
+  .pagination > li > a:hover,
+  .pagination > li > a:focus,
+  .pagination > li > span:hover,
+  .pagination > li > span:focus {
+    color: #1f5c80;
+    background-color: #eeeeee;
+    border-color: #ddd; }
+  .pagination > .active > a,
+  .pagination > .active > a:hover,
+  .pagination > .active > a:focus,
+  .pagination > .active > span,
+  .pagination > .active > span:hover,
+  .pagination > .active > span:focus {
+    z-index: 2;
+    color: #fff;
+    background-color: #f1f1f1;
+    border-color: #f1f1f1;
+    cursor: default; }
+  .pagination > .disabled > span,
+  .pagination > .disabled > span:hover,
+  .pagination > .disabled > span:focus,
+  .pagination > .disabled > a,
+  .pagination > .disabled > a:hover,
+  .pagination > .disabled > a:focus {
+    color: #999999;
+    background-color: #fff;
+    border-color: #ddd;
+    cursor: not-allowed; }
 
 .pagination-lg > li > a,
 .pagination-lg > li > span {
   padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.33;
-}
+  font-size: 18px; }
+
 .pagination-lg > li:first-child > a,
 .pagination-lg > li:first-child > span {
   border-bottom-left-radius: 6px;
-  border-top-left-radius: 6px;
-}
+  border-top-left-radius: 6px; }
+
 .pagination-lg > li:last-child > a,
 .pagination-lg > li:last-child > span {
   border-bottom-right-radius: 6px;
-  border-top-right-radius: 6px;
-}
+  border-top-right-radius: 6px; }
 
 .pagination-sm > li > a,
 .pagination-sm > li > span {
   padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-}
+  font-size: 12px; }
+
 .pagination-sm > li:first-child > a,
 .pagination-sm > li:first-child > span {
   border-bottom-left-radius: 3px;
-  border-top-left-radius: 3px;
-}
+  border-top-left-radius: 3px; }
+
 .pagination-sm > li:last-child > a,
 .pagination-sm > li:last-child > span {
   border-bottom-right-radius: 3px;
-  border-top-right-radius: 3px;
-}
+  border-top-right-radius: 3px; }
 
 .pager {
   padding-left: 0;
   margin: 20px 0;
   list-style: none;
-  text-align: center;
-}
-.pager:before, .pager:after {
-  content: " ";
-  display: table;
-}
-.pager:after {
-  clear: both;
-}
-.pager li {
-  display: inline;
-}
-.pager li > a,
-.pager li > span {
-  display: inline-block;
-  padding: 5px 14px;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 15px;
-}
-.pager li > a:hover,
-.pager li > a:focus {
-  text-decoration: none;
-  background-color: #eeeeee;
-}
-.pager .next > a,
-.pager .next > span {
-  float: right;
-}
-.pager .previous > a,
-.pager .previous > span {
-  float: left;
-}
-.pager .disabled > a,
-.pager .disabled > a:hover,
-.pager .disabled > a:focus,
-.pager .disabled > span {
-  color: #999999;
-  background-color: #fff;
-  cursor: not-allowed;
-}
+  text-align: center; }
+  .pager:before,
+  .pager:after {
+    content: " ";
+    display: table; }
+  .pager:after {
+    clear: both; }
+  .pager li {
+    display: inline; }
+    .pager li > a,
+    .pager li > span {
+      display: inline-block;
+      padding: 5px 14px;
+      background-color: #fff;
+      border: 1px solid #ddd;
+      border-radius: 15px; }
+    .pager li > a:hover,
+    .pager li > a:focus {
+      text-decoration: none;
+      background-color: #eeeeee; }
+  .pager .next > a,
+  .pager .next > span {
+    float: right; }
+  .pager .previous > a,
+  .pager .previous > span {
+    float: left; }
+  .pager .disabled > a,
+  .pager .disabled > a:hover,
+  .pager .disabled > a:focus,
+  .pager .disabled > span {
+    color: #999999;
+    background-color: #fff;
+    cursor: not-allowed; }
 
 .label {
   display: inline;
-  padding: .2em .6em .3em;
+  padding: 0.2em 0.6em 0.3em;
   font-size: 75%;
   font-weight: bold;
   line-height: 1;
@@ -5488,63 +4480,54 @@ tbody.collapse.in {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: .25em;
-}
-.label:empty {
-  display: none;
-}
-.btn .label, .btn-ghost .label {
-  position: relative;
-  top: -1px;
-}
+  border-radius: .25em; }
+  .label:empty {
+    display: none; }
+  .btn .label, .btn-ghost .label {
+    position: relative;
+    top: -1px; }
 
-a.label:hover, a.label:focus {
+a.label:hover,
+a.label:focus {
   color: #fff;
   text-decoration: none;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 .label-default {
-  background-color: #999999;
-}
-.label-default[href]:hover, .label-default[href]:focus {
-  background-color: gray;
-}
+  background-color: #999999; }
+  .label-default[href]:hover,
+  .label-default[href]:focus {
+    background-color: gray; }
 
 .label-primary {
-  background-color: #f1f1f1;
-}
-.label-primary[href]:hover, .label-primary[href]:focus {
-  background-color: #d7d7d7;
-}
+  background-color: #f1f1f1; }
+  .label-primary[href]:hover,
+  .label-primary[href]:focus {
+    background-color: #d7d7d7; }
 
 .label-success {
-  background-color: #9bb83a;
-}
-.label-success[href]:hover, .label-success[href]:focus {
-  background-color: #7a912e;
-}
+  background-color: #9bb83a; }
+  .label-success[href]:hover,
+  .label-success[href]:focus {
+    background-color: #7a912e; }
 
 .label-info {
-  background-color: #389Bc9;
-}
-.label-info[href]:hover, .label-info[href]:focus {
-  background-color: #2c7da2;
-}
+  background-color: #389Bc9; }
+  .label-info[href]:hover,
+  .label-info[href]:focus {
+    background-color: #2c7da2; }
 
 .label-warning {
-  background-color: #e5d321;
-}
-.label-warning[href]:hover, .label-warning[href]:focus {
-  background-color: #bdae16;
-}
+  background-color: #e5d321; }
+  .label-warning[href]:hover,
+  .label-warning[href]:focus {
+    background-color: #bdae16; }
 
 .label-danger {
-  background-color: #e53221;
-}
-.label-danger[href]:hover, .label-danger[href]:focus {
-  background-color: #bd2516;
-}
+  background-color: #e53221; }
+  .label-danger[href]:hover,
+  .label-danger[href]:focus {
+    background-color: #bd2516; }
 
 .badge {
   display: inline-block;
@@ -5554,82 +4537,68 @@ a.label:hover, a.label:focus {
   font-weight: bold;
   color: #fff;
   line-height: 1;
-  vertical-align: middle;
+  vertical-align: baseline;
   white-space: nowrap;
   text-align: center;
   background-color: #999999;
-  border-radius: 10px;
-}
-.badge:empty {
-  display: none;
-}
-.btn .badge, .btn-ghost .badge {
-  position: relative;
-  top: -1px;
-}
-.btn-xs .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn-ghost .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn-ghost .badge {
-  top: 0;
-  padding: 1px 5px;
-}
-.list-group-item.active > .badge, .nav-pills > .active > a > .badge {
-  color: #2e88be;
-  background-color: #fff;
-}
-.list-group-item > .badge {
-  float: right;
-}
-.list-group-item > .badge + .badge {
-  margin-right: 5px;
-}
-.nav-pills > li > a > .badge {
-  margin-left: 3px;
-}
+  border-radius: 10px; }
+  .badge:empty {
+    display: none; }
+  .btn .badge, .btn-ghost .badge {
+    position: relative;
+    top: -1px; }
+  .btn-xs .badge,
+  .btn-group-xs > .btn .badge,
+  .btn-group-xs > .btn-ghost .badge,
+  .btn-group-xs > .btn .badge, .btn-group-xs > .btn-ghost .badge {
+    top: 0;
+    padding: 1px 5px; }
+  .list-group-item.active > .badge,
+  .nav-pills > .active > a > .badge {
+    color: #2e88be;
+    background-color: #fff; }
+  .list-group-item > .badge {
+    float: right; }
+  .list-group-item > .badge + .badge {
+    margin-right: 5px; }
+  .nav-pills > li > a > .badge {
+    margin-left: 3px; }
 
-a.badge:hover, a.badge:focus {
+a.badge:hover,
+a.badge:focus {
   color: #fff;
   text-decoration: none;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 .jumbotron {
-  padding-top: 30px;
-  padding-bottom: 30px;
+  padding: 30px 15px;
   margin-bottom: 30px;
   color: inherit;
-  background-color: #eeeeee;
-}
-.jumbotron h1,
-.jumbotron .h1 {
-  color: inherit;
-}
-.jumbotron p {
-  margin-bottom: 15px;
-  font-size: 21px;
-  font-weight: 200;
-}
-.jumbotron > hr {
-  border-top-color: #d5d5d5;
-}
-.container .jumbotron, .container-fluid .jumbotron {
-  border-radius: 6px;
-}
-.jumbotron .container {
-  max-width: 100%;
-}
-@media screen and (min-width: 768px) {
-  .jumbotron {
-    padding-top: 48px;
-    padding-bottom: 48px;
-  }
-  .container .jumbotron, .container-fluid .jumbotron {
-    padding-left: 60px;
-    padding-right: 60px;
-  }
+  background-color: #eeeeee; }
   .jumbotron h1,
   .jumbotron .h1 {
-    font-size: 63px;
-  }
-}
+    color: inherit; }
+  .jumbotron p {
+    margin-bottom: 15px;
+    font-size: 21px;
+    font-weight: 200; }
+  .jumbotron > hr {
+    border-top-color: #d5d5d5; }
+  .container .jumbotron,
+  .container-fluid .jumbotron {
+    border-radius: 6px; }
+  .jumbotron .container {
+    max-width: 100%; }
+  @media screen and (min-width: 768px) {
+    .jumbotron {
+      padding: 48px 0; }
+      .container .jumbotron,
+      .container-fluid .jumbotron {
+        padding-left: 60px;
+        padding-right: 60px; }
+      .jumbotron h1,
+      .jumbotron .h1 {
+        font-size: 63px; } }
 
 .thumbnail {
   display: block;
@@ -5641,124 +4610,95 @@ a.badge:hover, a.badge:focus {
   border-radius: 4px;
   -webkit-transition: border 0.2s ease-in-out;
   -o-transition: border 0.2s ease-in-out;
-  transition: border 0.2s ease-in-out;
-}
-.thumbnail > img,
-.thumbnail a > img {
-  display: block;
-  max-width: 100%;
-  height: auto;
-  margin-left: auto;
-  margin-right: auto;
-}
-.thumbnail .caption {
-  padding: 9px;
-  color: #666;
-}
+  transition: border 0.2s ease-in-out; }
+  .thumbnail > img,
+  .thumbnail a > img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin-left: auto;
+    margin-right: auto; }
+  .thumbnail .caption {
+    padding: 9px;
+    color: #666; }
 
 a.thumbnail:hover,
 a.thumbnail:focus,
 a.thumbnail.active {
-  border-color: #2e88be;
-}
+  border-color: #2e88be; }
 
 .alert {
   padding: 15px;
   margin-bottom: 20px;
   border: 1px solid transparent;
-  border-radius: 4px;
-}
-.alert h4 {
-  margin-top: 0;
-  color: inherit;
-}
-.alert .alert-link {
-  font-weight: bold;
-}
-.alert > p,
-.alert > ul {
-  margin-bottom: 0;
-}
-.alert > p + p {
-  margin-top: 5px;
-}
+  border-radius: 4px; }
+  .alert h4 {
+    margin-top: 0;
+    color: inherit; }
+  .alert .alert-link {
+    font-weight: bold; }
+  .alert > p,
+  .alert > ul {
+    margin-bottom: 0; }
+  .alert > p + p {
+    margin-top: 5px; }
 
-.alert-dismissable,
-.alert-dismissible {
-  padding-right: 35px;
-}
-.alert-dismissable .close,
-.alert-dismissible .close {
-  position: relative;
-  top: -2px;
-  right: -21px;
-  color: inherit;
-}
+.alert-dismissable, .alert-dismissible {
+  padding-right: 35px; }
+  .alert-dismissable .close, .alert-dismissible .close {
+    position: relative;
+    top: -2px;
+    right: -21px;
+    color: inherit; }
 
 .alert-success {
-  background-color: #ebf0d7;
-  border-color: #cddb9c;
-  color: #4d5c1d;
-}
-.alert-success hr {
-  border-top-color: #c4d489;
-}
-.alert-success .alert-link {
-  color: #2d3511;
-}
+  background-color: #ebf1d8;
+  border-color: #cddc9d;
+  color: #4e5c1d; }
+  .alert-success hr {
+    border-top-color: #c3d58a; }
+  .alert-success .alert-link {
+    color: #2d3511; }
 
 .alert-info {
   background-color: #d7ebf4;
-  border-color: #9bcde4;
-  color: #1c4d64;
-}
-.alert-info hr {
-  border-top-color: #87c3df;
-}
-.alert-info .alert-link {
-  color: #112e3c;
-}
+  border-color: #9ccde4;
+  color: #1c4e65; }
+  .alert-info hr {
+    border-top-color: #88c3df; }
+  .alert-info .alert-link {
+    color: #112f3d; }
 
 .alert-warning {
-  background-color: #f9f6d2;
+  background-color: #faf6d3;
   border-color: #f2e990;
-  color: #726910;
-}
-.alert-warning hr {
-  border-top-color: #efe479;
-}
-.alert-warning .alert-link {
-  color: #45400a;
-}
+  color: #736a11; }
+  .alert-warning hr {
+    border-top-color: #efe479; }
+  .alert-warning .alert-link {
+    color: #47410a; }
 
 .alert-danger {
-  background-color: #f9d6d2;
-  border-color: #f29890;
-  color: #721910;
-}
-.alert-danger hr {
-  border-top-color: #ef8379;
-}
-.alert-danger .alert-link {
-  color: #450f0a;
-}
+  background-color: #fad6d3;
+  border-color: #f29990;
+  color: #731911; }
+  .alert-danger hr {
+    border-top-color: #ef8479; }
+  .alert-danger .alert-link {
+    color: #470f0a; }
 
 @-webkit-keyframes progress-bar-stripes {
   from {
-    background-position: 40px 0;
-  }
+    background-position: 40px 0; }
   to {
-    background-position: 0 0;
-  }
-}
+    background-position: 0 0; } }
+
 @keyframes progress-bar-stripes {
   from {
-    background-position: 40px 0;
-  }
+    background-position: 40px 0; }
   to {
-    background-position: 0 0;
-  }
-}
+    background-position: 0 0; } }
+
 .progress {
   overflow: hidden;
   height: 20px;
@@ -5766,8 +4706,7 @@ a.thumbnail.active {
   background-color: #f5f5f5;
   border-radius: 4px;
   -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-}
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); }
 
 .progress-bar {
   float: left;
@@ -5782,123 +4721,96 @@ a.thumbnail.active {
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   -webkit-transition: width 0.6s ease;
   -o-transition: width 0.6s ease;
-  transition: width 0.6s ease;
-}
+  transition: width 0.6s ease; }
 
 .progress-striped .progress-bar,
 .progress-bar-striped {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-size: 40px 40px;
-}
+  background-size: 40px 40px; }
 
 .progress.active .progress-bar,
 .progress-bar.active {
   -webkit-animation: progress-bar-stripes 2s linear infinite;
   -o-animation: progress-bar-stripes 2s linear infinite;
-  animation: progress-bar-stripes 2s linear infinite;
-}
+  animation: progress-bar-stripes 2s linear infinite; }
 
 .progress-bar-success {
-  background-color: #9bb83a;
-}
-.progress-striped .progress-bar-success {
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-}
+  background-color: #9bb83a; }
+  .progress-striped .progress-bar-success {
+    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
 .progress-bar-info {
-  background-color: #389Bc9;
-}
-.progress-striped .progress-bar-info {
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-}
+  background-color: #389Bc9; }
+  .progress-striped .progress-bar-info {
+    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
 .progress-bar-warning {
-  background-color: #e5d321;
-}
-.progress-striped .progress-bar-warning {
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-}
+  background-color: #e5d321; }
+  .progress-striped .progress-bar-warning {
+    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
 .progress-bar-danger {
-  background-color: #e53221;
-}
-.progress-striped .progress-bar-danger {
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-}
+  background-color: #e53221; }
+  .progress-striped .progress-bar-danger {
+    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
 .media {
-  margin-top: 15px;
-}
-.media:first-child {
-  margin-top: 0;
-}
+  margin-top: 15px; }
+  .media:first-child {
+    margin-top: 0; }
 
 .media,
 .media-body {
   zoom: 1;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 .media-body {
-  width: 10000px;
-}
+  width: 10000px; }
 
 .media-object {
-  display: block;
-}
-.media-object.img-thumbnail {
-  max-width: none;
-}
+  display: block; }
 
 .media-right,
 .media > .pull-right {
-  padding-left: 10px;
-}
+  padding-left: 10px; }
 
 .media-left,
 .media > .pull-left {
-  padding-right: 10px;
-}
+  padding-right: 10px; }
 
 .media-left,
 .media-right,
 .media-body {
   display: table-cell;
-  vertical-align: top;
-}
+  vertical-align: top; }
 
 .media-middle {
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
 .media-bottom {
-  vertical-align: bottom;
-}
+  vertical-align: bottom; }
 
 .media-heading {
   margin-top: 0;
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
 .media-list {
   padding-left: 0;
-  list-style: none;
-}
+  list-style: none; }
 
 .list-group {
   margin-bottom: 20px;
-  padding-left: 0;
-}
+  padding-left: 0; }
 
 .list-group-item {
   position: relative;
@@ -5906,190 +4818,145 @@ a.thumbnail.active {
   padding: 10px 15px;
   margin-bottom: -1px;
   background-color: #fff;
-  border: 1px solid #ddd;
-}
-.list-group-item:first-child {
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
-}
-.list-group-item:last-child {
-  margin-bottom: 0;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
-}
+  border: 1px solid #ddd; }
+  .list-group-item:first-child {
+    border-top-right-radius: 4px;
+    border-top-left-radius: 4px; }
+  .list-group-item:last-child {
+    margin-bottom: 0;
+    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: 4px; }
 
-a.list-group-item,
-button.list-group-item {
-  color: #555;
-}
-a.list-group-item .list-group-item-heading,
-button.list-group-item .list-group-item-heading {
-  color: #333;
-}
-a.list-group-item:hover, a.list-group-item:focus,
-button.list-group-item:hover,
-button.list-group-item:focus {
-  text-decoration: none;
-  color: #555;
-  background-color: #f5f5f5;
-}
+a.list-group-item {
+  color: #555; }
+  a.list-group-item .list-group-item-heading {
+    color: #333; }
+  a.list-group-item:hover,
+  a.list-group-item:focus {
+    text-decoration: none;
+    color: #555;
+    background-color: #f5f5f5; }
 
-button.list-group-item {
-  width: 100%;
-  text-align: left;
-}
-
-.list-group-item.disabled, .list-group-item.disabled:hover, .list-group-item.disabled:focus {
+.list-group-item.disabled,
+.list-group-item.disabled:hover,
+.list-group-item.disabled:focus {
   background-color: #eeeeee;
   color: #999999;
-  cursor: not-allowed;
-}
-.list-group-item.disabled .list-group-item-heading, .list-group-item.disabled:hover .list-group-item-heading, .list-group-item.disabled:focus .list-group-item-heading {
-  color: inherit;
-}
-.list-group-item.disabled .list-group-item-text, .list-group-item.disabled:hover .list-group-item-text, .list-group-item.disabled:focus .list-group-item-text {
-  color: #999999;
-}
-.list-group-item.active, .list-group-item.active:hover, .list-group-item.active:focus {
+  cursor: not-allowed; }
+  .list-group-item.disabled .list-group-item-heading,
+  .list-group-item.disabled:hover .list-group-item-heading,
+  .list-group-item.disabled:focus .list-group-item-heading {
+    color: inherit; }
+  .list-group-item.disabled .list-group-item-text,
+  .list-group-item.disabled:hover .list-group-item-text,
+  .list-group-item.disabled:focus .list-group-item-text {
+    color: #999999; }
+
+.list-group-item.active,
+.list-group-item.active:hover,
+.list-group-item.active:focus {
   z-index: 2;
   color: #666;
   background-color: #f1f1f1;
-  border-color: #f1f1f1;
-}
-.list-group-item.active .list-group-item-heading,
-.list-group-item.active .list-group-item-heading > small,
-.list-group-item.active .list-group-item-heading > .small, .list-group-item.active:hover .list-group-item-heading,
-.list-group-item.active:hover .list-group-item-heading > small,
-.list-group-item.active:hover .list-group-item-heading > .small, .list-group-item.active:focus .list-group-item-heading,
-.list-group-item.active:focus .list-group-item-heading > small,
-.list-group-item.active:focus .list-group-item-heading > .small {
-  color: inherit;
-}
-.list-group-item.active .list-group-item-text, .list-group-item.active:hover .list-group-item-text, .list-group-item.active:focus .list-group-item-text {
-  color: white;
-}
+  border-color: #f1f1f1; }
+  .list-group-item.active .list-group-item-heading,
+  .list-group-item.active .list-group-item-heading > small,
+  .list-group-item.active .list-group-item-heading > .small,
+  .list-group-item.active:hover .list-group-item-heading,
+  .list-group-item.active:hover .list-group-item-heading > small,
+  .list-group-item.active:hover .list-group-item-heading > .small,
+  .list-group-item.active:focus .list-group-item-heading,
+  .list-group-item.active:focus .list-group-item-heading > small,
+  .list-group-item.active:focus .list-group-item-heading > .small {
+    color: inherit; }
+  .list-group-item.active .list-group-item-text,
+  .list-group-item.active:hover .list-group-item-text,
+  .list-group-item.active:focus .list-group-item-text {
+    color: white; }
 
 .list-group-item-success {
   color: #9bb83a;
-  background-color: #f5f8eb;
-}
+  background-color: #f5f8eb; }
 
-a.list-group-item-success,
-button.list-group-item-success {
-  color: #9bb83a;
-}
-a.list-group-item-success .list-group-item-heading,
-button.list-group-item-success .list-group-item-heading {
-  color: inherit;
-}
-a.list-group-item-success:hover, a.list-group-item-success:focus,
-button.list-group-item-success:hover,
-button.list-group-item-success:focus {
-  color: #9bb83a;
-  background-color: #ecf1d8;
-}
-a.list-group-item-success.active, a.list-group-item-success.active:hover, a.list-group-item-success.active:focus,
-button.list-group-item-success.active,
-button.list-group-item-success.active:hover,
-button.list-group-item-success.active:focus {
-  color: #fff;
-  background-color: #9bb83a;
-  border-color: #9bb83a;
-}
+a.list-group-item-success {
+  color: #9bb83a; }
+  a.list-group-item-success .list-group-item-heading {
+    color: inherit; }
+  a.list-group-item-success:hover,
+  a.list-group-item-success:focus {
+    color: #9bb83a;
+    background-color: #ecf1d8; }
+  a.list-group-item-success.active,
+  a.list-group-item-success.active:hover,
+  a.list-group-item-success.active:focus {
+    color: #fff;
+    background-color: #9bb83a;
+    border-color: #9bb83a; }
 
 .list-group-item-info {
   color: #389Bc9;
-  background-color: #ebf5f9;
-}
+  background-color: #ebf5f9; }
 
-a.list-group-item-info,
-button.list-group-item-info {
-  color: #389Bc9;
-}
-a.list-group-item-info .list-group-item-heading,
-button.list-group-item-info .list-group-item-heading {
-  color: inherit;
-}
-a.list-group-item-info:hover, a.list-group-item-info:focus,
-button.list-group-item-info:hover,
-button.list-group-item-info:focus {
-  color: #389Bc9;
-  background-color: #d7ebf3;
-}
-a.list-group-item-info.active, a.list-group-item-info.active:hover, a.list-group-item-info.active:focus,
-button.list-group-item-info.active,
-button.list-group-item-info.active:hover,
-button.list-group-item-info.active:focus {
-  color: #fff;
-  background-color: #389Bc9;
-  border-color: #389Bc9;
-}
+a.list-group-item-info {
+  color: #389Bc9; }
+  a.list-group-item-info .list-group-item-heading {
+    color: inherit; }
+  a.list-group-item-info:hover,
+  a.list-group-item-info:focus {
+    color: #389Bc9;
+    background-color: #d7ebf3; }
+  a.list-group-item-info.active,
+  a.list-group-item-info.active:hover,
+  a.list-group-item-info.active:focus {
+    color: #fff;
+    background-color: #389Bc9;
+    border-color: #389Bc9; }
 
 .list-group-item-warning {
   color: #e5d321;
-  background-color: #fdfde9;
-}
+  background-color: #fdfde9; }
 
-a.list-group-item-warning,
-button.list-group-item-warning {
-  color: #e5d321;
-}
-a.list-group-item-warning .list-group-item-heading,
-button.list-group-item-warning .list-group-item-heading {
-  color: inherit;
-}
-a.list-group-item-warning:hover, a.list-group-item-warning:focus,
-button.list-group-item-warning:hover,
-button.list-group-item-warning:focus {
-  color: #e5d321;
-  background-color: #fbfbd2;
-}
-a.list-group-item-warning.active, a.list-group-item-warning.active:hover, a.list-group-item-warning.active:focus,
-button.list-group-item-warning.active,
-button.list-group-item-warning.active:hover,
-button.list-group-item-warning.active:focus {
-  color: #fff;
-  background-color: #e5d321;
-  border-color: #e5d321;
-}
+a.list-group-item-warning {
+  color: #e5d321; }
+  a.list-group-item-warning .list-group-item-heading {
+    color: inherit; }
+  a.list-group-item-warning:hover,
+  a.list-group-item-warning:focus {
+    color: #e5d321;
+    background-color: #fbfbd2; }
+  a.list-group-item-warning.active,
+  a.list-group-item-warning.active:hover,
+  a.list-group-item-warning.active:focus {
+    color: #fff;
+    background-color: #e5d321;
+    border-color: #e5d321; }
 
 .list-group-item-danger {
   color: #e53221;
-  background-color: #fceae8;
-}
+  background-color: #fceae8; }
 
-a.list-group-item-danger,
-button.list-group-item-danger {
-  color: #e53221;
-}
-a.list-group-item-danger .list-group-item-heading,
-button.list-group-item-danger .list-group-item-heading {
-  color: inherit;
-}
-a.list-group-item-danger:hover, a.list-group-item-danger:focus,
-button.list-group-item-danger:hover,
-button.list-group-item-danger:focus {
-  color: #e53221;
-  background-color: #f9d5d1;
-}
-a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-group-item-danger.active:focus,
-button.list-group-item-danger.active,
-button.list-group-item-danger.active:hover,
-button.list-group-item-danger.active:focus {
-  color: #fff;
-  background-color: #e53221;
-  border-color: #e53221;
-}
+a.list-group-item-danger {
+  color: #e53221; }
+  a.list-group-item-danger .list-group-item-heading {
+    color: inherit; }
+  a.list-group-item-danger:hover,
+  a.list-group-item-danger:focus {
+    color: #e53221;
+    background-color: #f9d5d1; }
+  a.list-group-item-danger.active,
+  a.list-group-item-danger.active:hover,
+  a.list-group-item-danger.active:focus {
+    color: #fff;
+    background-color: #e53221;
+    border-color: #e53221; }
 
 .list-group-item-heading {
   margin-top: 0;
-  margin-bottom: 5px;
-}
+  margin-bottom: 5px; }
 
 .list-group-item-text {
   margin-bottom: 0;
-  line-height: 1.3;
-}
+  line-height: 1.3; }
 
 .panel {
   margin-bottom: 20px;
@@ -6097,394 +4964,323 @@ button.list-group-item-danger.active:focus {
   border: 1px solid transparent;
   border-radius: 4px;
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-}
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05); }
 
 .panel-body {
-  padding: 15px;
-}
-.panel-body:before, .panel-body:after {
-  content: " ";
-  display: table;
-}
-.panel-body:after {
-  clear: both;
-}
+  padding: 15px; }
+  .panel-body:before,
+  .panel-body:after {
+    content: " ";
+    display: table; }
+  .panel-body:after {
+    clear: both; }
 
 .panel-heading {
   padding: 10px 15px;
   border-bottom: 1px solid transparent;
   border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
-}
-.panel-heading > .dropdown .dropdown-toggle {
-  color: inherit;
-}
+  border-top-left-radius: 3px; }
+  .panel-heading > .dropdown .dropdown-toggle {
+    color: inherit; }
 
 .panel-title {
   margin-top: 0;
   margin-bottom: 0;
   font-size: 16px;
-  color: inherit;
-}
-.panel-title > a,
-.panel-title > small,
-.panel-title > .small,
-.panel-title > small > a,
-.panel-title > .small > a {
-  color: inherit;
-}
+  color: inherit; }
+  .panel-title > a,
+  .panel-title > small,
+  .panel-title > .small,
+  .panel-title > small > a,
+  .panel-title > .small > a {
+    color: inherit; }
 
 .panel-footer {
   padding: 10px 15px;
   background-color: #f5f5f5;
   border-top: 1px solid #ddd;
   border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
-}
+  border-bottom-left-radius: 3px; }
 
 .panel > .list-group,
 .panel > .panel-collapse > .list-group {
-  margin-bottom: 0;
-}
-.panel > .list-group .list-group-item,
-.panel > .panel-collapse > .list-group .list-group-item {
-  border-width: 1px 0;
-  border-radius: 0;
-}
-.panel > .list-group:first-child .list-group-item:first-child,
-.panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
-  border-top: 0;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
-}
-.panel > .list-group:last-child .list-group-item:last-child,
-.panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
-  border-bottom: 0;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
-}
-.panel > .panel-heading + .panel-collapse > .list-group .list-group-item:first-child {
-  border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
+  margin-bottom: 0; }
+  .panel > .list-group .list-group-item,
+  .panel > .panel-collapse > .list-group .list-group-item {
+    border-width: 1px 0;
+    border-radius: 0; }
+  .panel > .list-group:first-child .list-group-item:first-child,
+  .panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
+    border-top: 0;
+    border-top-right-radius: 3px;
+    border-top-left-radius: 3px; }
+  .panel > .list-group:last-child .list-group-item:last-child,
+  .panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
+    border-bottom: 0;
+    border-bottom-right-radius: 3px;
+    border-bottom-left-radius: 3px; }
 
 .panel-heading + .list-group .list-group-item:first-child {
-  border-top-width: 0;
-}
+  border-top-width: 0; }
 
 .list-group + .panel-footer {
-  border-top-width: 0;
-}
+  border-top-width: 0; }
 
 .panel > .table,
 .panel > .table-responsive > .table,
 .panel > .panel-collapse > .table {
-  margin-bottom: 0;
-}
-.panel > .table caption,
-.panel > .table-responsive > .table caption,
-.panel > .panel-collapse > .table caption {
-  padding-left: 15px;
-  padding-right: 15px;
-}
+  margin-bottom: 0; }
+  .panel > .table caption,
+  .panel > .table-responsive > .table caption,
+  .panel > .panel-collapse > .table caption {
+    padding-left: 15px;
+    padding-right: 15px; }
+
 .panel > .table:first-child,
 .panel > .table-responsive:first-child > .table:first-child {
   border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
-}
-.panel > .table:first-child > thead:first-child > tr:first-child,
-.panel > .table:first-child > tbody:first-child > tr:first-child,
-.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child,
-.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child {
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
-}
-.panel > .table:first-child > thead:first-child > tr:first-child td:first-child,
-.panel > .table:first-child > thead:first-child > tr:first-child th:first-child,
-.panel > .table:first-child > tbody:first-child > tr:first-child td:first-child,
-.panel > .table:first-child > tbody:first-child > tr:first-child th:first-child,
-.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:first-child,
-.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:first-child,
-.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:first-child,
-.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child {
-  border-top-left-radius: 3px;
-}
-.panel > .table:first-child > thead:first-child > tr:first-child td:last-child,
-.panel > .table:first-child > thead:first-child > tr:first-child th:last-child,
-.panel > .table:first-child > tbody:first-child > tr:first-child td:last-child,
-.panel > .table:first-child > tbody:first-child > tr:first-child th:last-child,
-.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:last-child,
-.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:last-child,
-.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:last-child,
-.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child {
-  border-top-right-radius: 3px;
-}
+  border-top-left-radius: 3px; }
+  .panel > .table:first-child > thead:first-child > tr:first-child,
+  .panel > .table:first-child > tbody:first-child > tr:first-child,
+  .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child,
+  .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child {
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px; }
+    .panel > .table:first-child > thead:first-child > tr:first-child td:first-child,
+    .panel > .table:first-child > thead:first-child > tr:first-child th:first-child,
+    .panel > .table:first-child > tbody:first-child > tr:first-child td:first-child,
+    .panel > .table:first-child > tbody:first-child > tr:first-child th:first-child,
+    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:first-child,
+    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:first-child,
+    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:first-child,
+    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child {
+      border-top-left-radius: 3px; }
+    .panel > .table:first-child > thead:first-child > tr:first-child td:last-child,
+    .panel > .table:first-child > thead:first-child > tr:first-child th:last-child,
+    .panel > .table:first-child > tbody:first-child > tr:first-child td:last-child,
+    .panel > .table:first-child > tbody:first-child > tr:first-child th:last-child,
+    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:last-child,
+    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:last-child,
+    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:last-child,
+    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child {
+      border-top-right-radius: 3px; }
+
 .panel > .table:last-child,
 .panel > .table-responsive:last-child > .table:last-child {
   border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
-}
-.panel > .table:last-child > tbody:last-child > tr:last-child,
-.panel > .table:last-child > tfoot:last-child > tr:last-child,
-.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child,
-.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child {
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
-}
-.panel > .table:last-child > tbody:last-child > tr:last-child td:first-child,
-.panel > .table:last-child > tbody:last-child > tr:last-child th:first-child,
-.panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
-.panel > .table:last-child > tfoot:last-child > tr:last-child th:first-child,
-.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:first-child,
-.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:first-child,
-.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
-.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child {
-  border-bottom-left-radius: 3px;
-}
-.panel > .table:last-child > tbody:last-child > tr:last-child td:last-child,
-.panel > .table:last-child > tbody:last-child > tr:last-child th:last-child,
-.panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
-.panel > .table:last-child > tfoot:last-child > tr:last-child th:last-child,
-.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:last-child,
-.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:last-child,
-.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
-.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child {
-  border-bottom-right-radius: 3px;
-}
+  border-bottom-left-radius: 3px; }
+  .panel > .table:last-child > tbody:last-child > tr:last-child,
+  .panel > .table:last-child > tfoot:last-child > tr:last-child,
+  .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child,
+  .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px; }
+    .panel > .table:last-child > tbody:last-child > tr:last-child td:first-child,
+    .panel > .table:last-child > tbody:last-child > tr:last-child th:first-child,
+    .panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
+    .panel > .table:last-child > tfoot:last-child > tr:last-child th:first-child,
+    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:first-child,
+    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:first-child,
+    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
+    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child {
+      border-bottom-left-radius: 3px; }
+    .panel > .table:last-child > tbody:last-child > tr:last-child td:last-child,
+    .panel > .table:last-child > tbody:last-child > tr:last-child th:last-child,
+    .panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
+    .panel > .table:last-child > tfoot:last-child > tr:last-child th:last-child,
+    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:last-child,
+    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:last-child,
+    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
+    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child {
+      border-bottom-right-radius: 3px; }
+
 .panel > .panel-body + .table,
 .panel > .panel-body + .table-responsive,
 .panel > .table + .panel-body,
 .panel > .table-responsive + .panel-body {
-  border-top: 1px solid #ddd;
-}
+  border-top: 1px solid #ddd; }
+
 .panel > .table > tbody:first-child > tr:first-child th,
 .panel > .table > tbody:first-child > tr:first-child td {
-  border-top: 0;
-}
+  border-top: 0; }
+
 .panel > .table-bordered,
 .panel > .table-responsive > .table-bordered {
-  border: 0;
-}
-.panel > .table-bordered > thead > tr > th:first-child,
-.panel > .table-bordered > thead > tr > td:first-child,
-.panel > .table-bordered > tbody > tr > th:first-child,
-.panel > .table-bordered > tbody > tr > td:first-child,
-.panel > .table-bordered > tfoot > tr > th:first-child,
-.panel > .table-bordered > tfoot > tr > td:first-child,
-.panel > .table-responsive > .table-bordered > thead > tr > th:first-child,
-.panel > .table-responsive > .table-bordered > thead > tr > td:first-child,
-.panel > .table-responsive > .table-bordered > tbody > tr > th:first-child,
-.panel > .table-responsive > .table-bordered > tbody > tr > td:first-child,
-.panel > .table-responsive > .table-bordered > tfoot > tr > th:first-child,
-.panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child {
-  border-left: 0;
-}
-.panel > .table-bordered > thead > tr > th:last-child,
-.panel > .table-bordered > thead > tr > td:last-child,
-.panel > .table-bordered > tbody > tr > th:last-child,
-.panel > .table-bordered > tbody > tr > td:last-child,
-.panel > .table-bordered > tfoot > tr > th:last-child,
-.panel > .table-bordered > tfoot > tr > td:last-child,
-.panel > .table-responsive > .table-bordered > thead > tr > th:last-child,
-.panel > .table-responsive > .table-bordered > thead > tr > td:last-child,
-.panel > .table-responsive > .table-bordered > tbody > tr > th:last-child,
-.panel > .table-responsive > .table-bordered > tbody > tr > td:last-child,
-.panel > .table-responsive > .table-bordered > tfoot > tr > th:last-child,
-.panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child {
-  border-right: 0;
-}
-.panel > .table-bordered > thead > tr:first-child > td,
-.panel > .table-bordered > thead > tr:first-child > th,
-.panel > .table-bordered > tbody > tr:first-child > td,
-.panel > .table-bordered > tbody > tr:first-child > th,
-.panel > .table-responsive > .table-bordered > thead > tr:first-child > td,
-.panel > .table-responsive > .table-bordered > thead > tr:first-child > th,
-.panel > .table-responsive > .table-bordered > tbody > tr:first-child > td,
-.panel > .table-responsive > .table-bordered > tbody > tr:first-child > th {
-  border-bottom: 0;
-}
-.panel > .table-bordered > tbody > tr:last-child > td,
-.panel > .table-bordered > tbody > tr:last-child > th,
-.panel > .table-bordered > tfoot > tr:last-child > td,
-.panel > .table-bordered > tfoot > tr:last-child > th,
-.panel > .table-responsive > .table-bordered > tbody > tr:last-child > td,
-.panel > .table-responsive > .table-bordered > tbody > tr:last-child > th,
-.panel > .table-responsive > .table-bordered > tfoot > tr:last-child > td,
-.panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th {
-  border-bottom: 0;
-}
+  border: 0; }
+  .panel > .table-bordered > thead > tr > th:first-child,
+  .panel > .table-bordered > thead > tr > td:first-child,
+  .panel > .table-bordered > tbody > tr > th:first-child,
+  .panel > .table-bordered > tbody > tr > td:first-child,
+  .panel > .table-bordered > tfoot > tr > th:first-child,
+  .panel > .table-bordered > tfoot > tr > td:first-child,
+  .panel > .table-responsive > .table-bordered > thead > tr > th:first-child,
+  .panel > .table-responsive > .table-bordered > thead > tr > td:first-child,
+  .panel > .table-responsive > .table-bordered > tbody > tr > th:first-child,
+  .panel > .table-responsive > .table-bordered > tbody > tr > td:first-child,
+  .panel > .table-responsive > .table-bordered > tfoot > tr > th:first-child,
+  .panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+    border-left: 0; }
+  .panel > .table-bordered > thead > tr > th:last-child,
+  .panel > .table-bordered > thead > tr > td:last-child,
+  .panel > .table-bordered > tbody > tr > th:last-child,
+  .panel > .table-bordered > tbody > tr > td:last-child,
+  .panel > .table-bordered > tfoot > tr > th:last-child,
+  .panel > .table-bordered > tfoot > tr > td:last-child,
+  .panel > .table-responsive > .table-bordered > thead > tr > th:last-child,
+  .panel > .table-responsive > .table-bordered > thead > tr > td:last-child,
+  .panel > .table-responsive > .table-bordered > tbody > tr > th:last-child,
+  .panel > .table-responsive > .table-bordered > tbody > tr > td:last-child,
+  .panel > .table-responsive > .table-bordered > tfoot > tr > th:last-child,
+  .panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+    border-right: 0; }
+  .panel > .table-bordered > thead > tr:first-child > td,
+  .panel > .table-bordered > thead > tr:first-child > th,
+  .panel > .table-bordered > tbody > tr:first-child > td,
+  .panel > .table-bordered > tbody > tr:first-child > th,
+  .panel > .table-responsive > .table-bordered > thead > tr:first-child > td,
+  .panel > .table-responsive > .table-bordered > thead > tr:first-child > th,
+  .panel > .table-responsive > .table-bordered > tbody > tr:first-child > td,
+  .panel > .table-responsive > .table-bordered > tbody > tr:first-child > th {
+    border-bottom: 0; }
+  .panel > .table-bordered > tbody > tr:last-child > td,
+  .panel > .table-bordered > tbody > tr:last-child > th,
+  .panel > .table-bordered > tfoot > tr:last-child > td,
+  .panel > .table-bordered > tfoot > tr:last-child > th,
+  .panel > .table-responsive > .table-bordered > tbody > tr:last-child > td,
+  .panel > .table-responsive > .table-bordered > tbody > tr:last-child > th,
+  .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > td,
+  .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th {
+    border-bottom: 0; }
+
 .panel > .table-responsive {
   border: 0;
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 
 .panel-group {
-  margin-bottom: 20px;
-}
-.panel-group .panel {
-  margin-bottom: 0;
-  border-radius: 4px;
-}
-.panel-group .panel + .panel {
-  margin-top: 5px;
-}
-.panel-group .panel-heading {
-  border-bottom: 0;
-}
-.panel-group .panel-heading + .panel-collapse > .panel-body,
-.panel-group .panel-heading + .panel-collapse > .list-group {
-  border-top: 1px solid #ddd;
-}
-.panel-group .panel-footer {
-  border-top: 0;
-}
-.panel-group .panel-footer + .panel-collapse .panel-body {
-  border-bottom: 1px solid #ddd;
-}
+  margin-bottom: 20px; }
+  .panel-group .panel {
+    margin-bottom: 0;
+    border-radius: 4px; }
+    .panel-group .panel + .panel {
+      margin-top: 5px; }
+  .panel-group .panel-heading {
+    border-bottom: 0; }
+    .panel-group .panel-heading + .panel-collapse > .panel-body,
+    .panel-group .panel-heading + .panel-collapse > .list-group {
+      border-top: 1px solid #ddd; }
+  .panel-group .panel-footer {
+    border-top: 0; }
+    .panel-group .panel-footer + .panel-collapse .panel-body {
+      border-bottom: 1px solid #ddd; }
 
 .panel-default {
-  border-color: #ddd;
-}
-.panel-default > .panel-heading {
-  color: #333333;
-  background-color: #f5f5f5;
-  border-color: #ddd;
-}
-.panel-default > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #ddd;
-}
-.panel-default > .panel-heading .badge {
-  color: #f5f5f5;
-  background-color: #333333;
-}
-.panel-default > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #ddd;
-}
+  border-color: #ddd; }
+  .panel-default > .panel-heading {
+    color: #333333;
+    background-color: #f5f5f5;
+    border-color: #ddd; }
+    .panel-default > .panel-heading + .panel-collapse > .panel-body {
+      border-top-color: #ddd; }
+    .panel-default > .panel-heading .badge {
+      color: #f5f5f5;
+      background-color: #333333; }
+  .panel-default > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #ddd; }
 
 .panel-primary {
-  border-color: #f1f1f1;
-}
-.panel-primary > .panel-heading {
-  color: #fff;
-  background-color: #f1f1f1;
-  border-color: #f1f1f1;
-}
-.panel-primary > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #f1f1f1;
-}
-.panel-primary > .panel-heading .badge {
-  color: #f1f1f1;
-  background-color: #fff;
-}
-.panel-primary > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #f1f1f1;
-}
+  border-color: #f1f1f1; }
+  .panel-primary > .panel-heading {
+    color: #fff;
+    background-color: #f1f1f1;
+    border-color: #f1f1f1; }
+    .panel-primary > .panel-heading + .panel-collapse > .panel-body {
+      border-top-color: #f1f1f1; }
+    .panel-primary > .panel-heading .badge {
+      color: #f1f1f1;
+      background-color: #fff; }
+  .panel-primary > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #f1f1f1; }
 
 .panel-success {
-  border-color: #f5f8eb;
-}
-.panel-success > .panel-heading {
-  color: #9bb83a;
-  background-color: #f5f8eb;
-  border-color: #f5f8eb;
-}
-.panel-success > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #f5f8eb;
-}
-.panel-success > .panel-heading .badge {
-  color: #f5f8eb;
-  background-color: #9bb83a;
-}
-.panel-success > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #f5f8eb;
-}
+  border-color: #f5f8eb; }
+  .panel-success > .panel-heading {
+    color: #9bb83a;
+    background-color: #f5f8eb;
+    border-color: #f5f8eb; }
+    .panel-success > .panel-heading + .panel-collapse > .panel-body {
+      border-top-color: #f5f8eb; }
+    .panel-success > .panel-heading .badge {
+      color: #f5f8eb;
+      background-color: #9bb83a; }
+  .panel-success > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #f5f8eb; }
 
 .panel-info {
-  border-color: #ebf5f9;
-}
-.panel-info > .panel-heading {
-  color: #389Bc9;
-  background-color: #ebf5f9;
-  border-color: #ebf5f9;
-}
-.panel-info > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #ebf5f9;
-}
-.panel-info > .panel-heading .badge {
-  color: #ebf5f9;
-  background-color: #389Bc9;
-}
-.panel-info > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #ebf5f9;
-}
+  border-color: #ebf5f9; }
+  .panel-info > .panel-heading {
+    color: #389Bc9;
+    background-color: #ebf5f9;
+    border-color: #ebf5f9; }
+    .panel-info > .panel-heading + .panel-collapse > .panel-body {
+      border-top-color: #ebf5f9; }
+    .panel-info > .panel-heading .badge {
+      color: #ebf5f9;
+      background-color: #389Bc9; }
+  .panel-info > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #ebf5f9; }
 
 .panel-warning {
-  border-color: #fdfde9;
-}
-.panel-warning > .panel-heading {
-  color: #e5d321;
-  background-color: #fdfde9;
-  border-color: #fdfde9;
-}
-.panel-warning > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #fdfde9;
-}
-.panel-warning > .panel-heading .badge {
-  color: #fdfde9;
-  background-color: #e5d321;
-}
-.panel-warning > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #fdfde9;
-}
+  border-color: #fdfde9; }
+  .panel-warning > .panel-heading {
+    color: #e5d321;
+    background-color: #fdfde9;
+    border-color: #fdfde9; }
+    .panel-warning > .panel-heading + .panel-collapse > .panel-body {
+      border-top-color: #fdfde9; }
+    .panel-warning > .panel-heading .badge {
+      color: #fdfde9;
+      background-color: #e5d321; }
+  .panel-warning > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #fdfde9; }
 
 .panel-danger {
-  border-color: #fceae8;
-}
-.panel-danger > .panel-heading {
-  color: #e53221;
-  background-color: #fceae8;
-  border-color: #fceae8;
-}
-.panel-danger > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #fceae8;
-}
-.panel-danger > .panel-heading .badge {
-  color: #fceae8;
-  background-color: #e53221;
-}
-.panel-danger > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #fceae8;
-}
+  border-color: #fceae8; }
+  .panel-danger > .panel-heading {
+    color: #e53221;
+    background-color: #fceae8;
+    border-color: #fceae8; }
+    .panel-danger > .panel-heading + .panel-collapse > .panel-body {
+      border-top-color: #fceae8; }
+    .panel-danger > .panel-heading .badge {
+      color: #fceae8;
+      background-color: #e53221; }
+  .panel-danger > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #fceae8; }
 
 .embed-responsive {
   position: relative;
   display: block;
   height: 0;
   padding: 0;
-  overflow: hidden;
-}
-.embed-responsive .embed-responsive-item,
-.embed-responsive iframe,
-.embed-responsive embed,
-.embed-responsive object,
-.embed-responsive video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  height: 100%;
-  width: 100%;
-  border: 0;
-}
+  overflow: hidden; }
+  .embed-responsive .embed-responsive-item,
+  .embed-responsive iframe,
+  .embed-responsive embed,
+  .embed-responsive object,
+  .embed-responsive video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+    border: 0; }
 
 .embed-responsive-16by9 {
-  padding-bottom: 56.25%;
-}
+  padding-bottom: 56.25%; }
 
 .embed-responsive-4by3 {
-  padding-bottom: 75%;
-}
+  padding-bottom: 75%; }
 
 .well {
   min-height: 20px;
@@ -6494,22 +5290,18 @@ button.list-group-item-danger.active:focus {
   border: 1px solid #e3e3e3;
   border-radius: 4px;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-}
-.well blockquote {
-  border-color: #ddd;
-  border-color: rgba(0, 0, 0, 0.15);
-}
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); }
+  .well blockquote {
+    border-color: #ddd;
+    border-color: rgba(0, 0, 0, 0.15); }
 
 .well-lg {
   padding: 24px;
-  border-radius: 6px;
-}
+  border-radius: 6px; }
 
 .well-sm {
   padding: 9px;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
 .close {
   float: right;
@@ -6519,27 +5311,24 @@ button.list-group-item-danger.active:focus {
   color: #000;
   text-shadow: 0 1px 0 #fff;
   opacity: 0.2;
-  filter: alpha(opacity=20);
-}
-.close:hover, .close:focus {
-  color: #000;
-  text-decoration: none;
-  cursor: pointer;
-  opacity: 0.5;
-  filter: alpha(opacity=50);
-}
+  filter: alpha(opacity=20); }
+  .close:hover,
+  .close:focus {
+    color: #000;
+    text-decoration: none;
+    cursor: pointer;
+    opacity: 0.5;
+    filter: alpha(opacity=50); }
 
 button.close {
   padding: 0;
   cursor: pointer;
   background: transparent;
   border: 0;
-  -webkit-appearance: none;
-}
+  -webkit-appearance: none; }
 
 .modal-open {
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 .modal {
   display: none;
@@ -6551,35 +5340,30 @@ button.close {
   left: 0;
   z-index: 1050;
   -webkit-overflow-scrolling: touch;
-  outline: 0;
-}
-.modal.fade .modal-dialog {
-  -webkit-transform: translate(0, -25%);
-  -ms-transform: translate(0, -25%);
-  -o-transform: translate(0, -25%);
-  transform: translate(0, -25%);
-  -webkit-transition: -webkit-transform 0.3s ease-out;
-  -moz-transition: -moz-transform 0.3s ease-out;
-  -o-transition: -o-transform 0.3s ease-out;
-  transition: transform 0.3s ease-out;
-}
-.modal.in .modal-dialog {
-  -webkit-transform: translate(0, 0);
-  -ms-transform: translate(0, 0);
-  -o-transform: translate(0, 0);
-  transform: translate(0, 0);
-}
+  outline: 0; }
+  .modal.fade .modal-dialog {
+    -webkit-transform: translate(0, -25%);
+    -ms-transform: translate(0, -25%);
+    -o-transform: translate(0, -25%);
+    transform: translate(0, -25%);
+    -webkit-transition: -webkit-transform 0.3s ease-out;
+    -moz-transition: -moz-transform 0.3s ease-out;
+    -o-transition: -o-transform 0.3s ease-out;
+    transition: transform 0.3s ease-out; }
+  .modal.in .modal-dialog {
+    -webkit-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    -o-transform: translate(0, 0);
+    transform: translate(0, 0); }
 
 .modal-open .modal {
   overflow-x: hidden;
-  overflow-y: auto;
-}
+  overflow-y: auto; }
 
 .modal-dialog {
   position: relative;
   width: auto;
-  margin: 10px;
-}
+  margin: 10px; }
 
 .modal-content {
   position: relative;
@@ -6590,8 +5374,7 @@ button.close {
   -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
-  outline: 0;
-}
+  outline: 0; }
 
 .modal-backdrop {
   position: fixed;
@@ -6600,205 +5383,166 @@ button.close {
   bottom: 0;
   left: 0;
   z-index: 1040;
-  background-color: #000;
-}
-.modal-backdrop.fade {
-  opacity: 0;
-  filter: alpha(opacity=0);
-}
-.modal-backdrop.in {
-  opacity: 0.5;
-  filter: alpha(opacity=50);
-}
+  background-color: #000; }
+  .modal-backdrop.fade {
+    opacity: 0;
+    filter: alpha(opacity=0); }
+  .modal-backdrop.in {
+    opacity: 0.5;
+    filter: alpha(opacity=50); }
 
 .modal-header {
   padding: 15px;
   border-bottom: 1px solid #ddd;
-  min-height: 16.42857px;
-}
+  min-height: 16.42857px; }
 
 .modal-header .close {
-  margin-top: -2px;
-}
+  margin-top: -2px; }
 
 .modal-title {
   margin: 0;
-  line-height: 1.42857;
-}
+  line-height: 1.42857; }
 
 .modal-body {
   position: relative;
-  padding: 15px;
-}
+  padding: 15px; }
 
 .modal-footer {
   padding: 15px;
   text-align: right;
-  border-top: 1px solid #ddd;
-}
-.modal-footer:before, .modal-footer:after {
-  content: " ";
-  display: table;
-}
-.modal-footer:after {
-  clear: both;
-}
-.modal-footer .btn + .btn, .modal-footer .btn-ghost + .btn, .modal-footer .btn + .btn-ghost, .modal-footer .btn-ghost + .btn-ghost {
-  margin-left: 5px;
-  margin-bottom: 0;
-}
-.modal-footer .btn-group .btn + .btn, .modal-footer .btn-group .btn-ghost + .btn, .modal-footer .btn-group .btn + .btn-ghost, .modal-footer .btn-group .btn-ghost + .btn-ghost {
-  margin-left: -1px;
-}
-.modal-footer .btn-block + .btn-block {
-  margin-left: 0;
-}
+  border-top: 1px solid #ddd; }
+  .modal-footer:before,
+  .modal-footer:after {
+    content: " ";
+    display: table; }
+  .modal-footer:after {
+    clear: both; }
+  .modal-footer .btn + .btn, .modal-footer .btn-ghost + .btn, .modal-footer .btn + .btn-ghost, .modal-footer .btn-ghost + .btn-ghost {
+    margin-left: 5px;
+    margin-bottom: 0; }
+  .modal-footer .btn-group .btn + .btn, .modal-footer .btn-group .btn-ghost + .btn, .modal-footer .btn-group .btn + .btn-ghost, .modal-footer .btn-group .btn-ghost + .btn-ghost {
+    margin-left: -1px; }
+  .modal-footer .btn-block + .btn-block {
+    margin-left: 0; }
 
 .modal-scrollbar-measure {
   position: absolute;
   top: -9999px;
   width: 50px;
   height: 50px;
-  overflow: scroll;
-}
+  overflow: scroll; }
 
 @media (min-width: 768px) {
   .modal-dialog {
     width: 600px;
-    margin: 30px auto;
-  }
-
+    margin: 30px auto; }
   .modal-content {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-  }
-
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
   .modal-sm {
-    width: 300px;
-  }
-}
+    width: 300px; } }
+
 @media (min-width: 992px) {
   .modal-lg {
-    width: 900px;
-  }
-}
+    width: 900px; } }
+
 .tooltip {
   position: absolute;
   z-index: 1070;
   display: block;
   font-family: "Source Sans Pro", Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-  letter-spacing: normal;
-  line-break: auto;
-  line-height: 1.42857;
-  text-align: left;
-  text-align: start;
-  text-decoration: none;
-  text-shadow: none;
-  text-transform: none;
-  white-space: normal;
-  word-break: normal;
-  word-spacing: normal;
-  word-wrap: normal;
   font-size: 12px;
+  font-weight: normal;
+  line-height: 1.4;
   opacity: 0;
-  filter: alpha(opacity=0);
-}
-.tooltip.in {
-  opacity: 0.9;
-  filter: alpha(opacity=90);
-}
-.tooltip.top {
-  margin-top: -3px;
-  padding: 5px 0;
-}
-.tooltip.right {
-  margin-left: 3px;
-  padding: 0 5px;
-}
-.tooltip.bottom {
-  margin-top: 3px;
-  padding: 5px 0;
-}
-.tooltip.left {
-  margin-left: -3px;
-  padding: 0 5px;
-}
+  filter: alpha(opacity=0); }
+  .tooltip.in {
+    opacity: 0.9;
+    filter: alpha(opacity=90); }
+  .tooltip.top {
+    margin-top: -3px;
+    padding: 5px 0; }
+  .tooltip.right {
+    margin-left: 3px;
+    padding: 0 5px; }
+  .tooltip.bottom {
+    margin-top: 3px;
+    padding: 5px 0; }
+  .tooltip.left {
+    margin-left: -3px;
+    padding: 0 5px; }
 
 .tooltip-inner {
   max-width: 200px;
   padding: 3px 8px;
   color: #fff;
   text-align: center;
+  text-decoration: none;
   background-color: #000;
-  border-radius: 4px;
-}
+  border-radius: 4px; }
 
 .tooltip-arrow {
   position: absolute;
   width: 0;
   height: 0;
   border-color: transparent;
-  border-style: solid;
-}
+  border-style: solid; }
 
 .tooltip.top .tooltip-arrow {
   bottom: 0;
   left: 50%;
   margin-left: -5px;
   border-width: 5px 5px 0;
-  border-top-color: #000;
-}
+  border-top-color: #000; }
+
 .tooltip.top-left .tooltip-arrow {
   bottom: 0;
   right: 5px;
   margin-bottom: -5px;
   border-width: 5px 5px 0;
-  border-top-color: #000;
-}
+  border-top-color: #000; }
+
 .tooltip.top-right .tooltip-arrow {
   bottom: 0;
   left: 5px;
   margin-bottom: -5px;
   border-width: 5px 5px 0;
-  border-top-color: #000;
-}
+  border-top-color: #000; }
+
 .tooltip.right .tooltip-arrow {
   top: 50%;
   left: 0;
   margin-top: -5px;
   border-width: 5px 5px 5px 0;
-  border-right-color: #000;
-}
+  border-right-color: #000; }
+
 .tooltip.left .tooltip-arrow {
   top: 50%;
   right: 0;
   margin-top: -5px;
   border-width: 5px 0 5px 5px;
-  border-left-color: #000;
-}
+  border-left-color: #000; }
+
 .tooltip.bottom .tooltip-arrow {
   top: 0;
   left: 50%;
   margin-left: -5px;
   border-width: 0 5px 5px;
-  border-bottom-color: #000;
-}
+  border-bottom-color: #000; }
+
 .tooltip.bottom-left .tooltip-arrow {
   top: 0;
   right: 5px;
   margin-top: -5px;
   border-width: 0 5px 5px;
-  border-bottom-color: #000;
-}
+  border-bottom-color: #000; }
+
 .tooltip.bottom-right .tooltip-arrow {
   top: 0;
   left: 5px;
   margin-top: -5px;
   border-width: 0 5px 5px;
-  border-bottom-color: #000;
-}
+  border-bottom-color: #000; }
 
 .popover {
   position: absolute;
@@ -6809,21 +5553,10 @@ button.close {
   max-width: 276px;
   padding: 1px;
   font-family: "Source Sans Pro", Arial, sans-serif;
-  font-style: normal;
+  font-size: 14px;
   font-weight: normal;
-  letter-spacing: normal;
-  line-break: auto;
   line-height: 1.42857;
   text-align: left;
-  text-align: start;
-  text-decoration: none;
-  text-shadow: none;
-  text-transform: none;
-  white-space: normal;
-  word-break: normal;
-  word-spacing: normal;
-  word-wrap: normal;
-  font-size: 14px;
   background-color: #fff;
   background-clip: padding-box;
   border: 1px solid #ccc;
@@ -6831,19 +5564,15 @@ button.close {
   border-radius: 6px;
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-}
-.popover.top {
-  margin-top: -10px;
-}
-.popover.right {
-  margin-left: 10px;
-}
-.popover.bottom {
-  margin-top: 10px;
-}
-.popover.left {
-  margin-left: -10px;
-}
+  white-space: normal; }
+  .popover.top {
+    margin-top: -10px; }
+  .popover.right {
+    margin-left: 10px; }
+  .popover.bottom {
+    margin-top: 10px; }
+  .popover.left {
+    margin-left: -10px; }
 
 .popover-title {
   margin: 0;
@@ -6851,30 +5580,26 @@ button.close {
   font-size: 14px;
   background-color: #f7f7f7;
   border-bottom: 1px solid #ebebeb;
-  border-radius: 5px 5px 0 0;
-}
+  border-radius: 5px 5px 0 0; }
 
 .popover-content {
-  padding: 9px 14px;
-}
+  padding: 9px 14px; }
 
-.popover > .arrow, .popover > .arrow:after {
+.popover > .arrow,
+.popover > .arrow:after {
   position: absolute;
   display: block;
   width: 0;
   height: 0;
   border-color: transparent;
-  border-style: solid;
-}
+  border-style: solid; }
 
 .popover > .arrow {
-  border-width: 11px;
-}
+  border-width: 11px; }
 
 .popover > .arrow:after {
   border-width: 10px;
-  content: "";
-}
+  content: ""; }
 
 .popover.top > .arrow {
   left: 50%;
@@ -6882,143 +5607,125 @@ button.close {
   border-bottom-width: 0;
   border-top-color: #999999;
   border-top-color: rgba(0, 0, 0, 0.05);
-  bottom: -11px;
-}
-.popover.top > .arrow:after {
-  content: " ";
-  bottom: 1px;
-  margin-left: -10px;
-  border-bottom-width: 0;
-  border-top-color: #fff;
-}
+  bottom: -11px; }
+  .popover.top > .arrow:after {
+    content: " ";
+    bottom: 1px;
+    margin-left: -10px;
+    border-bottom-width: 0;
+    border-top-color: #fff; }
+
 .popover.right > .arrow {
   top: 50%;
   left: -11px;
   margin-top: -11px;
   border-left-width: 0;
   border-right-color: #999999;
-  border-right-color: rgba(0, 0, 0, 0.05);
-}
-.popover.right > .arrow:after {
-  content: " ";
-  left: 1px;
-  bottom: -10px;
-  border-left-width: 0;
-  border-right-color: #fff;
-}
+  border-right-color: rgba(0, 0, 0, 0.05); }
+  .popover.right > .arrow:after {
+    content: " ";
+    left: 1px;
+    bottom: -10px;
+    border-left-width: 0;
+    border-right-color: #fff; }
+
 .popover.bottom > .arrow {
   left: 50%;
   margin-left: -11px;
   border-top-width: 0;
   border-bottom-color: #999999;
   border-bottom-color: rgba(0, 0, 0, 0.05);
-  top: -11px;
-}
-.popover.bottom > .arrow:after {
-  content: " ";
-  top: 1px;
-  margin-left: -10px;
-  border-top-width: 0;
-  border-bottom-color: #fff;
-}
+  top: -11px; }
+  .popover.bottom > .arrow:after {
+    content: " ";
+    top: 1px;
+    margin-left: -10px;
+    border-top-width: 0;
+    border-bottom-color: #fff; }
+
 .popover.left > .arrow {
   top: 50%;
   right: -11px;
   margin-top: -11px;
   border-right-width: 0;
   border-left-color: #999999;
-  border-left-color: rgba(0, 0, 0, 0.05);
-}
-.popover.left > .arrow:after {
-  content: " ";
-  right: 1px;
-  border-right-width: 0;
-  border-left-color: #fff;
-  bottom: -10px;
-}
+  border-left-color: rgba(0, 0, 0, 0.05); }
+  .popover.left > .arrow:after {
+    content: " ";
+    right: 1px;
+    border-right-width: 0;
+    border-left-color: #fff;
+    bottom: -10px; }
 
 .carousel {
-  position: relative;
-}
+  position: relative; }
 
 .carousel-inner {
   position: relative;
   overflow: hidden;
-  width: 100%;
-}
-.carousel-inner > .item {
-  display: none;
-  position: relative;
-  -webkit-transition: 0.6s ease-in-out left;
-  -o-transition: 0.6s ease-in-out left;
-  transition: 0.6s ease-in-out left;
-}
-.carousel-inner > .item > img,
-.carousel-inner > .item > a > img {
-  display: block;
-  max-width: 100%;
-  height: auto;
-  line-height: 1;
-}
-@media all and (transform-3d), (-webkit-transform-3d) {
+  width: 100%; }
   .carousel-inner > .item {
-    -webkit-transition: -webkit-transform 0.6s ease-in-out;
-    -moz-transition: -moz-transform 0.6s ease-in-out;
-    -o-transition: -o-transform 0.6s ease-in-out;
-    transition: transform 0.6s ease-in-out;
-    -webkit-backface-visibility: hidden;
-    -moz-backface-visibility: hidden;
-    backface-visibility: hidden;
-    -webkit-perspective: 1000px;
-    -moz-perspective: 1000px;
-    perspective: 1000px;
-  }
-  .carousel-inner > .item.next, .carousel-inner > .item.active.right {
-    -webkit-transform: translate3d(100%, 0, 0);
-    transform: translate3d(100%, 0, 0);
-    left: 0;
-  }
-  .carousel-inner > .item.prev, .carousel-inner > .item.active.left {
-    -webkit-transform: translate3d(-100%, 0, 0);
-    transform: translate3d(-100%, 0, 0);
-    left: 0;
-  }
-  .carousel-inner > .item.next.left, .carousel-inner > .item.prev.right, .carousel-inner > .item.active {
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
-    left: 0;
-  }
-}
-.carousel-inner > .active,
-.carousel-inner > .next,
-.carousel-inner > .prev {
-  display: block;
-}
-.carousel-inner > .active {
-  left: 0;
-}
-.carousel-inner > .next,
-.carousel-inner > .prev {
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-.carousel-inner > .next {
-  left: 100%;
-}
-.carousel-inner > .prev {
-  left: -100%;
-}
-.carousel-inner > .next.left,
-.carousel-inner > .prev.right {
-  left: 0;
-}
-.carousel-inner > .active.left {
-  left: -100%;
-}
-.carousel-inner > .active.right {
-  left: 100%;
-}
+    display: none;
+    position: relative;
+    -webkit-transition: 0.6s ease-in-out left;
+    -o-transition: 0.6s ease-in-out left;
+    transition: 0.6s ease-in-out left; }
+    .carousel-inner > .item > img,
+    .carousel-inner > .item > a > img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      line-height: 1; }
+    @media all and (transform-3d), (-webkit-transform-3d) {
+      .carousel-inner > .item {
+        -webkit-transition: -webkit-transform 0.6s ease-in-out;
+        -moz-transition: -moz-transform 0.6s ease-in-out;
+        -o-transition: -o-transform 0.6s ease-in-out;
+        transition: transform 0.6s ease-in-out;
+        -webkit-backface-visibility: hidden;
+        -moz-backface-visibility: hidden;
+        backface-visibility: hidden;
+        -webkit-perspective: 1000;
+        -moz-perspective: 1000;
+        perspective: 1000; }
+        .carousel-inner > .item.next,
+        .carousel-inner > .item.active.right {
+          -webkit-transform: translate3d(100%, 0, 0);
+          transform: translate3d(100%, 0, 0);
+          left: 0; }
+        .carousel-inner > .item.prev,
+        .carousel-inner > .item.active.left {
+          -webkit-transform: translate3d(-100%, 0, 0);
+          transform: translate3d(-100%, 0, 0);
+          left: 0; }
+        .carousel-inner > .item.next.left,
+        .carousel-inner > .item.prev.right,
+        .carousel-inner > .item.active {
+          -webkit-transform: translate3d(0, 0, 0);
+          transform: translate3d(0, 0, 0);
+          left: 0; } }
+  .carousel-inner > .active,
+  .carousel-inner > .next,
+  .carousel-inner > .prev {
+    display: block; }
+  .carousel-inner > .active {
+    left: 0; }
+  .carousel-inner > .next,
+  .carousel-inner > .prev {
+    position: absolute;
+    top: 0;
+    width: 100%; }
+  .carousel-inner > .next {
+    left: 100%; }
+  .carousel-inner > .prev {
+    left: -100%; }
+  .carousel-inner > .next.left,
+  .carousel-inner > .prev.right {
+    left: 0; }
+  .carousel-inner > .active.left {
+    left: -100%; }
+  .carousel-inner > .active.right {
+    left: 100%; }
 
 .carousel-control {
   position: absolute;
@@ -7031,64 +5738,55 @@ button.close {
   font-size: 20px;
   color: #fff;
   text-align: center;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
-}
-.carousel-control.left {
-  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
-  background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1);
-}
-.carousel-control.right {
-  left: auto;
-  right: 0;
-  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
-  background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1);
-}
-.carousel-control:hover, .carousel-control:focus {
-  outline: 0;
-  color: #fff;
-  text-decoration: none;
-  opacity: 0.9;
-  filter: alpha(opacity=90);
-}
-.carousel-control .icon-prev,
-.carousel-control .icon-next,
-.carousel-control .glyphicon-chevron-left,
-.carousel-control .glyphicon-chevron-right {
-  position: absolute;
-  top: 50%;
-  margin-top: -10px;
-  z-index: 5;
-  display: inline-block;
-}
-.carousel-control .icon-prev,
-.carousel-control .glyphicon-chevron-left {
-  left: 50%;
-  margin-left: -10px;
-}
-.carousel-control .icon-next,
-.carousel-control .glyphicon-chevron-right {
-  right: 50%;
-  margin-right: -10px;
-}
-.carousel-control .icon-prev,
-.carousel-control .icon-next {
-  width: 20px;
-  height: 20px;
-  line-height: 1;
-  font-family: serif;
-}
-.carousel-control .icon-prev:before {
-  content: '\2039';
-}
-.carousel-control .icon-next:before {
-  content: '\203a';
-}
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
+  .carousel-control.left {
+    background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+    background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1); }
+  .carousel-control.right {
+    left: auto;
+    right: 0;
+    background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+    background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1); }
+  .carousel-control:hover,
+  .carousel-control:focus {
+    outline: 0;
+    color: #fff;
+    text-decoration: none;
+    opacity: 0.9;
+    filter: alpha(opacity=90); }
+  .carousel-control .icon-prev,
+  .carousel-control .icon-next,
+  .carousel-control .glyphicon-chevron-left,
+  .carousel-control .glyphicon-chevron-right {
+    position: absolute;
+    top: 50%;
+    z-index: 5;
+    display: inline-block; }
+  .carousel-control .icon-prev,
+  .carousel-control .glyphicon-chevron-left {
+    left: 50%;
+    margin-left: -10px; }
+  .carousel-control .icon-next,
+  .carousel-control .glyphicon-chevron-right {
+    right: 50%;
+    margin-right: -10px; }
+  .carousel-control .icon-prev,
+  .carousel-control .icon-next {
+    width: 20px;
+    height: 20px;
+    margin-top: -10px;
+    line-height: 1;
+    font-family: serif; }
+  .carousel-control .icon-prev:before {
+    content: '\2039'; }
+  .carousel-control .icon-next:before {
+    content: '\203a'; }
 
 .carousel-indicators {
   position: absolute;
@@ -7099,26 +5797,23 @@ button.close {
   margin-left: -30%;
   padding-left: 0;
   list-style: none;
-  text-align: center;
-}
-.carousel-indicators li {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  margin: 1px;
-  text-indent: -999px;
-  border: 1px solid #fff;
-  border-radius: 10px;
-  cursor: pointer;
-  background-color: #000 \9;
-  background-color: transparent;
-}
-.carousel-indicators .active {
-  margin: 0;
-  width: 12px;
-  height: 12px;
-  background-color: #fff;
-}
+  text-align: center; }
+  .carousel-indicators li {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin: 1px;
+    text-indent: -999px;
+    border: 1px solid #fff;
+    border-radius: 10px;
+    cursor: pointer;
+    background-color: #000 \9;
+    background-color: transparent; }
+  .carousel-indicators .active {
+    margin: 0;
+    width: 12px;
+    height: 12px;
+    background-color: #fff; }
 
 .carousel-caption {
   position: absolute;
@@ -7130,11 +5825,9 @@ button.close {
   padding-bottom: 20px;
   color: #fff;
   text-align: center;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
-}
-.carousel-caption .btn, .carousel-caption .btn-ghost {
-  text-shadow: none;
-}
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
+  .carousel-caption .btn, .carousel-caption .btn-ghost {
+    text-shadow: none; }
 
 @media screen and (min-width: 768px) {
   .carousel-control .glyphicon-chevron-left,
@@ -7144,95 +5837,75 @@ button.close {
     width: 30px;
     height: 30px;
     margin-top: -15px;
-    font-size: 30px;
-  }
+    font-size: 30px; }
   .carousel-control .glyphicon-chevron-left,
   .carousel-control .icon-prev {
-    margin-left: -15px;
-  }
+    margin-left: -15px; }
   .carousel-control .glyphicon-chevron-right,
   .carousel-control .icon-next {
-    margin-right: -15px;
-  }
-
+    margin-right: -15px; }
   .carousel-caption {
     left: 20%;
     right: 20%;
-    padding-bottom: 30px;
-  }
-
+    padding-bottom: 30px; }
   .carousel-indicators {
-    bottom: 20px;
-  }
-}
-.clearfix:before, .clearfix:after {
-  content: " ";
-  display: table;
-}
+    bottom: 20px; } }
+
+.clearfix:before,
 .clearfix:after {
-  clear: both;
-}
+  content: " ";
+  display: table; }
+
+.clearfix:after {
+  clear: both; }
 
 .center-block {
   display: block;
   margin-left: auto;
-  margin-right: auto;
-}
+  margin-right: auto; }
 
 .pull-right {
-  float: right !important;
-}
+  float: right !important; }
 
 .pull-left {
-  float: left !important;
-}
+  float: left !important; }
 
 .hide {
-  display: none !important;
-}
+  display: none !important; }
 
 .show {
-  display: block !important;
-}
+  display: block !important; }
 
 .invisible {
-  visibility: hidden;
-}
+  visibility: hidden; }
 
 .text-hide {
   font: 0/0 a;
   color: transparent;
   text-shadow: none;
   background-color: transparent;
-  border: 0;
-}
+  border: 0; }
 
 .hidden {
-  display: none !important;
-}
+  display: none !important; }
 
 .affix {
-  position: fixed;
-}
+  position: fixed; }
 
 @-ms-viewport {
-  width: device-width;
-}
+  width: device-width; }
+
 .visible-xs {
-  display: none !important;
-}
+  display: none !important; }
 
 .visible-sm {
-  display: none !important;
-}
+  display: none !important; }
 
 .visible-md {
-  display: none !important;
-}
+  display: none !important; }
 
 .visible-lg {
-  display: none !important;
-}
+  display: none !important; }
 
 .visible-xs-block,
 .visible-xs-inline,
@@ -7246,227 +5919,152 @@ button.close {
 .visible-lg-block,
 .visible-lg-inline,
 .visible-lg-inline-block {
-  display: none !important;
-}
+  display: none !important; }
 
 @media (max-width: 767px) {
   .visible-xs {
-    display: block !important;
-  }
-
+    display: block !important; }
   table.visible-xs {
-    display: table !important;
-  }
-
+    display: table; }
   tr.visible-xs {
-    display: table-row !important;
-  }
-
+    display: table-row !important; }
   th.visible-xs,
   td.visible-xs {
-    display: table-cell !important;
-  }
-}
+    display: table-cell !important; } }
+
 @media (max-width: 767px) {
   .visible-xs-block {
-    display: block !important;
-  }
-}
+    display: block !important; } }
 
 @media (max-width: 767px) {
   .visible-xs-inline {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
 
 @media (max-width: 767px) {
   .visible-xs-inline-block {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
 
 @media (min-width: 768px) and (max-width: 991px) {
   .visible-sm {
-    display: block !important;
-  }
-
+    display: block !important; }
   table.visible-sm {
-    display: table !important;
-  }
-
+    display: table; }
   tr.visible-sm {
-    display: table-row !important;
-  }
-
+    display: table-row !important; }
   th.visible-sm,
   td.visible-sm {
-    display: table-cell !important;
-  }
-}
+    display: table-cell !important; } }
+
 @media (min-width: 768px) and (max-width: 991px) {
   .visible-sm-block {
-    display: block !important;
-  }
-}
+    display: block !important; } }
 
 @media (min-width: 768px) and (max-width: 991px) {
   .visible-sm-inline {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
 
 @media (min-width: 768px) and (max-width: 991px) {
   .visible-sm-inline-block {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
 
 @media (min-width: 992px) and (max-width: 1199px) {
   .visible-md {
-    display: block !important;
-  }
-
+    display: block !important; }
   table.visible-md {
-    display: table !important;
-  }
-
+    display: table; }
   tr.visible-md {
-    display: table-row !important;
-  }
-
+    display: table-row !important; }
   th.visible-md,
   td.visible-md {
-    display: table-cell !important;
-  }
-}
+    display: table-cell !important; } }
+
 @media (min-width: 992px) and (max-width: 1199px) {
   .visible-md-block {
-    display: block !important;
-  }
-}
+    display: block !important; } }
 
 @media (min-width: 992px) and (max-width: 1199px) {
   .visible-md-inline {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
 
 @media (min-width: 992px) and (max-width: 1199px) {
   .visible-md-inline-block {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
 
 @media (min-width: 1200px) {
   .visible-lg {
-    display: block !important;
-  }
-
+    display: block !important; }
   table.visible-lg {
-    display: table !important;
-  }
-
+    display: table; }
   tr.visible-lg {
-    display: table-row !important;
-  }
-
+    display: table-row !important; }
   th.visible-lg,
   td.visible-lg {
-    display: table-cell !important;
-  }
-}
+    display: table-cell !important; } }
+
 @media (min-width: 1200px) {
   .visible-lg-block {
-    display: block !important;
-  }
-}
+    display: block !important; } }
 
 @media (min-width: 1200px) {
   .visible-lg-inline {
-    display: inline !important;
-  }
-}
+    display: inline !important; } }
 
 @media (min-width: 1200px) {
   .visible-lg-inline-block {
-    display: inline-block !important;
-  }
-}
+    display: inline-block !important; } }
 
 @media (max-width: 767px) {
   .hidden-xs {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media (min-width: 768px) and (max-width: 991px) {
   .hidden-sm {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media (min-width: 992px) and (max-width: 1199px) {
   .hidden-md {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 @media (min-width: 1200px) {
   .hidden-lg {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 .visible-print {
-  display: none !important;
-}
+  display: none !important; }
 
 @media print {
   .visible-print {
-    display: block !important;
-  }
-
+    display: block !important; }
   table.visible-print {
-    display: table !important;
-  }
-
+    display: table; }
   tr.visible-print {
-    display: table-row !important;
-  }
-
+    display: table-row !important; }
   th.visible-print,
   td.visible-print {
-    display: table-cell !important;
-  }
-}
+    display: table-cell !important; } }
+
 .visible-print-block {
-  display: none !important;
-}
-@media print {
-  .visible-print-block {
-    display: block !important;
-  }
-}
+  display: none !important; }
+  @media print {
+    .visible-print-block {
+      display: block !important; } }
 
 .visible-print-inline {
-  display: none !important;
-}
-@media print {
-  .visible-print-inline {
-    display: inline !important;
-  }
-}
+  display: none !important; }
+  @media print {
+    .visible-print-inline {
+      display: inline !important; } }
 
 .visible-print-inline-block {
-  display: none !important;
-}
-@media print {
-  .visible-print-inline-block {
-    display: inline-block !important;
-  }
-}
+  display: none !important; }
+  @media print {
+    .visible-print-inline-block {
+      display: inline-block !important; } }
 
 @media print {
   .hidden-print {
-    display: none !important;
-  }
-}
+    display: none !important; } }
+
 /*doc
  ---
  title: Units extended
@@ -7530,14 +6128,12 @@ button.close {
  */
 body {
   -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-}
-body #sb-site a[name] {
-  content: "";
-  display: block;
-  height: 76px;
-  margin-top: -76px;
-}
+  text-rendering: optimizeLegibility; }
+  body #sb-site a[name] {
+    content: "";
+    display: block;
+    height: 76px;
+    margin-top: -76px; }
 
 /*doc
  ---
@@ -7642,24 +6238,20 @@ body #sb-site a[name] {
 </div>
  */
 .table tbody > tr > td.vert-align {
-  vertical-align: middle;
-}
+  vertical-align: middle; }
 
 @media screen and (min-width: 768px) {
   .text-left-sm {
-    text-align: left;
-  }
-}
+    text-align: left; } }
+
 @media screen and (min-width: 992px) {
   .text-left-md {
-    text-align: left;
-  }
-}
+    text-align: left; } }
+
 @media screen and (min-width: 1200px) {
   .text-left-lg {
-    text-align: left;
-  }
-}
+    text-align: left; } }
+
 /*doc
 ---
 title: Buttons
@@ -7687,50 +6279,40 @@ category: CSS
  */
 .btn-default:hover {
   background-color: #f9fafb;
-  color: #999999;
-}
+  color: #999999; }
+
 .btn-primary:hover {
-  background: #89a334;
-}
+  background: #89a334; }
+
 .btn-secondary {
-  color: #666;
-}
-.btn-secondary:hover {
-  color: #333333;
-  text-decoration: none;
-}
+  color: #666; }
+  .btn-secondary:hover {
+    color: #333333;
+    text-decoration: none; }
+
 .btn-ghost {
-  background-color: transparent;
-}
-.btn-ghost.btn-default {
-  border-color: #999999;
-  color: #999999;
-}
-.btn-ghost.btn-default:hover {
-  color: #fff;
-  background-color: #999999;
-}
-.btn-ghost.btn-primary {
-  border-color: #9bb83a;
-  color: #9bb83a;
-}
-.btn-ghost.btn-primary:hover {
-  color: #fff;
-}
-.btn-ghost.btn-primary-alt {
-  border-color: #e53221;
-  color: #e53221;
-}
-.btn-ghost.btn-primary-alt:hover {
-  color: #fff;
-}
-.btn-ghost.btn-danger, .btn-ghost.btn-primary-alt {
-  border-color: #e53221;
-  color: #e53221;
-}
-.btn-ghost.btn-danger:hover, .btn-ghost.btn-primary-alt:hover {
-  color: #fff;
-}
+  background-color: transparent; }
+  .btn-ghost.btn-default {
+    border-color: #999999;
+    color: #999999; }
+    .btn-ghost.btn-default:hover {
+      color: #fff;
+      background-color: #999999; }
+  .btn-ghost.btn-primary {
+    border-color: #9bb83a;
+    color: #9bb83a; }
+    .btn-ghost.btn-primary:hover {
+      color: #fff; }
+  .btn-ghost.btn-primary-alt {
+    border-color: #e53221;
+    color: #e53221; }
+    .btn-ghost.btn-primary-alt:hover {
+      color: #fff; }
+  .btn-ghost.btn-danger, .btn-ghost.btn-primary-alt {
+    border-color: #e53221;
+    color: #e53221; }
+    .btn-ghost.btn-danger:hover, .btn-ghost.btn-primary-alt:hover {
+      color: #fff; }
 
 /*doc
 //---
@@ -7846,75 +6428,58 @@ category: CSS
 ```
 */
 .form-group {
-  margin-bottom: 20px;
-}
+  margin-bottom: 20px; }
 
 .form-actions {
-  padding-top: 20px;
-}
+  padding-top: 20px; }
 
 .form-control {
   background: transparent;
   border: 1px solid #bbb;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-.form-control::-webkit-input-placeholder {
-  color: #999999;
-}
-.form-control::-moz-placeholder {
-  color: #999999;
-}
-.form-control:-moz-placeholder {
-  color: #999999;
-}
-.form-control:-ms-input-placeholder {
-  color: #999999;
-}
-.form-control:focus {
-  box-shadow: none;
-}
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1); }
+  .form-control::-webkit-input-placeholder {
+    color: #999999; }
+  .form-control::-moz-placeholder {
+    color: #999999; }
+  .form-control:-moz-placeholder {
+    color: #999999; }
+  .form-control:-ms-input-placeholder {
+    color: #999999; }
+  .form-control:focus {
+    box-shadow: none; }
 
 .has-error .form-control,
 .has-warning .form-control,
 .has-success .form-control {
-  box-shadow: none;
-}
-.has-error .form-control:focus,
-.has-warning .form-control:focus,
-.has-success .form-control:focus {
-  box-shadow: none;
-}
+  box-shadow: none; }
+  .has-error .form-control:focus,
+  .has-warning .form-control:focus,
+  .has-success .form-control:focus {
+    box-shadow: none; }
 
 label {
   color: #666;
-  margin-bottom: 10px;
-}
+  margin-bottom: 10px; }
 
 .checkbox label,
 .radio label {
   color: #666;
   font-size: 14px;
   margin-bottom: 0;
-  text-transform: none;
-}
+  text-transform: none; }
 
 .form-group.has-error label {
-  color: #e53221;
-}
+  color: #e53221; }
 
 textarea {
-  resize: vertical;
-}
+  resize: vertical; }
 
 .form-links {
-  text-align: left;
-}
-.form-links a {
-  padding: 7px 13px;
-}
-.form-links a.pull-left:first-child {
-  padding-left: 0;
-}
+  text-align: left; }
+  .form-links a {
+    padding: 7px 13px; }
+    .form-links a.pull-left:first-child {
+      padding-left: 0; }
 
 /*doc
 ---
@@ -7925,8 +6490,7 @@ category: CSS
 */
 .container-fluid {
   padding-left: 20px;
-  padding-right: 20px;
-}
+  padding-right: 20px; }
 
 /*doc
 //---
@@ -7996,11 +6560,10 @@ category: CSS
 */
 .table > tbody > tr > td {
   border-top: 0;
-  border-bottom: 1px solid #ddd;
-}
+  border-bottom: 1px solid #ddd; }
+
 .table-actions {
-  text-align: right;
-}
+  text-align: right; }
 
 /*doc
 ---
@@ -8106,51 +6669,50 @@ parent: typo
   margin: 30px auto 0;
   max-width: 480px;
   padding: 30px;
-  text-align: center;
-}
-@media screen and (min-width: 768px) {
-  .jumbotron {
-    margin: 40px auto 0;
-    padding: 60px;
-  }
-}
-.jumbotron .jumbotron-description {
-  margin-bottom: 20px;
-}
-@media screen and (min-width: 768px) {
+  text-align: center; }
+  @media screen and (min-width: 768px) {
+    .jumbotron {
+      margin: 40px auto 0;
+      padding: 60px; } }
   .jumbotron .jumbotron-description {
-    margin-bottom: 30px;
-  }
-}
-.jumbotron .jumbotron-description h1 {
-  color: #333333;
-  font-size: 38px;
-  font-weight: 600;
-  margin-bottom: 30px;
-  margin-top: 0;
-}
-@media screen and (min-width: 768px) {
-  .jumbotron .jumbotron-description h1 {
-    margin-bottom: 20px;
-  }
-}
-.jumbotron .jumbotron-description p {
-  color: #666;
-  font-size: 14px;
-  font-weight: normal;
-}
-.jumbotron .jumbotron-link {
-  margin-right: 20px;
-}
-.jumbotron .jumbotron-link:last-child {
-  margin-right: 0;
-}
-.jumbotron form {
-  margin-top: 0;
-}
-.jumbotron form .form-group {
-  text-align: left;
-}
+    margin-bottom: 20px; }
+    @media screen and (min-width: 768px) {
+      .jumbotron .jumbotron-description {
+        margin-bottom: 30px; } }
+    .jumbotron .jumbotron-description h1 {
+      color: #333333;
+      font-size: 38px;
+      font-weight: 600;
+      margin-bottom: 30px;
+      margin-top: 0; }
+      @media screen and (min-width: 768px) {
+        .jumbotron .jumbotron-description h1 {
+          margin-bottom: 20px; } }
+    .jumbotron .jumbotron-description p {
+      color: #666;
+      font-size: 14px;
+      font-weight: normal; }
+  .jumbotron .jumbotron-link {
+    margin-right: 20px; }
+    .jumbotron .jumbotron-link:last-child {
+      margin-right: 0; }
+  .jumbotron form {
+    margin-top: 0; }
+    .jumbotron form .form-group {
+      text-align: left; }
+
+.jumbotron-transparent {
+  background: transparent;
+  border: 0; }
+  .jumbotron-transparent .jumbotron-description h1,
+  .jumbotron-transparent .jumbotron-description p {
+    color: #fff; }
+  .jumbotron-transparent .control-label {
+    color: #fff; }
+  .jumbotron-transparent .form-control {
+    background: #fff; }
+  .jumbotron-transparent .form-links a {
+    color: #fff; }
 
 /*doc
 ---
@@ -8269,51 +6831,50 @@ category: Components
   margin: 30px auto 0;
   max-width: 480px;
   padding: 30px;
-  text-align: center;
-}
-@media screen and (min-width: 768px) {
-  .jumbotron {
-    margin: 40px auto 0;
-    padding: 60px;
-  }
-}
-.jumbotron .jumbotron-description {
-  margin-bottom: 20px;
-}
-@media screen and (min-width: 768px) {
+  text-align: center; }
+  @media screen and (min-width: 768px) {
+    .jumbotron {
+      margin: 40px auto 0;
+      padding: 60px; } }
   .jumbotron .jumbotron-description {
-    margin-bottom: 30px;
-  }
-}
-.jumbotron .jumbotron-description h1 {
-  color: #333333;
-  font-size: 38px;
-  font-weight: 600;
-  margin-bottom: 30px;
-  margin-top: 0;
-}
-@media screen and (min-width: 768px) {
-  .jumbotron .jumbotron-description h1 {
-    margin-bottom: 20px;
-  }
-}
-.jumbotron .jumbotron-description p {
-  color: #666;
-  font-size: 14px;
-  font-weight: normal;
-}
-.jumbotron .jumbotron-link {
-  margin-right: 20px;
-}
-.jumbotron .jumbotron-link:last-child {
-  margin-right: 0;
-}
-.jumbotron form {
-  margin-top: 0;
-}
-.jumbotron form .form-group {
-  text-align: left;
-}
+    margin-bottom: 20px; }
+    @media screen and (min-width: 768px) {
+      .jumbotron .jumbotron-description {
+        margin-bottom: 30px; } }
+    .jumbotron .jumbotron-description h1 {
+      color: #333333;
+      font-size: 38px;
+      font-weight: 600;
+      margin-bottom: 30px;
+      margin-top: 0; }
+      @media screen and (min-width: 768px) {
+        .jumbotron .jumbotron-description h1 {
+          margin-bottom: 20px; } }
+    .jumbotron .jumbotron-description p {
+      color: #666;
+      font-size: 14px;
+      font-weight: normal; }
+  .jumbotron .jumbotron-link {
+    margin-right: 20px; }
+    .jumbotron .jumbotron-link:last-child {
+      margin-right: 0; }
+  .jumbotron form {
+    margin-top: 0; }
+    .jumbotron form .form-group {
+      text-align: left; }
+
+.jumbotron-transparent {
+  background: transparent;
+  border: 0; }
+  .jumbotron-transparent .jumbotron-description h1,
+  .jumbotron-transparent .jumbotron-description p {
+    color: #fff; }
+  .jumbotron-transparent .control-label {
+    color: #fff; }
+  .jumbotron-transparent .form-control {
+    background: #fff; }
+  .jumbotron-transparent .form-links a {
+    color: #fff; }
 
 /*doc
 //---
@@ -8352,22 +6913,17 @@ parent: list_group
 ```
 */
 .list-group {
-  border: none;
-}
-.list-group-item {
-  border-width: 1px 0;
-}
-.list-group-item:first-child {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-.list-group-item:last-child {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.list-group-striped .list-group-item:nth-child(odd) {
-  background: #f1f8fb;
-}
+  border: none; }
+  .list-group-item {
+    border-width: 1px 0; }
+    .list-group-item:first-child {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0; }
+    .list-group-item:last-child {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0; }
+  .list-group-striped .list-group-item:nth-child(odd) {
+    background: #f1f8fb; }
 
 /*doc
 ---
@@ -8434,52 +6990,38 @@ Custom list for editable content
   margin-bottom: 20px;
   max-width: 100%;
   table-layout: fixed;
-  width: 100%;
-}
-.content-list:last-child {
-  margin-bottom: 0;
-}
-.content-list .content-list-row {
-  border-bottom: 1px solid #eeeeee;
-  display: table-row;
-}
-.content-list .content-list-column {
-  display: table-cell;
-  padding: 15px;
-  text-align: right;
-}
-.content-list .content-list-column:first-child {
-  text-align: left;
-  display: table-cell;
-}
-.content-list .content-list-column:nth-child(n+2) {
-  display: none;
-}
-@media screen and (min-width: 768px) {
-  .content-list .content-list-column:nth-child(n+2) {
+  width: 100%; }
+  .content-list:last-child {
+    margin-bottom: 0; }
+  .content-list .content-list-row {
+    border-bottom: 1px solid #eeeeee;
+    display: table-row; }
+  .content-list .content-list-column {
     display: table-cell;
-  }
-}
-.content-list .content-list-column:last-child {
-  display: table-cell;
-}
-.content-list .content-list-action {
-  display: inline-block;
-  margin-left: 25px;
-}
-.content-list .content-list-action:first-child {
-  margin-left: 0;
-}
-.content-list .content-list-header {
-  font-weight: bold;
-}
+    padding: 15px;
+    text-align: right; }
+    .content-list .content-list-column:first-child {
+      text-align: left;
+      display: table-cell; }
+    .content-list .content-list-column:nth-child(n+2) {
+      display: none; }
+      @media screen and (min-width: 768px) {
+        .content-list .content-list-column:nth-child(n+2) {
+          display: table-cell; } }
+    .content-list .content-list-column:last-child {
+      display: table-cell; }
+  .content-list .content-list-action {
+    display: inline-block;
+    margin-left: 25px; }
+    .content-list .content-list-action:first-child {
+      margin-left: 0; }
+  .content-list .content-list-header {
+    font-weight: bold; }
 
 .content-list-striped .content-list-row {
-  border-bottom: 0;
-}
-.content-list-striped .content-list-row:nth-child(even) {
-  background-color: #f8fafd;
-}
+  border-bottom: 0; }
+  .content-list-striped .content-list-row:nth-child(even) {
+    background-color: #f8fafd; }
 
 /*doc
 //---
@@ -8576,56 +7118,47 @@ Modular section setup which allows using a combination of header, body and foote
 
 */
 section.solid {
-  background-color: #F2F2F2;
-}
+  background-color: #F2F2F2; }
+
 section > .content header, section > .content .body, section > .content footer {
-  text-align: center;
-}
+  text-align: center; }
+
 section > .content header {
-  margin: 100px 0 50px;
-}
-section > .content header h2 {
-  font-size: 36px;
-  margin: 0;
-}
-section > .content header p {
-  margin: 10px 0 0;
-  font-weight: 200;
-}
+  margin: 100px 0 50px; }
+  section > .content header h2 {
+    font-size: 36px;
+    margin: 0; }
+  section > .content header p {
+    margin: 10px 0 0;
+    font-weight: 200; }
+
 section > .content .body {
-  margin: 50px 0;
-}
+  margin: 50px 0; }
+
 section > .content footer {
-  margin: 50px 0 100px;
-}
+  margin: 50px 0 100px; }
+
 section > .content h2 {
   font-size: 24px;
   font-weight: 200;
-  margin-top: 0;
-}
-@media (min-width: 992px) {
-  section > .content h2 {
-    font-weight: 200;
-    font-size: 32px;
-  }
-}
-@media (min-width: 1200px) {
-  section > .content h2 {
-    font-size: 48px;
-  }
-}
+  margin-top: 0; }
+  @media (min-width: 992px) {
+    section > .content h2 {
+      font-weight: 200;
+      font-size: 32px; } }
+  @media (min-width: 1200px) {
+    section > .content h2 {
+      font-size: 48px; } }
+
 section > .content p {
   font-size: 18px;
-  font-weight: 200;
-}
-@media (min-width: 992px) {
-  section > .content p {
-    font-size: 20px;
-  }
-}
+  font-weight: 200; }
+  @media (min-width: 992px) {
+    section > .content p {
+      font-size: 20px; } }
+
 section > .content a {
-  font-weight: normal;
-}
+  font-weight: normal; }
 
 /*doc
 ---
@@ -8682,22 +7215,16 @@ category: JavaScript
 */
 .modal-backdrop {
   position: fixed;
-  bottom: 0;
-}
+  bottom: 0; }
 
 .modal-content {
   -webkit-box-shadow: 0 2px 4px rgba(187, 187, 187, 0.4);
   box-shadow: 0 2px 4px rgba(187, 187, 187, 0.4);
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 .modal-header {
-  background-color: #fcfcfc;
-}
+  background-color: #fcfcfc; }
 
 .modal-dialog .footnote {
   color: #999999;
-  font-size: 12px;
-}
-
-/*# sourceMappingURL=mnd-bootstrap.css.map */
+  font-size: 12px; }

--- a/dist/mnd-bootstrap.css
+++ b/dist/mnd-bootstrap.css
@@ -1,6318 +1,2674 @@
-/*doc
- ---
- title: Units extended
- name: units_extended
- category: Variables
- ---
-
- Those are the units that you can use
-<div class="clearfix">
-  <div class="variable-box">
-    <span>$base-unit = $base-unit // 14px</span>
-  </div>
-  <div class="variable-box">
-    <span>$base-unit-x2 = $base-unit-x2</span>
-  </div>
-  <div class="variable-box">
-    <span>$base-unit-x3 = $base-unit-x3</span>
-  </div>
-  <div class="variable-box">
-    <span>$space = 10px</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-small = $space / 2</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-large = $space * 2</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-larger = $space * 4</span>
-  </div>
-  <div class="variable-box">
-    <span>$font-size-larger = 38px</span>
-  </div>
-</div>
- */
-/*doc
- ---
- title: Colors extended
- name: colors_extended
- category: Variables
- ---
-
- Those are the colors that you can use
-<div class="clearfix">
-  <div class="color-box gray-lighten">
-    <span>$gray-lighten</span>
-  </div>
-  <div class="color-box gray-lightest">
-    <span>$gray-lightest</span>
-  </div>
-  <div class="color-box white">
-    <span>$white</span>
-  </div>
-  <div class="color-box brand-primary-custom">
-    <span>$brand-primary-custom</span>
-  </div>
-  <div class="color-box blue-light">
-    <span>$blue-light</span>
-  </div>
-</div>
- */
-/*doc
- ---
- title: Colors
- name: colors
- category: Variables
- ---
-
- Those are the colors that you can use
-<div class="clearfix">
-  <div class="color-box gray-darker">
-    <span>$gray-darker</span>
-  </div>
-  <div class="color-box gray-dark">
-    <span>$gray-dark</span>
-  </div>
-  <div class="color-box gray">
-    <span>$gray</span>
-  </div>
-  <div class="color-box gray-light">
-    <span>$gray-light</span>
-  </div>
-  <div class="color-box gray-lighter">
-    <span>$gray-lighter</span>
-  </div>
-  <div class="color-box brand-primary">
-    <span>$brand-primary</span>
-  </div>
-  <div class="color-box brand-success">
-    <span>$brand-success</span>
-  </div>
-  <div class="color-box brand-info">
-    <span>$brand-info</span>
-  </div>
-  <div class="color-box brand-warning">
-    <span>$brand-warning</span>
-  </div>
-  <div class="color-box brand-danger">
-    <span>$brand-danger</span>
-  </div>
-</div>
- */
+/*doc --- title: Units extended name: units_extended category: Variables --- Those are the units that you can use <div class="clearfix"> <div class="variable-box"> <span>$base-unit = $base-unit // 14px</span> </div> <div class="variable-box"> <span>$base-unit-x2 = $base-unit-x2</span> </div> <div class="variable-box"> <span>$base-unit-x3 = $base-unit-x3</span> </div> <div class="variable-box"> <span>$space = 10px</span> </div> <div class="variable-box"> <span>$space-small = $space / 2</span> </div> <div class="variable-box"> <span>$space-large = $space * 2</span> </div> <div class="variable-box"> <span>$space-larger = $space * 4</span> </div> <div class="variable-box"> <span>$font-size-larger = 38px</span> </div> </div> */
+/*doc --- title: Colors extended name: colors_extended category: Variables --- Those are the colors that you can use <div class="clearfix"> <div class="color-box gray-lighten"> <span>$gray-lighten</span> </div> <div class="color-box gray-lightest"> <span>$gray-lightest</span> </div> <div class="color-box white"> <span>$white</span> </div> <div class="color-box brand-primary-custom"> <span>$brand-primary-custom</span> </div> <div class="color-box blue-light"> <span>$blue-light</span> </div> </div> */
+/*doc --- title: Colors name: colors category: Variables --- Those are the colors that you can use <div class="clearfix"> <div class="color-box gray-darker"> <span>$gray-darker</span> </div> <div class="color-box gray-dark"> <span>$gray-dark</span> </div> <div class="color-box gray"> <span>$gray</span> </div> <div class="color-box gray-light"> <span>$gray-light</span> </div> <div class="color-box gray-lighter"> <span>$gray-lighter</span> </div> <div class="color-box brand-primary"> <span>$brand-primary</span> </div> <div class="color-box brand-success"> <span>$brand-success</span> </div> <div class="color-box brand-info"> <span>$brand-info</span> </div> <div class="color-box brand-warning"> <span>$brand-warning</span> </div> <div class="color-box brand-danger"> <span>$brand-danger</span> </div> </div> */
 @import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic");
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 @import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic");
-html {
-  font-family: sans-serif;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%; }
+html { font-family: sans-serif; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
 
-body {
-  margin: 0; }
+body { margin: 0; }
 
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
-  display: block; }
+article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary { display: block; }
 
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-  vertical-align: baseline; }
+audio, canvas, progress, video { display: inline-block; vertical-align: baseline; }
 
-audio:not([controls]) {
-  display: none;
-  height: 0; }
+audio:not([controls]) { display: none; height: 0; }
 
-[hidden],
-template {
-  display: none; }
+[hidden], template { display: none; }
 
-a {
-  background-color: transparent; }
+a { background-color: transparent; }
 
-a:active,
-a:hover {
-  outline: 0; }
+a:active, a:hover { outline: 0; }
 
-abbr[title] {
-  border-bottom: 1px dotted; }
+abbr[title] { border-bottom: 1px dotted; }
 
-b,
-strong {
-  font-weight: bold; }
+b, strong { font-weight: bold; }
 
-dfn {
-  font-style: italic; }
+dfn { font-style: italic; }
 
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0; }
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-mark {
-  background: #ff0;
-  color: #000; }
+mark { background: #ff0; color: #000; }
 
-small {
-  font-size: 80%; }
+small { font-size: 80%; }
 
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline; }
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-sup {
-  top: -0.5em; }
+sup { top: -0.5em; }
 
-sub {
-  bottom: -0.25em; }
+sub { bottom: -0.25em; }
 
-img {
-  border: 0; }
+img { border: 0; }
 
-svg:not(:root) {
-  overflow: hidden; }
+svg:not(:root) { overflow: hidden; }
 
-figure {
-  margin: 1em 40px; }
+figure { margin: 1em 40px; }
 
-hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0; }
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-pre {
-  overflow: auto; }
+pre { overflow: auto; }
 
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em; }
+code, kbd, pre, samp { font-family: monospace, monospace; font-size: 1em; }
 
-button,
-input,
-optgroup,
-select,
-textarea {
-  color: inherit;
-  font: inherit;
-  margin: 0; }
+button, input, optgroup, select, textarea { color: inherit; font: inherit; margin: 0; }
 
-button {
-  overflow: visible; }
+button { overflow: visible; }
 
-button,
-select {
-  text-transform: none; }
+button, select { text-transform: none; }
 
-button,
-html input[type="button"], input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button;
-  cursor: pointer; }
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; cursor: pointer; }
 
-button[disabled],
-html input[disabled] {
-  cursor: default; }
+button[disabled], html input[disabled] { cursor: default; }
 
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0; }
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-input {
-  line-height: normal; }
+input { line-height: normal; }
 
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box;
-  padding: 0; }
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; padding: 0; }
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto; }
+input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-outer-spin-button { height: auto; }
 
-input[type="search"] {
-  -webkit-appearance: textfield;
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  box-sizing: content-box; }
+input[type="search"] { -webkit-appearance: textfield; -moz-box-sizing: content-box; -webkit-box-sizing: content-box; box-sizing: content-box; }
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none; }
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em; }
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-legend {
-  border: 0;
-  padding: 0; }
+legend { border: 0; padding: 0; }
 
-textarea {
-  overflow: auto; }
+textarea { overflow: auto; }
 
-optgroup {
-  font-weight: bold; }
+optgroup { font-weight: bold; }
 
-table {
-  border-collapse: collapse;
-  border-spacing: 0; }
+table { border-collapse: collapse; border-spacing: 0; }
 
-td,
-th {
-  padding: 0; }
+td, th { padding: 0; }
 
 /*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
-@media print {
-  *,
-  *:before,
-  *:after {
-    background: transparent !important;
-    color: #000 !important;
-    box-shadow: none !important;
-    text-shadow: none !important; }
-  a,
-  a:visited {
-    text-decoration: underline; }
-  a[href]:after {
-    content: " (" attr(href) ")"; }
-  abbr[title]:after {
-    content: " (" attr(title) ")"; }
-  a[href^="#"]:after,
-  a[href^="javascript:"]:after {
-    content: ""; }
-  pre,
-  blockquote {
-    border: 1px solid #999;
-    page-break-inside: avoid; }
-  thead {
-    display: table-header-group; }
-  tr,
-  img {
-    page-break-inside: avoid; }
-  img {
-    max-width: 100% !important; }
-  p,
-  h2,
-  h3 {
-    orphans: 3;
-    widows: 3; }
-  h2,
-  h3 {
-    page-break-after: avoid; }
-  select {
-    background: #fff !important; }
-  .navbar {
-    display: none; }
-  .btn > .caret,
-  .btn-ghost > .caret,
-  .dropup > .btn > .caret, .dropup > .btn-ghost > .caret {
-    border-top-color: #000 !important; }
-  .label {
-    border: 1px solid #000; }
-  .table {
-    border-collapse: collapse !important; }
-    .table td,
-    .table th {
-      background-color: #fff !important; }
-  .table-bordered th,
-  .table-bordered td {
-    border: 1px solid #ddd !important; } }
-
-@font-face {
-  font-family: 'Glyphicons Halflings';
-  src: url("bootstrap/glyphicons-halflings-regular.eot");
-  src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg"); }
-
-.glyphicon {
-  position: relative;
-  top: 1px;
-  display: inline-block;
-  font-family: 'Glyphicons Halflings';
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
-
-.glyphicon-asterisk:before {
-  content: "\2a"; }
-
-.glyphicon-plus:before {
-  content: "\2b"; }
-
-.glyphicon-euro:before,
-.glyphicon-eur:before {
-  content: "\20ac"; }
-
-.glyphicon-minus:before {
-  content: "\2212"; }
-
-.glyphicon-cloud:before {
-  content: "\2601"; }
-
-.glyphicon-envelope:before {
-  content: "\2709"; }
-
-.glyphicon-pencil:before {
-  content: "\270f"; }
-
-.glyphicon-glass:before {
-  content: "\e001"; }
-
-.glyphicon-music:before {
-  content: "\e002"; }
-
-.glyphicon-search:before {
-  content: "\e003"; }
+@media print { *, *:before, *:after { background: transparent !important; color: #000 !important; box-shadow: none !important; text-shadow: none !important; }
+  a, a:visited { text-decoration: underline; }
+  a[href]:after { content: " (" attr(href) ")"; }
+  abbr[title]:after { content: " (" attr(title) ")"; }
+  a[href^="#"]:after, a[href^="javascript:"]:after { content: ""; }
+  pre, blockquote { border: 1px solid #999; page-break-inside: avoid; }
+  thead { display: table-header-group; }
+  tr, img { page-break-inside: avoid; }
+  img { max-width: 100% !important; }
+  p, h2, h3 { orphans: 3; widows: 3; }
+  h2, h3 { page-break-after: avoid; }
+  select { background: #fff !important; }
+  .navbar { display: none; }
+  .btn > .caret, .btn-ghost > .caret, .dropup > .btn > .caret, .dropup > .btn-ghost > .caret { border-top-color: #000 !important; }
+  .label { border: 1px solid #000; }
+  .table { border-collapse: collapse !important; }
+  .table td, .table th { background-color: #fff !important; }
+  .table-bordered th, .table-bordered td { border: 1px solid #ddd !important; } }
 
-.glyphicon-heart:before {
-  content: "\e005"; }
+@font-face { font-family: 'Glyphicons Halflings'; src: url("bootstrap/glyphicons-halflings-regular.eot"); src: url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg"); }
 
-.glyphicon-star:before {
-  content: "\e006"; }
+.glyphicon { position: relative; top: 1px; display: inline-block; font-family: 'Glyphicons Halflings'; font-style: normal; font-weight: normal; line-height: 1; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
-.glyphicon-star-empty:before {
-  content: "\e007"; }
+.glyphicon-asterisk:before { content: "\2a"; }
 
-.glyphicon-user:before {
-  content: "\e008"; }
+.glyphicon-plus:before { content: "\2b"; }
 
-.glyphicon-film:before {
-  content: "\e009"; }
+.glyphicon-euro:before, .glyphicon-eur:before { content: "\20ac"; }
 
-.glyphicon-th-large:before {
-  content: "\e010"; }
+.glyphicon-minus:before { content: "\2212"; }
 
-.glyphicon-th:before {
-  content: "\e011"; }
+.glyphicon-cloud:before { content: "\2601"; }
 
-.glyphicon-th-list:before {
-  content: "\e012"; }
+.glyphicon-envelope:before { content: "\2709"; }
 
-.glyphicon-ok:before {
-  content: "\e013"; }
+.glyphicon-pencil:before { content: "\270f"; }
 
-.glyphicon-remove:before {
-  content: "\e014"; }
+.glyphicon-glass:before { content: "\e001"; }
 
-.glyphicon-zoom-in:before {
-  content: "\e015"; }
+.glyphicon-music:before { content: "\e002"; }
 
-.glyphicon-zoom-out:before {
-  content: "\e016"; }
+.glyphicon-search:before { content: "\e003"; }
 
-.glyphicon-off:before {
-  content: "\e017"; }
+.glyphicon-heart:before { content: "\e005"; }
 
-.glyphicon-signal:before {
-  content: "\e018"; }
+.glyphicon-star:before { content: "\e006"; }
 
-.glyphicon-cog:before {
-  content: "\e019"; }
+.glyphicon-star-empty:before { content: "\e007"; }
 
-.glyphicon-trash:before {
-  content: "\e020"; }
+.glyphicon-user:before { content: "\e008"; }
 
-.glyphicon-home:before {
-  content: "\e021"; }
+.glyphicon-film:before { content: "\e009"; }
 
-.glyphicon-file:before {
-  content: "\e022"; }
+.glyphicon-th-large:before { content: "\e010"; }
 
-.glyphicon-time:before {
-  content: "\e023"; }
+.glyphicon-th:before { content: "\e011"; }
 
-.glyphicon-road:before {
-  content: "\e024"; }
+.glyphicon-th-list:before { content: "\e012"; }
 
-.glyphicon-download-alt:before {
-  content: "\e025"; }
+.glyphicon-ok:before { content: "\e013"; }
 
-.glyphicon-download:before {
-  content: "\e026"; }
+.glyphicon-remove:before { content: "\e014"; }
 
-.glyphicon-upload:before {
-  content: "\e027"; }
+.glyphicon-zoom-in:before { content: "\e015"; }
 
-.glyphicon-inbox:before {
-  content: "\e028"; }
+.glyphicon-zoom-out:before { content: "\e016"; }
 
-.glyphicon-play-circle:before {
-  content: "\e029"; }
+.glyphicon-off:before { content: "\e017"; }
 
-.glyphicon-repeat:before {
-  content: "\e030"; }
+.glyphicon-signal:before { content: "\e018"; }
 
-.glyphicon-refresh:before {
-  content: "\e031"; }
+.glyphicon-cog:before { content: "\e019"; }
 
-.glyphicon-list-alt:before {
-  content: "\e032"; }
+.glyphicon-trash:before { content: "\e020"; }
 
-.glyphicon-lock:before {
-  content: "\e033"; }
+.glyphicon-home:before { content: "\e021"; }
 
-.glyphicon-flag:before {
-  content: "\e034"; }
+.glyphicon-file:before { content: "\e022"; }
 
-.glyphicon-headphones:before {
-  content: "\e035"; }
+.glyphicon-time:before { content: "\e023"; }
 
-.glyphicon-volume-off:before {
-  content: "\e036"; }
+.glyphicon-road:before { content: "\e024"; }
 
-.glyphicon-volume-down:before {
-  content: "\e037"; }
+.glyphicon-download-alt:before { content: "\e025"; }
 
-.glyphicon-volume-up:before {
-  content: "\e038"; }
+.glyphicon-download:before { content: "\e026"; }
 
-.glyphicon-qrcode:before {
-  content: "\e039"; }
+.glyphicon-upload:before { content: "\e027"; }
 
-.glyphicon-barcode:before {
-  content: "\e040"; }
+.glyphicon-inbox:before { content: "\e028"; }
 
-.glyphicon-tag:before {
-  content: "\e041"; }
+.glyphicon-play-circle:before { content: "\e029"; }
 
-.glyphicon-tags:before {
-  content: "\e042"; }
+.glyphicon-repeat:before { content: "\e030"; }
 
-.glyphicon-book:before {
-  content: "\e043"; }
+.glyphicon-refresh:before { content: "\e031"; }
 
-.glyphicon-bookmark:before {
-  content: "\e044"; }
+.glyphicon-list-alt:before { content: "\e032"; }
 
-.glyphicon-print:before {
-  content: "\e045"; }
+.glyphicon-lock:before { content: "\e033"; }
 
-.glyphicon-camera:before {
-  content: "\e046"; }
+.glyphicon-flag:before { content: "\e034"; }
 
-.glyphicon-font:before {
-  content: "\e047"; }
+.glyphicon-headphones:before { content: "\e035"; }
 
-.glyphicon-bold:before {
-  content: "\e048"; }
+.glyphicon-volume-off:before { content: "\e036"; }
 
-.glyphicon-italic:before {
-  content: "\e049"; }
+.glyphicon-volume-down:before { content: "\e037"; }
 
-.glyphicon-text-height:before {
-  content: "\e050"; }
+.glyphicon-volume-up:before { content: "\e038"; }
 
-.glyphicon-text-width:before {
-  content: "\e051"; }
+.glyphicon-qrcode:before { content: "\e039"; }
 
-.glyphicon-align-left:before {
-  content: "\e052"; }
+.glyphicon-barcode:before { content: "\e040"; }
 
-.glyphicon-align-center:before {
-  content: "\e053"; }
+.glyphicon-tag:before { content: "\e041"; }
 
-.glyphicon-align-right:before {
-  content: "\e054"; }
+.glyphicon-tags:before { content: "\e042"; }
 
-.glyphicon-align-justify:before {
-  content: "\e055"; }
+.glyphicon-book:before { content: "\e043"; }
 
-.glyphicon-list:before {
-  content: "\e056"; }
+.glyphicon-bookmark:before { content: "\e044"; }
 
-.glyphicon-indent-left:before {
-  content: "\e057"; }
+.glyphicon-print:before { content: "\e045"; }
 
-.glyphicon-indent-right:before {
-  content: "\e058"; }
+.glyphicon-camera:before { content: "\e046"; }
 
-.glyphicon-facetime-video:before {
-  content: "\e059"; }
+.glyphicon-font:before { content: "\e047"; }
 
-.glyphicon-picture:before {
-  content: "\e060"; }
+.glyphicon-bold:before { content: "\e048"; }
 
-.glyphicon-map-marker:before {
-  content: "\e062"; }
+.glyphicon-italic:before { content: "\e049"; }
 
-.glyphicon-adjust:before {
-  content: "\e063"; }
+.glyphicon-text-height:before { content: "\e050"; }
 
-.glyphicon-tint:before {
-  content: "\e064"; }
+.glyphicon-text-width:before { content: "\e051"; }
 
-.glyphicon-edit:before {
-  content: "\e065"; }
+.glyphicon-align-left:before { content: "\e052"; }
 
-.glyphicon-share:before {
-  content: "\e066"; }
+.glyphicon-align-center:before { content: "\e053"; }
 
-.glyphicon-check:before {
-  content: "\e067"; }
+.glyphicon-align-right:before { content: "\e054"; }
 
-.glyphicon-move:before {
-  content: "\e068"; }
+.glyphicon-align-justify:before { content: "\e055"; }
 
-.glyphicon-step-backward:before {
-  content: "\e069"; }
+.glyphicon-list:before { content: "\e056"; }
 
-.glyphicon-fast-backward:before {
-  content: "\e070"; }
+.glyphicon-indent-left:before { content: "\e057"; }
 
-.glyphicon-backward:before {
-  content: "\e071"; }
+.glyphicon-indent-right:before { content: "\e058"; }
 
-.glyphicon-play:before {
-  content: "\e072"; }
+.glyphicon-facetime-video:before { content: "\e059"; }
 
-.glyphicon-pause:before {
-  content: "\e073"; }
+.glyphicon-picture:before { content: "\e060"; }
 
-.glyphicon-stop:before {
-  content: "\e074"; }
+.glyphicon-map-marker:before { content: "\e062"; }
 
-.glyphicon-forward:before {
-  content: "\e075"; }
+.glyphicon-adjust:before { content: "\e063"; }
 
-.glyphicon-fast-forward:before {
-  content: "\e076"; }
+.glyphicon-tint:before { content: "\e064"; }
 
-.glyphicon-step-forward:before {
-  content: "\e077"; }
+.glyphicon-edit:before { content: "\e065"; }
 
-.glyphicon-eject:before {
-  content: "\e078"; }
+.glyphicon-share:before { content: "\e066"; }
 
-.glyphicon-chevron-left:before {
-  content: "\e079"; }
+.glyphicon-check:before { content: "\e067"; }
 
-.glyphicon-chevron-right:before {
-  content: "\e080"; }
+.glyphicon-move:before { content: "\e068"; }
 
-.glyphicon-plus-sign:before {
-  content: "\e081"; }
+.glyphicon-step-backward:before { content: "\e069"; }
 
-.glyphicon-minus-sign:before {
-  content: "\e082"; }
+.glyphicon-fast-backward:before { content: "\e070"; }
 
-.glyphicon-remove-sign:before {
-  content: "\e083"; }
+.glyphicon-backward:before { content: "\e071"; }
 
-.glyphicon-ok-sign:before {
-  content: "\e084"; }
+.glyphicon-play:before { content: "\e072"; }
 
-.glyphicon-question-sign:before {
-  content: "\e085"; }
+.glyphicon-pause:before { content: "\e073"; }
 
-.glyphicon-info-sign:before {
-  content: "\e086"; }
+.glyphicon-stop:before { content: "\e074"; }
 
-.glyphicon-screenshot:before {
-  content: "\e087"; }
+.glyphicon-forward:before { content: "\e075"; }
 
-.glyphicon-remove-circle:before {
-  content: "\e088"; }
+.glyphicon-fast-forward:before { content: "\e076"; }
 
-.glyphicon-ok-circle:before {
-  content: "\e089"; }
+.glyphicon-step-forward:before { content: "\e077"; }
 
-.glyphicon-ban-circle:before {
-  content: "\e090"; }
+.glyphicon-eject:before { content: "\e078"; }
 
-.glyphicon-arrow-left:before {
-  content: "\e091"; }
+.glyphicon-chevron-left:before { content: "\e079"; }
 
-.glyphicon-arrow-right:before {
-  content: "\e092"; }
+.glyphicon-chevron-right:before { content: "\e080"; }
 
-.glyphicon-arrow-up:before {
-  content: "\e093"; }
+.glyphicon-plus-sign:before { content: "\e081"; }
 
-.glyphicon-arrow-down:before {
-  content: "\e094"; }
+.glyphicon-minus-sign:before { content: "\e082"; }
 
-.glyphicon-share-alt:before {
-  content: "\e095"; }
+.glyphicon-remove-sign:before { content: "\e083"; }
 
-.glyphicon-resize-full:before {
-  content: "\e096"; }
+.glyphicon-ok-sign:before { content: "\e084"; }
 
-.glyphicon-resize-small:before {
-  content: "\e097"; }
+.glyphicon-question-sign:before { content: "\e085"; }
 
-.glyphicon-exclamation-sign:before {
-  content: "\e101"; }
+.glyphicon-info-sign:before { content: "\e086"; }
 
-.glyphicon-gift:before {
-  content: "\e102"; }
+.glyphicon-screenshot:before { content: "\e087"; }
 
-.glyphicon-leaf:before {
-  content: "\e103"; }
+.glyphicon-remove-circle:before { content: "\e088"; }
 
-.glyphicon-fire:before {
-  content: "\e104"; }
+.glyphicon-ok-circle:before { content: "\e089"; }
 
-.glyphicon-eye-open:before {
-  content: "\e105"; }
+.glyphicon-ban-circle:before { content: "\e090"; }
 
-.glyphicon-eye-close:before {
-  content: "\e106"; }
+.glyphicon-arrow-left:before { content: "\e091"; }
 
-.glyphicon-warning-sign:before {
-  content: "\e107"; }
+.glyphicon-arrow-right:before { content: "\e092"; }
 
-.glyphicon-plane:before {
-  content: "\e108"; }
+.glyphicon-arrow-up:before { content: "\e093"; }
 
-.glyphicon-calendar:before {
-  content: "\e109"; }
+.glyphicon-arrow-down:before { content: "\e094"; }
 
-.glyphicon-random:before {
-  content: "\e110"; }
+.glyphicon-share-alt:before { content: "\e095"; }
 
-.glyphicon-comment:before {
-  content: "\e111"; }
+.glyphicon-resize-full:before { content: "\e096"; }
 
-.glyphicon-magnet:before {
-  content: "\e112"; }
+.glyphicon-resize-small:before { content: "\e097"; }
 
-.glyphicon-chevron-up:before {
-  content: "\e113"; }
+.glyphicon-exclamation-sign:before { content: "\e101"; }
 
-.glyphicon-chevron-down:before {
-  content: "\e114"; }
+.glyphicon-gift:before { content: "\e102"; }
 
-.glyphicon-retweet:before {
-  content: "\e115"; }
+.glyphicon-leaf:before { content: "\e103"; }
 
-.glyphicon-shopping-cart:before {
-  content: "\e116"; }
+.glyphicon-fire:before { content: "\e104"; }
 
-.glyphicon-folder-close:before {
-  content: "\e117"; }
+.glyphicon-eye-open:before { content: "\e105"; }
 
-.glyphicon-folder-open:before {
-  content: "\e118"; }
+.glyphicon-eye-close:before { content: "\e106"; }
 
-.glyphicon-resize-vertical:before {
-  content: "\e119"; }
+.glyphicon-warning-sign:before { content: "\e107"; }
 
-.glyphicon-resize-horizontal:before {
-  content: "\e120"; }
+.glyphicon-plane:before { content: "\e108"; }
 
-.glyphicon-hdd:before {
-  content: "\e121"; }
+.glyphicon-calendar:before { content: "\e109"; }
 
-.glyphicon-bullhorn:before {
-  content: "\e122"; }
+.glyphicon-random:before { content: "\e110"; }
 
-.glyphicon-bell:before {
-  content: "\e123"; }
+.glyphicon-comment:before { content: "\e111"; }
 
-.glyphicon-certificate:before {
-  content: "\e124"; }
+.glyphicon-magnet:before { content: "\e112"; }
 
-.glyphicon-thumbs-up:before {
-  content: "\e125"; }
+.glyphicon-chevron-up:before { content: "\e113"; }
 
-.glyphicon-thumbs-down:before {
-  content: "\e126"; }
+.glyphicon-chevron-down:before { content: "\e114"; }
 
-.glyphicon-hand-right:before {
-  content: "\e127"; }
+.glyphicon-retweet:before { content: "\e115"; }
 
-.glyphicon-hand-left:before {
-  content: "\e128"; }
+.glyphicon-shopping-cart:before { content: "\e116"; }
 
-.glyphicon-hand-up:before {
-  content: "\e129"; }
+.glyphicon-folder-close:before { content: "\e117"; }
 
-.glyphicon-hand-down:before {
-  content: "\e130"; }
+.glyphicon-folder-open:before { content: "\e118"; }
 
-.glyphicon-circle-arrow-right:before {
-  content: "\e131"; }
+.glyphicon-resize-vertical:before { content: "\e119"; }
 
-.glyphicon-circle-arrow-left:before {
-  content: "\e132"; }
+.glyphicon-resize-horizontal:before { content: "\e120"; }
 
-.glyphicon-circle-arrow-up:before {
-  content: "\e133"; }
+.glyphicon-hdd:before { content: "\e121"; }
 
-.glyphicon-circle-arrow-down:before {
-  content: "\e134"; }
+.glyphicon-bullhorn:before { content: "\e122"; }
 
-.glyphicon-globe:before {
-  content: "\e135"; }
+.glyphicon-bell:before { content: "\e123"; }
 
-.glyphicon-wrench:before {
-  content: "\e136"; }
+.glyphicon-certificate:before { content: "\e124"; }
 
-.glyphicon-tasks:before {
-  content: "\e137"; }
+.glyphicon-thumbs-up:before { content: "\e125"; }
 
-.glyphicon-filter:before {
-  content: "\e138"; }
+.glyphicon-thumbs-down:before { content: "\e126"; }
 
-.glyphicon-briefcase:before {
-  content: "\e139"; }
+.glyphicon-hand-right:before { content: "\e127"; }
 
-.glyphicon-fullscreen:before {
-  content: "\e140"; }
+.glyphicon-hand-left:before { content: "\e128"; }
 
-.glyphicon-dashboard:before {
-  content: "\e141"; }
+.glyphicon-hand-up:before { content: "\e129"; }
 
-.glyphicon-paperclip:before {
-  content: "\e142"; }
+.glyphicon-hand-down:before { content: "\e130"; }
 
-.glyphicon-heart-empty:before {
-  content: "\e143"; }
+.glyphicon-circle-arrow-right:before { content: "\e131"; }
 
-.glyphicon-link:before {
-  content: "\e144"; }
+.glyphicon-circle-arrow-left:before { content: "\e132"; }
 
-.glyphicon-phone:before {
-  content: "\e145"; }
+.glyphicon-circle-arrow-up:before { content: "\e133"; }
 
-.glyphicon-pushpin:before {
-  content: "\e146"; }
+.glyphicon-circle-arrow-down:before { content: "\e134"; }
 
-.glyphicon-usd:before {
-  content: "\e148"; }
+.glyphicon-globe:before { content: "\e135"; }
 
-.glyphicon-gbp:before {
-  content: "\e149"; }
+.glyphicon-wrench:before { content: "\e136"; }
 
-.glyphicon-sort:before {
-  content: "\e150"; }
+.glyphicon-tasks:before { content: "\e137"; }
 
-.glyphicon-sort-by-alphabet:before {
-  content: "\e151"; }
+.glyphicon-filter:before { content: "\e138"; }
 
-.glyphicon-sort-by-alphabet-alt:before {
-  content: "\e152"; }
+.glyphicon-briefcase:before { content: "\e139"; }
 
-.glyphicon-sort-by-order:before {
-  content: "\e153"; }
+.glyphicon-fullscreen:before { content: "\e140"; }
 
-.glyphicon-sort-by-order-alt:before {
-  content: "\e154"; }
+.glyphicon-dashboard:before { content: "\e141"; }
 
-.glyphicon-sort-by-attributes:before {
-  content: "\e155"; }
+.glyphicon-paperclip:before { content: "\e142"; }
 
-.glyphicon-sort-by-attributes-alt:before {
-  content: "\e156"; }
+.glyphicon-heart-empty:before { content: "\e143"; }
 
-.glyphicon-unchecked:before {
-  content: "\e157"; }
+.glyphicon-link:before { content: "\e144"; }
 
-.glyphicon-expand:before {
-  content: "\e158"; }
+.glyphicon-phone:before { content: "\e145"; }
 
-.glyphicon-collapse-down:before {
-  content: "\e159"; }
+.glyphicon-pushpin:before { content: "\e146"; }
 
-.glyphicon-collapse-up:before {
-  content: "\e160"; }
+.glyphicon-usd:before { content: "\e148"; }
 
-.glyphicon-log-in:before {
-  content: "\e161"; }
+.glyphicon-gbp:before { content: "\e149"; }
 
-.glyphicon-flash:before {
-  content: "\e162"; }
+.glyphicon-sort:before { content: "\e150"; }
 
-.glyphicon-log-out:before {
-  content: "\e163"; }
+.glyphicon-sort-by-alphabet:before { content: "\e151"; }
 
-.glyphicon-new-window:before {
-  content: "\e164"; }
+.glyphicon-sort-by-alphabet-alt:before { content: "\e152"; }
 
-.glyphicon-record:before {
-  content: "\e165"; }
+.glyphicon-sort-by-order:before { content: "\e153"; }
 
-.glyphicon-save:before {
-  content: "\e166"; }
+.glyphicon-sort-by-order-alt:before { content: "\e154"; }
 
-.glyphicon-open:before {
-  content: "\e167"; }
+.glyphicon-sort-by-attributes:before { content: "\e155"; }
 
-.glyphicon-saved:before {
-  content: "\e168"; }
+.glyphicon-sort-by-attributes-alt:before { content: "\e156"; }
 
-.glyphicon-import:before {
-  content: "\e169"; }
+.glyphicon-unchecked:before { content: "\e157"; }
 
-.glyphicon-export:before {
-  content: "\e170"; }
+.glyphicon-expand:before { content: "\e158"; }
 
-.glyphicon-send:before {
-  content: "\e171"; }
+.glyphicon-collapse-down:before { content: "\e159"; }
 
-.glyphicon-floppy-disk:before {
-  content: "\e172"; }
+.glyphicon-collapse-up:before { content: "\e160"; }
 
-.glyphicon-floppy-saved:before {
-  content: "\e173"; }
+.glyphicon-log-in:before { content: "\e161"; }
 
-.glyphicon-floppy-remove:before {
-  content: "\e174"; }
+.glyphicon-flash:before { content: "\e162"; }
 
-.glyphicon-floppy-save:before {
-  content: "\e175"; }
+.glyphicon-log-out:before { content: "\e163"; }
 
-.glyphicon-floppy-open:before {
-  content: "\e176"; }
+.glyphicon-new-window:before { content: "\e164"; }
 
-.glyphicon-credit-card:before {
-  content: "\e177"; }
+.glyphicon-record:before { content: "\e165"; }
 
-.glyphicon-transfer:before {
-  content: "\e178"; }
+.glyphicon-save:before { content: "\e166"; }
 
-.glyphicon-cutlery:before {
-  content: "\e179"; }
+.glyphicon-open:before { content: "\e167"; }
 
-.glyphicon-header:before {
-  content: "\e180"; }
+.glyphicon-saved:before { content: "\e168"; }
 
-.glyphicon-compressed:before {
-  content: "\e181"; }
+.glyphicon-import:before { content: "\e169"; }
 
-.glyphicon-earphone:before {
-  content: "\e182"; }
+.glyphicon-export:before { content: "\e170"; }
 
-.glyphicon-phone-alt:before {
-  content: "\e183"; }
+.glyphicon-send:before { content: "\e171"; }
 
-.glyphicon-tower:before {
-  content: "\e184"; }
+.glyphicon-floppy-disk:before { content: "\e172"; }
 
-.glyphicon-stats:before {
-  content: "\e185"; }
+.glyphicon-floppy-saved:before { content: "\e173"; }
 
-.glyphicon-sd-video:before {
-  content: "\e186"; }
+.glyphicon-floppy-remove:before { content: "\e174"; }
 
-.glyphicon-hd-video:before {
-  content: "\e187"; }
+.glyphicon-floppy-save:before { content: "\e175"; }
 
-.glyphicon-subtitles:before {
-  content: "\e188"; }
+.glyphicon-floppy-open:before { content: "\e176"; }
 
-.glyphicon-sound-stereo:before {
-  content: "\e189"; }
+.glyphicon-credit-card:before { content: "\e177"; }
 
-.glyphicon-sound-dolby:before {
-  content: "\e190"; }
+.glyphicon-transfer:before { content: "\e178"; }
 
-.glyphicon-sound-5-1:before {
-  content: "\e191"; }
+.glyphicon-cutlery:before { content: "\e179"; }
 
-.glyphicon-sound-6-1:before {
-  content: "\e192"; }
+.glyphicon-header:before { content: "\e180"; }
 
-.glyphicon-sound-7-1:before {
-  content: "\e193"; }
+.glyphicon-compressed:before { content: "\e181"; }
 
-.glyphicon-copyright-mark:before {
-  content: "\e194"; }
+.glyphicon-earphone:before { content: "\e182"; }
 
-.glyphicon-registration-mark:before {
-  content: "\e195"; }
+.glyphicon-phone-alt:before { content: "\e183"; }
 
-.glyphicon-cloud-download:before {
-  content: "\e197"; }
+.glyphicon-tower:before { content: "\e184"; }
 
-.glyphicon-cloud-upload:before {
-  content: "\e198"; }
+.glyphicon-stats:before { content: "\e185"; }
 
-.glyphicon-tree-conifer:before {
-  content: "\e199"; }
+.glyphicon-sd-video:before { content: "\e186"; }
 
-.glyphicon-tree-deciduous:before {
-  content: "\e200"; }
+.glyphicon-hd-video:before { content: "\e187"; }
 
-.glyphicon-cd:before {
-  content: "\e201"; }
+.glyphicon-subtitles:before { content: "\e188"; }
 
-.glyphicon-save-file:before {
-  content: "\e202"; }
+.glyphicon-sound-stereo:before { content: "\e189"; }
 
-.glyphicon-open-file:before {
-  content: "\e203"; }
+.glyphicon-sound-dolby:before { content: "\e190"; }
 
-.glyphicon-level-up:before {
-  content: "\e204"; }
+.glyphicon-sound-5-1:before { content: "\e191"; }
 
-.glyphicon-copy:before {
-  content: "\e205"; }
+.glyphicon-sound-6-1:before { content: "\e192"; }
 
-.glyphicon-paste:before {
-  content: "\e206"; }
+.glyphicon-sound-7-1:before { content: "\e193"; }
 
-.glyphicon-alert:before {
-  content: "\e209"; }
+.glyphicon-copyright-mark:before { content: "\e194"; }
 
-.glyphicon-equalizer:before {
-  content: "\e210"; }
+.glyphicon-registration-mark:before { content: "\e195"; }
 
-.glyphicon-king:before {
-  content: "\e211"; }
+.glyphicon-cloud-download:before { content: "\e197"; }
 
-.glyphicon-queen:before {
-  content: "\e212"; }
+.glyphicon-cloud-upload:before { content: "\e198"; }
 
-.glyphicon-pawn:before {
-  content: "\e213"; }
+.glyphicon-tree-conifer:before { content: "\e199"; }
 
-.glyphicon-bishop:before {
-  content: "\e214"; }
+.glyphicon-tree-deciduous:before { content: "\e200"; }
 
-.glyphicon-knight:before {
-  content: "\e215"; }
+.glyphicon-cd:before { content: "\e201"; }
 
-.glyphicon-baby-formula:before {
-  content: "\e216"; }
+.glyphicon-save-file:before { content: "\e202"; }
 
-.glyphicon-tent:before {
-  content: "\26fa"; }
+.glyphicon-open-file:before { content: "\e203"; }
 
-.glyphicon-blackboard:before {
-  content: "\e218"; }
+.glyphicon-level-up:before { content: "\e204"; }
 
-.glyphicon-bed:before {
-  content: "\e219"; }
+.glyphicon-copy:before { content: "\e205"; }
 
-.glyphicon-apple:before {
-  content: "\f8ff"; }
+.glyphicon-paste:before { content: "\e206"; }
 
-.glyphicon-erase:before {
-  content: "\e221"; }
+.glyphicon-alert:before { content: "\e209"; }
 
-.glyphicon-hourglass:before {
-  content: "\231b"; }
+.glyphicon-equalizer:before { content: "\e210"; }
 
-.glyphicon-lamp:before {
-  content: "\e223"; }
+.glyphicon-king:before { content: "\e211"; }
 
-.glyphicon-duplicate:before {
-  content: "\e224"; }
+.glyphicon-queen:before { content: "\e212"; }
 
-.glyphicon-piggy-bank:before {
-  content: "\e225"; }
+.glyphicon-pawn:before { content: "\e213"; }
 
-.glyphicon-scissors:before {
-  content: "\e226"; }
+.glyphicon-bishop:before { content: "\e214"; }
 
-.glyphicon-bitcoin:before {
-  content: "\e227"; }
+.glyphicon-knight:before { content: "\e215"; }
 
-.glyphicon-btc:before {
-  content: "\e227"; }
+.glyphicon-baby-formula:before { content: "\e216"; }
 
-.glyphicon-xbt:before {
-  content: "\e227"; }
+.glyphicon-tent:before { content: "\26fa"; }
 
-.glyphicon-yen:before {
-  content: "\00a5"; }
+.glyphicon-blackboard:before { content: "\e218"; }
 
-.glyphicon-jpy:before {
-  content: "\00a5"; }
+.glyphicon-bed:before { content: "\e219"; }
 
-.glyphicon-ruble:before {
-  content: "\20bd"; }
+.glyphicon-apple:before { content: "\f8ff"; }
 
-.glyphicon-rub:before {
-  content: "\20bd"; }
+.glyphicon-erase:before { content: "\e221"; }
 
-.glyphicon-scale:before {
-  content: "\e230"; }
+.glyphicon-hourglass:before { content: "\231b"; }
 
-.glyphicon-ice-lolly:before {
-  content: "\e231"; }
+.glyphicon-lamp:before { content: "\e223"; }
 
-.glyphicon-ice-lolly-tasted:before {
-  content: "\e232"; }
+.glyphicon-duplicate:before { content: "\e224"; }
 
-.glyphicon-education:before {
-  content: "\e233"; }
+.glyphicon-piggy-bank:before { content: "\e225"; }
 
-.glyphicon-option-horizontal:before {
-  content: "\e234"; }
+.glyphicon-scissors:before { content: "\e226"; }
 
-.glyphicon-option-vertical:before {
-  content: "\e235"; }
+.glyphicon-bitcoin:before { content: "\e227"; }
 
-.glyphicon-menu-hamburger:before {
-  content: "\e236"; }
+.glyphicon-btc:before { content: "\e227"; }
 
-.glyphicon-modal-window:before {
-  content: "\e237"; }
+.glyphicon-xbt:before { content: "\e227"; }
 
-.glyphicon-oil:before {
-  content: "\e238"; }
+.glyphicon-yen:before { content: "\00a5"; }
 
-.glyphicon-grain:before {
-  content: "\e239"; }
+.glyphicon-jpy:before { content: "\00a5"; }
 
-.glyphicon-sunglasses:before {
-  content: "\e240"; }
+.glyphicon-ruble:before { content: "\20bd"; }
 
-.glyphicon-text-size:before {
-  content: "\e241"; }
+.glyphicon-rub:before { content: "\20bd"; }
 
-.glyphicon-text-color:before {
-  content: "\e242"; }
+.glyphicon-scale:before { content: "\e230"; }
 
-.glyphicon-text-background:before {
-  content: "\e243"; }
+.glyphicon-ice-lolly:before { content: "\e231"; }
 
-.glyphicon-object-align-top:before {
-  content: "\e244"; }
+.glyphicon-ice-lolly-tasted:before { content: "\e232"; }
 
-.glyphicon-object-align-bottom:before {
-  content: "\e245"; }
+.glyphicon-education:before { content: "\e233"; }
 
-.glyphicon-object-align-horizontal:before {
-  content: "\e246"; }
+.glyphicon-option-horizontal:before { content: "\e234"; }
 
-.glyphicon-object-align-left:before {
-  content: "\e247"; }
+.glyphicon-option-vertical:before { content: "\e235"; }
 
-.glyphicon-object-align-vertical:before {
-  content: "\e248"; }
+.glyphicon-menu-hamburger:before { content: "\e236"; }
 
-.glyphicon-object-align-right:before {
-  content: "\e249"; }
+.glyphicon-modal-window:before { content: "\e237"; }
 
-.glyphicon-triangle-right:before {
-  content: "\e250"; }
+.glyphicon-oil:before { content: "\e238"; }
 
-.glyphicon-triangle-left:before {
-  content: "\e251"; }
+.glyphicon-grain:before { content: "\e239"; }
 
-.glyphicon-triangle-bottom:before {
-  content: "\e252"; }
+.glyphicon-sunglasses:before { content: "\e240"; }
 
-.glyphicon-triangle-top:before {
-  content: "\e253"; }
+.glyphicon-text-size:before { content: "\e241"; }
 
-.glyphicon-console:before {
-  content: "\e254"; }
+.glyphicon-text-color:before { content: "\e242"; }
 
-.glyphicon-superscript:before {
-  content: "\e255"; }
+.glyphicon-text-background:before { content: "\e243"; }
 
-.glyphicon-subscript:before {
-  content: "\e256"; }
+.glyphicon-object-align-top:before { content: "\e244"; }
 
-.glyphicon-menu-left:before {
-  content: "\e257"; }
+.glyphicon-object-align-bottom:before { content: "\e245"; }
 
-.glyphicon-menu-right:before {
-  content: "\e258"; }
+.glyphicon-object-align-horizontal:before { content: "\e246"; }
 
-.glyphicon-menu-down:before {
-  content: "\e259"; }
+.glyphicon-object-align-left:before { content: "\e247"; }
 
-.glyphicon-menu-up:before {
-  content: "\e260"; }
+.glyphicon-object-align-vertical:before { content: "\e248"; }
 
-* {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box; }
+.glyphicon-object-align-right:before { content: "\e249"; }
 
-*:before,
-*:after {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box; }
+.glyphicon-triangle-right:before { content: "\e250"; }
 
-html {
-  font-size: 10px;
-  -webkit-tap-highlight-color: transparent; }
+.glyphicon-triangle-left:before { content: "\e251"; }
 
-body {
-  font-family: "Source Sans Pro", Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.42857;
-  color: #666;
-  background-color: #fff; }
+.glyphicon-triangle-bottom:before { content: "\e252"; }
 
-input,
-button,
-select,
-textarea {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit; }
+.glyphicon-triangle-top:before { content: "\e253"; }
 
-a {
-  color: #2e88be;
-  text-decoration: none; }
-  a:hover,
-  a:focus {
-    color: #1f5c80;
-    text-decoration: underline; }
-  a:focus {
-    outline: thin dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px; }
+.glyphicon-console:before { content: "\e254"; }
 
-figure {
-  margin: 0; }
+.glyphicon-superscript:before { content: "\e255"; }
 
-img {
-  vertical-align: middle; }
+.glyphicon-subscript:before { content: "\e256"; }
 
-.img-responsive {
-  display: block;
-  max-width: 100%;
-  height: auto; }
+.glyphicon-menu-left:before { content: "\e257"; }
 
-.img-rounded {
-  border-radius: 6px; }
+.glyphicon-menu-right:before { content: "\e258"; }
 
-.img-thumbnail {
-  padding: 4px;
-  line-height: 1.42857;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  -webkit-transition: all 0.2s ease-in-out;
-  -o-transition: all 0.2s ease-in-out;
-  transition: all 0.2s ease-in-out;
-  display: inline-block;
-  max-width: 100%;
-  height: auto; }
+.glyphicon-menu-down:before { content: "\e259"; }
 
-.img-circle {
-  border-radius: 50%; }
+.glyphicon-menu-up:before { content: "\e260"; }
 
-hr {
-  margin-top: 20px;
-  margin-bottom: 20px;
-  border: 0;
-  border-top: 1px solid #eeeeee; }
+* { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0; }
+*:before, *:after { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
 
-.sr-only-focusable:active,
-.sr-only-focusable:focus {
-  position: static;
-  width: auto;
-  height: auto;
-  margin: 0;
-  overflow: visible;
-  clip: auto; }
+html { font-size: 10px; -webkit-tap-highlight-color: transparent; }
 
-[role="button"] {
-  cursor: pointer; }
+body { font-family: "Source Sans Pro", Arial, sans-serif; font-size: 14px; line-height: 1.42857; color: #666; background-color: #fff; }
 
-h1, h2, h3, h4, h5, h6,
-.h1, .h2, .h3, .h4, .h5, .h6 {
-  font-family: inherit;
-  font-weight: 500;
-  line-height: 1.1;
-  color: inherit; }
-  h1 small,
-  h1 .small, h2 small,
-  h2 .small, h3 small,
-  h3 .small, h4 small,
-  h4 .small, h5 small,
-  h5 .small, h6 small,
-  h6 .small,
-  .h1 small,
-  .h1 .small, .h2 small,
-  .h2 .small, .h3 small,
-  .h3 .small, .h4 small,
-  .h4 .small, .h5 small,
-  .h5 .small, .h6 small,
-  .h6 .small {
-    font-weight: normal;
-    line-height: 1;
-    color: #999999; }
+input, button, select, textarea { font-family: inherit; font-size: inherit; line-height: inherit; }
 
-h1, .h1,
-h2, .h2,
-h3, .h3 {
-  margin-top: 20px;
-  margin-bottom: 10px; }
-  h1 small,
-  h1 .small, .h1 small,
-  .h1 .small,
-  h2 small,
-  h2 .small, .h2 small,
-  .h2 .small,
-  h3 small,
-  h3 .small, .h3 small,
-  .h3 .small {
-    font-size: 65%; }
+a { color: #2e88be; text-decoration: none; }
 
-h4, .h4,
-h5, .h5,
-h6, .h6 {
-  margin-top: 10px;
-  margin-bottom: 10px; }
-  h4 small,
-  h4 .small, .h4 small,
-  .h4 .small,
-  h5 small,
-  h5 .small, .h5 small,
-  .h5 .small,
-  h6 small,
-  h6 .small, .h6 small,
-  .h6 .small {
-    font-size: 75%; }
+a:hover, a:focus { color: #1f5c80; text-decoration: underline; }
 
-h1, .h1 {
-  font-size: 28px; }
+a:focus { outline: thin dotted; outline: 5px auto -webkit-focus-ring-color; outline-offset: -2px; }
 
-h2, .h2 {
-  font-size: 30px; }
+figure { margin: 0; }
 
-h3, .h3 {
-  font-size: 24px; }
+img { vertical-align: middle; }
 
-h4, .h4 {
-  font-size: 18px; }
+.img-responsive { display: block; max-width: 100%; height: auto; }
 
-h5, .h5 {
-  font-size: 14px; }
+.img-rounded { border-radius: 6px; }
 
-h6, .h6 {
-  font-size: 12px; }
+.img-thumbnail { padding: 4px; line-height: 1.42857; background-color: #fff; border: 1px solid #ddd; border-radius: 4px; -webkit-transition: all 0.2s ease-in-out; -o-transition: all 0.2s ease-in-out; transition: all 0.2s ease-in-out; display: inline-block; max-width: 100%; height: auto; }
 
-p {
-  margin: 0 0 10px; }
+.img-circle { border-radius: 50%; }
 
-.lead {
-  margin-bottom: 20px;
-  font-size: 16px;
-  font-weight: 300;
-  line-height: 1.4; }
-  @media (min-width: 768px) {
-    .lead {
-      font-size: 21px; } }
+hr { margin-top: 20px; margin-bottom: 20px; border: 0; border-top: 1px solid #eeeeee; }
 
-small,
-.small {
-  font-size: 85%; }
+.sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); border: 0; }
 
-mark,
-.mark {
-  background-color: #fdfde9;
-  padding: .2em; }
+.sr-only-focusable:active, .sr-only-focusable:focus { position: static; width: auto; height: auto; margin: 0; overflow: visible; clip: auto; }
 
-.text-left {
-  text-align: left; }
+[role="button"] { cursor: pointer; }
 
-.text-right {
-  text-align: right; }
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 { font-family: inherit; font-weight: 500; line-height: 1.1; color: inherit; }
 
-.text-center {
-  text-align: center; }
+h1 small, h1 .small, h2 small, h2 .small, h3 small, h3 .small, h4 small, h4 .small, h5 small, h5 .small, h6 small, h6 .small, .h1 small, .h1 .small, .h2 small, .h2 .small, .h3 small, .h3 .small, .h4 small, .h4 .small, .h5 small, .h5 .small, .h6 small, .h6 .small { font-weight: normal; line-height: 1; color: #999999; }
 
-.text-justify {
-  text-align: justify; }
+h1, .h1, h2, .h2, h3, .h3 { margin-top: 20px; margin-bottom: 10px; }
 
-.text-nowrap {
-  white-space: nowrap; }
+h1 small, h1 .small, .h1 small, .h1 .small, h2 small, h2 .small, .h2 small, .h2 .small, h3 small, h3 .small, .h3 small, .h3 .small { font-size: 65%; }
 
-.text-lowercase {
-  text-transform: lowercase; }
+h4, .h4, h5, .h5, h6, .h6 { margin-top: 10px; margin-bottom: 10px; }
 
-.text-uppercase, .initialism {
-  text-transform: uppercase; }
+h4 small, h4 .small, .h4 small, .h4 .small, h5 small, h5 .small, .h5 small, .h5 .small, h6 small, h6 .small, .h6 small, .h6 .small { font-size: 75%; }
 
-.text-capitalize {
-  text-transform: capitalize; }
+h1, .h1 { font-size: 28px; }
 
-.text-muted {
-  color: #999999; }
+h2, .h2 { font-size: 30px; }
 
-.text-primary {
-  color: #f1f1f1; }
+h3, .h3 { font-size: 24px; }
 
-a.text-primary:hover {
-  color: #d7d7d7; }
+h4, .h4 { font-size: 18px; }
 
-.text-success {
-  color: #9bb83a; }
+h5, .h5 { font-size: 14px; }
 
-a.text-success:hover {
-  color: #7a912e; }
+h6, .h6 { font-size: 12px; }
 
-.text-info {
-  color: #389Bc9; }
+p { margin: 0 0 10px; }
 
-a.text-info:hover {
-  color: #2c7da2; }
+.lead { margin-bottom: 20px; font-size: 16px; font-weight: 300; line-height: 1.4; }
 
-.text-warning {
-  color: #e5d321; }
+@media (min-width: 768px) { .lead { font-size: 21px; } }
 
-a.text-warning:hover {
-  color: #bdae16; }
+small, .small { font-size: 85%; }
 
-.text-danger {
-  color: #e53221; }
+mark, .mark { background-color: #fdfde9; padding: .2em; }
 
-a.text-danger:hover {
-  color: #bd2516; }
+.text-left { text-align: left; }
 
-.bg-primary {
-  color: #fff; }
+.text-right { text-align: right; }
 
-.bg-primary {
-  background-color: #f1f1f1; }
+.text-center { text-align: center; }
 
-a.bg-primary:hover {
-  background-color: #d7d7d7; }
+.text-justify { text-align: justify; }
 
-.bg-success {
-  background-color: #f5f8eb; }
+.text-nowrap { white-space: nowrap; }
 
-a.bg-success:hover {
-  background-color: #e2ebc5; }
+.text-lowercase { text-transform: lowercase; }
 
-.bg-info {
-  background-color: #ebf5f9; }
+.text-uppercase, .initialism { text-transform: uppercase; }
 
-a.bg-info:hover {
-  background-color: #c4e1ed; }
+.text-capitalize { text-transform: capitalize; }
 
-.bg-warning {
-  background-color: #fdfde9; }
+.text-muted { color: #999999; }
 
-a.bg-warning:hover {
-  background-color: #f9f9ba; }
+.text-primary { color: #f1f1f1; }
 
-.bg-danger {
-  background-color: #fceae8; }
+a.text-primary:hover { color: #d7d7d7; }
 
-a.bg-danger:hover {
-  background-color: #f6c1bb; }
+.text-success { color: #9bb83a; }
 
-.page-header {
-  padding-bottom: 9px;
-  margin: 40px 0 20px;
-  border-bottom: 1px solid #eeeeee; }
+a.text-success:hover { color: #7a912e; }
 
-ul,
-ol {
-  margin-top: 0;
-  margin-bottom: 10px; }
-  ul ul,
-  ul ol,
-  ol ul,
-  ol ol {
-    margin-bottom: 0; }
+.text-info { color: #389Bc9; }
 
-.list-unstyled {
-  padding-left: 0;
-  list-style: none; }
+a.text-info:hover { color: #2c7da2; }
 
-.list-inline {
-  padding-left: 0;
-  list-style: none;
-  margin-left: -5px; }
-  .list-inline > li {
-    display: inline-block;
-    padding-left: 5px;
-    padding-right: 5px; }
+.text-warning { color: #e5d321; }
 
-dl {
-  margin-top: 0;
-  margin-bottom: 20px; }
+a.text-warning:hover { color: #bdae16; }
 
-dt,
-dd {
-  line-height: 1.42857; }
+.text-danger { color: #e53221; }
 
-dt {
-  font-weight: bold; }
+a.text-danger:hover { color: #bd2516; }
 
-dd {
-  margin-left: 0; }
+.bg-primary { color: #fff; }
 
-.dl-horizontal dd:before,
-.dl-horizontal dd:after {
-  content: " ";
-  display: table; }
+.bg-primary { background-color: #f1f1f1; }
 
-.dl-horizontal dd:after {
-  clear: both; }
+a.bg-primary:hover { background-color: #d7d7d7; }
 
-@media (min-width: 768px) {
-  .dl-horizontal dt {
-    float: left;
-    width: 160px;
-    clear: left;
-    text-align: right;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap; }
-  .dl-horizontal dd {
-    margin-left: 180px; } }
+.bg-success { background-color: #f5f8eb; }
 
-abbr[title],
-abbr[data-original-title] {
-  cursor: help;
-  border-bottom: 1px dotted #999999; }
+a.bg-success:hover { background-color: #e2ebc5; }
 
-.initialism {
-  font-size: 90%; }
+.bg-info { background-color: #ebf5f9; }
 
-blockquote {
-  padding: 10px 20px;
-  margin: 0 0 20px;
-  font-size: 17.5px;
-  border-left: 5px solid #eeeeee; }
-  blockquote p:last-child,
-  blockquote ul:last-child,
-  blockquote ol:last-child {
-    margin-bottom: 0; }
-  blockquote footer,
-  blockquote small,
-  blockquote .small {
-    display: block;
-    font-size: 80%;
-    line-height: 1.42857;
-    color: #999999; }
-    blockquote footer:before,
-    blockquote small:before,
-    blockquote .small:before {
-      content: '\2014 \00A0'; }
+a.bg-info:hover { background-color: #c4e1ed; }
 
-.blockquote-reverse,
-blockquote.pull-right {
-  padding-right: 15px;
-  padding-left: 0;
-  border-right: 5px solid #eeeeee;
-  border-left: 0;
-  text-align: right; }
-  .blockquote-reverse footer:before,
-  .blockquote-reverse small:before,
-  .blockquote-reverse .small:before,
-  blockquote.pull-right footer:before,
-  blockquote.pull-right small:before,
-  blockquote.pull-right .small:before {
-    content: ''; }
-  .blockquote-reverse footer:after,
-  .blockquote-reverse small:after,
-  .blockquote-reverse .small:after,
-  blockquote.pull-right footer:after,
-  blockquote.pull-right small:after,
-  blockquote.pull-right .small:after {
-    content: '\00A0 \2014'; }
+.bg-warning { background-color: #fdfde9; }
 
-address {
-  margin-bottom: 20px;
-  font-style: normal;
-  line-height: 1.42857; }
+a.bg-warning:hover { background-color: #f9f9ba; }
 
-code,
-kbd,
-pre,
-samp {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace; }
+.bg-danger { background-color: #fceae8; }
 
-code {
-  padding: 2px 4px;
-  font-size: 90%;
-  color: #c7254e;
-  background-color: #f9f2f4;
-  border-radius: 4px; }
+a.bg-danger:hover { background-color: #f6c1bb; }
 
-kbd {
-  padding: 2px 4px;
-  font-size: 90%;
-  color: #fff;
-  background-color: #333;
-  border-radius: 3px;
-  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25); }
-  kbd kbd {
-    padding: 0;
-    font-size: 100%;
-    font-weight: bold;
-    box-shadow: none; }
+.page-header { padding-bottom: 9px; margin: 40px 0 20px; border-bottom: 1px solid #eeeeee; }
 
-pre {
-  display: block;
-  padding: 9.5px;
-  margin: 0 0 10px;
-  font-size: 13px;
-  line-height: 1.42857;
-  word-break: break-all;
-  word-wrap: break-word;
-  color: #333333;
-  background-color: #f5f5f5;
-  border: 1px solid #ccc;
-  border-radius: 4px; }
-  pre code {
-    padding: 0;
-    font-size: inherit;
-    color: inherit;
-    white-space: pre-wrap;
-    background-color: transparent;
-    border-radius: 0; }
+ul, ol { margin-top: 0; margin-bottom: 10px; }
 
-.pre-scrollable {
-  max-height: 340px;
-  overflow-y: scroll; }
+ul ul, ul ol, ol ul, ol ol { margin-bottom: 0; }
 
-.container {
-  margin-right: auto;
-  margin-left: auto;
-  padding-left: 15px;
-  padding-right: 15px; }
-  .container:before,
-  .container:after {
-    content: " ";
-    display: table; }
-  .container:after {
-    clear: both; }
-  @media (min-width: 768px) {
-    .container {
-      width: 750px; } }
-  @media (min-width: 992px) {
-    .container {
-      width: 970px; } }
-  @media (min-width: 1200px) {
-    .container {
-      width: 1170px; } }
+.list-unstyled { padding-left: 0; list-style: none; }
 
-.container-fluid {
-  margin-right: auto;
-  margin-left: auto;
-  padding-left: 15px;
-  padding-right: 15px; }
-  .container-fluid:before,
-  .container-fluid:after {
-    content: " ";
-    display: table; }
-  .container-fluid:after {
-    clear: both; }
+.list-inline { padding-left: 0; list-style: none; margin-left: -5px; }
 
-.row {
-  margin-left: -15px;
-  margin-right: -15px; }
-  .row:before,
-  .row:after {
-    content: " ";
-    display: table; }
-  .row:after {
-    clear: both; }
+.list-inline > li { display: inline-block; padding-left: 5px; padding-right: 5px; }
 
-.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
-  position: relative;
-  min-height: 1px;
-  padding-left: 15px;
-  padding-right: 15px; }
+dl { margin-top: 0; margin-bottom: 20px; }
 
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
-  float: left; }
+dt, dd { line-height: 1.42857; }
 
-.col-xs-1 {
-  width: 8.33333%; }
+dt { font-weight: bold; }
 
-.col-xs-2 {
-  width: 16.66667%; }
+dd { margin-left: 0; }
 
-.col-xs-3 {
-  width: 25%; }
+.dl-horizontal dd:before, .dl-horizontal dd:after { content: " "; display: table; }
 
-.col-xs-4 {
-  width: 33.33333%; }
+.dl-horizontal dd:after { clear: both; }
 
-.col-xs-5 {
-  width: 41.66667%; }
+@media (min-width: 768px) { .dl-horizontal dt { float: left; width: 160px; clear: left; text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .dl-horizontal dd { margin-left: 180px; } }
 
-.col-xs-6 {
-  width: 50%; }
+abbr[title], abbr[data-original-title] { cursor: help; border-bottom: 1px dotted #999999; }
 
-.col-xs-7 {
-  width: 58.33333%; }
+.initialism { font-size: 90%; }
 
-.col-xs-8 {
-  width: 66.66667%; }
+blockquote { padding: 10px 20px; margin: 0 0 20px; font-size: 17.5px; border-left: 5px solid #eeeeee; }
 
-.col-xs-9 {
-  width: 75%; }
+blockquote p:last-child, blockquote ul:last-child, blockquote ol:last-child { margin-bottom: 0; }
 
-.col-xs-10 {
-  width: 83.33333%; }
+blockquote footer, blockquote small, blockquote .small { display: block; font-size: 80%; line-height: 1.42857; color: #999999; }
 
-.col-xs-11 {
-  width: 91.66667%; }
+blockquote footer:before, blockquote small:before, blockquote .small:before { content: '\2014 \00A0'; }
 
-.col-xs-12 {
-  width: 100%; }
+.blockquote-reverse, blockquote.pull-right { padding-right: 15px; padding-left: 0; border-right: 5px solid #eeeeee; border-left: 0; text-align: right; }
 
-.col-xs-pull-0 {
-  right: auto; }
+.blockquote-reverse footer:before, .blockquote-reverse small:before, .blockquote-reverse .small:before, blockquote.pull-right footer:before, blockquote.pull-right small:before, blockquote.pull-right .small:before { content: ''; }
 
-.col-xs-pull-1 {
-  right: 8.33333%; }
+.blockquote-reverse footer:after, .blockquote-reverse small:after, .blockquote-reverse .small:after, blockquote.pull-right footer:after, blockquote.pull-right small:after, blockquote.pull-right .small:after { content: '\00A0 \2014'; }
 
-.col-xs-pull-2 {
-  right: 16.66667%; }
+address { margin-bottom: 20px; font-style: normal; line-height: 1.42857; }
 
-.col-xs-pull-3 {
-  right: 25%; }
+code, kbd, pre, samp { font-family: Menlo, Monaco, Consolas, "Courier New", monospace; }
 
-.col-xs-pull-4 {
-  right: 33.33333%; }
+code { padding: 2px 4px; font-size: 90%; color: #c7254e; background-color: #f9f2f4; border-radius: 4px; }
 
-.col-xs-pull-5 {
-  right: 41.66667%; }
+kbd { padding: 2px 4px; font-size: 90%; color: #fff; background-color: #333; border-radius: 3px; box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25); }
 
-.col-xs-pull-6 {
-  right: 50%; }
+kbd kbd { padding: 0; font-size: 100%; font-weight: bold; box-shadow: none; }
 
-.col-xs-pull-7 {
-  right: 58.33333%; }
+pre { display: block; padding: 9.5px; margin: 0 0 10px; font-size: 13px; line-height: 1.42857; word-break: break-all; word-wrap: break-word; color: #333333; background-color: #f5f5f5; border: 1px solid #ccc; border-radius: 4px; }
 
-.col-xs-pull-8 {
-  right: 66.66667%; }
+pre code { padding: 0; font-size: inherit; color: inherit; white-space: pre-wrap; background-color: transparent; border-radius: 0; }
 
-.col-xs-pull-9 {
-  right: 75%; }
+.pre-scrollable { max-height: 340px; overflow-y: scroll; }
 
-.col-xs-pull-10 {
-  right: 83.33333%; }
+.container { margin-right: auto; margin-left: auto; padding-left: 15px; padding-right: 15px; }
 
-.col-xs-pull-11 {
-  right: 91.66667%; }
+.container:before, .container:after { content: " "; display: table; }
 
-.col-xs-pull-12 {
-  right: 100%; }
+.container:after { clear: both; }
 
-.col-xs-push-0 {
-  left: auto; }
+@media (min-width: 768px) { .container { width: 750px; } }
 
-.col-xs-push-1 {
-  left: 8.33333%; }
+@media (min-width: 992px) { .container { width: 970px; } }
 
-.col-xs-push-2 {
-  left: 16.66667%; }
+@media (min-width: 1200px) { .container { width: 1170px; } }
 
-.col-xs-push-3 {
-  left: 25%; }
+.container-fluid { margin-right: auto; margin-left: auto; padding-left: 15px; padding-right: 15px; }
 
-.col-xs-push-4 {
-  left: 33.33333%; }
+.container-fluid:before, .container-fluid:after { content: " "; display: table; }
 
-.col-xs-push-5 {
-  left: 41.66667%; }
+.container-fluid:after { clear: both; }
 
-.col-xs-push-6 {
-  left: 50%; }
+.row { margin-left: -15px; margin-right: -15px; }
 
-.col-xs-push-7 {
-  left: 58.33333%; }
+.row:before, .row:after { content: " "; display: table; }
 
-.col-xs-push-8 {
-  left: 66.66667%; }
+.row:after { clear: both; }
 
-.col-xs-push-9 {
-  left: 75%; }
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 { position: relative; min-height: 1px; padding-left: 15px; padding-right: 15px; }
 
-.col-xs-push-10 {
-  left: 83.33333%; }
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 { float: left; }
 
-.col-xs-push-11 {
-  left: 91.66667%; }
+.col-xs-1 { width: 8.33333%; }
 
-.col-xs-push-12 {
-  left: 100%; }
+.col-xs-2 { width: 16.66667%; }
 
-.col-xs-offset-0 {
-  margin-left: 0%; }
+.col-xs-3 { width: 25%; }
 
-.col-xs-offset-1 {
-  margin-left: 8.33333%; }
+.col-xs-4 { width: 33.33333%; }
 
-.col-xs-offset-2 {
-  margin-left: 16.66667%; }
+.col-xs-5 { width: 41.66667%; }
 
-.col-xs-offset-3 {
-  margin-left: 25%; }
+.col-xs-6 { width: 50%; }
 
-.col-xs-offset-4 {
-  margin-left: 33.33333%; }
+.col-xs-7 { width: 58.33333%; }
 
-.col-xs-offset-5 {
-  margin-left: 41.66667%; }
+.col-xs-8 { width: 66.66667%; }
 
-.col-xs-offset-6 {
-  margin-left: 50%; }
+.col-xs-9 { width: 75%; }
 
-.col-xs-offset-7 {
-  margin-left: 58.33333%; }
+.col-xs-10 { width: 83.33333%; }
 
-.col-xs-offset-8 {
-  margin-left: 66.66667%; }
+.col-xs-11 { width: 91.66667%; }
 
-.col-xs-offset-9 {
-  margin-left: 75%; }
+.col-xs-12 { width: 100%; }
 
-.col-xs-offset-10 {
-  margin-left: 83.33333%; }
+.col-xs-pull-0 { right: auto; }
 
-.col-xs-offset-11 {
-  margin-left: 91.66667%; }
+.col-xs-pull-1 { right: 8.33333%; }
 
-.col-xs-offset-12 {
-  margin-left: 100%; }
+.col-xs-pull-2 { right: 16.66667%; }
 
-@media (min-width: 768px) {
-  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
-    float: left; }
-  .col-sm-1 {
-    width: 8.33333%; }
-  .col-sm-2 {
-    width: 16.66667%; }
-  .col-sm-3 {
-    width: 25%; }
-  .col-sm-4 {
-    width: 33.33333%; }
-  .col-sm-5 {
-    width: 41.66667%; }
-  .col-sm-6 {
-    width: 50%; }
-  .col-sm-7 {
-    width: 58.33333%; }
-  .col-sm-8 {
-    width: 66.66667%; }
-  .col-sm-9 {
-    width: 75%; }
-  .col-sm-10 {
-    width: 83.33333%; }
-  .col-sm-11 {
-    width: 91.66667%; }
-  .col-sm-12 {
-    width: 100%; }
-  .col-sm-pull-0 {
-    right: auto; }
-  .col-sm-pull-1 {
-    right: 8.33333%; }
-  .col-sm-pull-2 {
-    right: 16.66667%; }
-  .col-sm-pull-3 {
-    right: 25%; }
-  .col-sm-pull-4 {
-    right: 33.33333%; }
-  .col-sm-pull-5 {
-    right: 41.66667%; }
-  .col-sm-pull-6 {
-    right: 50%; }
-  .col-sm-pull-7 {
-    right: 58.33333%; }
-  .col-sm-pull-8 {
-    right: 66.66667%; }
-  .col-sm-pull-9 {
-    right: 75%; }
-  .col-sm-pull-10 {
-    right: 83.33333%; }
-  .col-sm-pull-11 {
-    right: 91.66667%; }
-  .col-sm-pull-12 {
-    right: 100%; }
-  .col-sm-push-0 {
-    left: auto; }
-  .col-sm-push-1 {
-    left: 8.33333%; }
-  .col-sm-push-2 {
-    left: 16.66667%; }
-  .col-sm-push-3 {
-    left: 25%; }
-  .col-sm-push-4 {
-    left: 33.33333%; }
-  .col-sm-push-5 {
-    left: 41.66667%; }
-  .col-sm-push-6 {
-    left: 50%; }
-  .col-sm-push-7 {
-    left: 58.33333%; }
-  .col-sm-push-8 {
-    left: 66.66667%; }
-  .col-sm-push-9 {
-    left: 75%; }
-  .col-sm-push-10 {
-    left: 83.33333%; }
-  .col-sm-push-11 {
-    left: 91.66667%; }
-  .col-sm-push-12 {
-    left: 100%; }
-  .col-sm-offset-0 {
-    margin-left: 0%; }
-  .col-sm-offset-1 {
-    margin-left: 8.33333%; }
-  .col-sm-offset-2 {
-    margin-left: 16.66667%; }
-  .col-sm-offset-3 {
-    margin-left: 25%; }
-  .col-sm-offset-4 {
-    margin-left: 33.33333%; }
-  .col-sm-offset-5 {
-    margin-left: 41.66667%; }
-  .col-sm-offset-6 {
-    margin-left: 50%; }
-  .col-sm-offset-7 {
-    margin-left: 58.33333%; }
-  .col-sm-offset-8 {
-    margin-left: 66.66667%; }
-  .col-sm-offset-9 {
-    margin-left: 75%; }
-  .col-sm-offset-10 {
-    margin-left: 83.33333%; }
-  .col-sm-offset-11 {
-    margin-left: 91.66667%; }
-  .col-sm-offset-12 {
-    margin-left: 100%; } }
-
-@media (min-width: 992px) {
-  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
-    float: left; }
-  .col-md-1 {
-    width: 8.33333%; }
-  .col-md-2 {
-    width: 16.66667%; }
-  .col-md-3 {
-    width: 25%; }
-  .col-md-4 {
-    width: 33.33333%; }
-  .col-md-5 {
-    width: 41.66667%; }
-  .col-md-6 {
-    width: 50%; }
-  .col-md-7 {
-    width: 58.33333%; }
-  .col-md-8 {
-    width: 66.66667%; }
-  .col-md-9 {
-    width: 75%; }
-  .col-md-10 {
-    width: 83.33333%; }
-  .col-md-11 {
-    width: 91.66667%; }
-  .col-md-12 {
-    width: 100%; }
-  .col-md-pull-0 {
-    right: auto; }
-  .col-md-pull-1 {
-    right: 8.33333%; }
-  .col-md-pull-2 {
-    right: 16.66667%; }
-  .col-md-pull-3 {
-    right: 25%; }
-  .col-md-pull-4 {
-    right: 33.33333%; }
-  .col-md-pull-5 {
-    right: 41.66667%; }
-  .col-md-pull-6 {
-    right: 50%; }
-  .col-md-pull-7 {
-    right: 58.33333%; }
-  .col-md-pull-8 {
-    right: 66.66667%; }
-  .col-md-pull-9 {
-    right: 75%; }
-  .col-md-pull-10 {
-    right: 83.33333%; }
-  .col-md-pull-11 {
-    right: 91.66667%; }
-  .col-md-pull-12 {
-    right: 100%; }
-  .col-md-push-0 {
-    left: auto; }
-  .col-md-push-1 {
-    left: 8.33333%; }
-  .col-md-push-2 {
-    left: 16.66667%; }
-  .col-md-push-3 {
-    left: 25%; }
-  .col-md-push-4 {
-    left: 33.33333%; }
-  .col-md-push-5 {
-    left: 41.66667%; }
-  .col-md-push-6 {
-    left: 50%; }
-  .col-md-push-7 {
-    left: 58.33333%; }
-  .col-md-push-8 {
-    left: 66.66667%; }
-  .col-md-push-9 {
-    left: 75%; }
-  .col-md-push-10 {
-    left: 83.33333%; }
-  .col-md-push-11 {
-    left: 91.66667%; }
-  .col-md-push-12 {
-    left: 100%; }
-  .col-md-offset-0 {
-    margin-left: 0%; }
-  .col-md-offset-1 {
-    margin-left: 8.33333%; }
-  .col-md-offset-2 {
-    margin-left: 16.66667%; }
-  .col-md-offset-3 {
-    margin-left: 25%; }
-  .col-md-offset-4 {
-    margin-left: 33.33333%; }
-  .col-md-offset-5 {
-    margin-left: 41.66667%; }
-  .col-md-offset-6 {
-    margin-left: 50%; }
-  .col-md-offset-7 {
-    margin-left: 58.33333%; }
-  .col-md-offset-8 {
-    margin-left: 66.66667%; }
-  .col-md-offset-9 {
-    margin-left: 75%; }
-  .col-md-offset-10 {
-    margin-left: 83.33333%; }
-  .col-md-offset-11 {
-    margin-left: 91.66667%; }
-  .col-md-offset-12 {
-    margin-left: 100%; } }
-
-@media (min-width: 1200px) {
-  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
-    float: left; }
-  .col-lg-1 {
-    width: 8.33333%; }
-  .col-lg-2 {
-    width: 16.66667%; }
-  .col-lg-3 {
-    width: 25%; }
-  .col-lg-4 {
-    width: 33.33333%; }
-  .col-lg-5 {
-    width: 41.66667%; }
-  .col-lg-6 {
-    width: 50%; }
-  .col-lg-7 {
-    width: 58.33333%; }
-  .col-lg-8 {
-    width: 66.66667%; }
-  .col-lg-9 {
-    width: 75%; }
-  .col-lg-10 {
-    width: 83.33333%; }
-  .col-lg-11 {
-    width: 91.66667%; }
-  .col-lg-12 {
-    width: 100%; }
-  .col-lg-pull-0 {
-    right: auto; }
-  .col-lg-pull-1 {
-    right: 8.33333%; }
-  .col-lg-pull-2 {
-    right: 16.66667%; }
-  .col-lg-pull-3 {
-    right: 25%; }
-  .col-lg-pull-4 {
-    right: 33.33333%; }
-  .col-lg-pull-5 {
-    right: 41.66667%; }
-  .col-lg-pull-6 {
-    right: 50%; }
-  .col-lg-pull-7 {
-    right: 58.33333%; }
-  .col-lg-pull-8 {
-    right: 66.66667%; }
-  .col-lg-pull-9 {
-    right: 75%; }
-  .col-lg-pull-10 {
-    right: 83.33333%; }
-  .col-lg-pull-11 {
-    right: 91.66667%; }
-  .col-lg-pull-12 {
-    right: 100%; }
-  .col-lg-push-0 {
-    left: auto; }
-  .col-lg-push-1 {
-    left: 8.33333%; }
-  .col-lg-push-2 {
-    left: 16.66667%; }
-  .col-lg-push-3 {
-    left: 25%; }
-  .col-lg-push-4 {
-    left: 33.33333%; }
-  .col-lg-push-5 {
-    left: 41.66667%; }
-  .col-lg-push-6 {
-    left: 50%; }
-  .col-lg-push-7 {
-    left: 58.33333%; }
-  .col-lg-push-8 {
-    left: 66.66667%; }
-  .col-lg-push-9 {
-    left: 75%; }
-  .col-lg-push-10 {
-    left: 83.33333%; }
-  .col-lg-push-11 {
-    left: 91.66667%; }
-  .col-lg-push-12 {
-    left: 100%; }
-  .col-lg-offset-0 {
-    margin-left: 0%; }
-  .col-lg-offset-1 {
-    margin-left: 8.33333%; }
-  .col-lg-offset-2 {
-    margin-left: 16.66667%; }
-  .col-lg-offset-3 {
-    margin-left: 25%; }
-  .col-lg-offset-4 {
-    margin-left: 33.33333%; }
-  .col-lg-offset-5 {
-    margin-left: 41.66667%; }
-  .col-lg-offset-6 {
-    margin-left: 50%; }
-  .col-lg-offset-7 {
-    margin-left: 58.33333%; }
-  .col-lg-offset-8 {
-    margin-left: 66.66667%; }
-  .col-lg-offset-9 {
-    margin-left: 75%; }
-  .col-lg-offset-10 {
-    margin-left: 83.33333%; }
-  .col-lg-offset-11 {
-    margin-left: 91.66667%; }
-  .col-lg-offset-12 {
-    margin-left: 100%; } }
-
-table {
-  background-color: transparent; }
-
-caption {
-  padding-top: 20px;
-  padding-bottom: 20px;
-  color: #999999;
-  text-align: left; }
-
-th {
-  text-align: left; }
-
-.table {
-  width: 100%;
-  max-width: 100%;
-  margin-bottom: 20px; }
-  .table > thead > tr > th,
-  .table > thead > tr > td,
-  .table > tbody > tr > th,
-  .table > tbody > tr > td,
-  .table > tfoot > tr > th,
-  .table > tfoot > tr > td {
-    padding: 20px;
-    line-height: 1.42857;
-    vertical-align: top;
-    border-top: 1px solid #ddd; }
-  .table > thead > tr > th {
-    vertical-align: bottom;
-    border-bottom: 2px solid #ddd; }
-  .table > caption + thead > tr:first-child > th,
-  .table > caption + thead > tr:first-child > td,
-  .table > colgroup + thead > tr:first-child > th,
-  .table > colgroup + thead > tr:first-child > td,
-  .table > thead:first-child > tr:first-child > th,
-  .table > thead:first-child > tr:first-child > td {
-    border-top: 0; }
-  .table > tbody + tbody {
-    border-top: 2px solid #ddd; }
-  .table .table {
-    background-color: #fff; }
-
-.table-condensed > thead > tr > th,
-.table-condensed > thead > tr > td,
-.table-condensed > tbody > tr > th,
-.table-condensed > tbody > tr > td,
-.table-condensed > tfoot > tr > th,
-.table-condensed > tfoot > tr > td {
-  padding: 5px; }
-
-.table-bordered {
-  border: 1px solid #ddd; }
-  .table-bordered > thead > tr > th,
-  .table-bordered > thead > tr > td,
-  .table-bordered > tbody > tr > th,
-  .table-bordered > tbody > tr > td,
-  .table-bordered > tfoot > tr > th,
-  .table-bordered > tfoot > tr > td {
-    border: 1px solid #ddd; }
-  .table-bordered > thead > tr > th,
-  .table-bordered > thead > tr > td {
-    border-bottom-width: 2px; }
-
-.table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: #f1f8fb; }
-
-.table-hover > tbody > tr:hover {
-  background-color: #f5f5f5; }
-
-table col[class*="col-"] {
-  position: static;
-  float: none;
-  display: table-column; }
-
-table td[class*="col-"],
-table th[class*="col-"] {
-  position: static;
-  float: none;
-  display: table-cell; }
-
-.table > thead > tr > td.active,
-.table > thead > tr > th.active,
-.table > thead > tr.active > td,
-.table > thead > tr.active > th,
-.table > tbody > tr > td.active,
-.table > tbody > tr > th.active,
-.table > tbody > tr.active > td,
-.table > tbody > tr.active > th,
-.table > tfoot > tr > td.active,
-.table > tfoot > tr > th.active,
-.table > tfoot > tr.active > td,
-.table > tfoot > tr.active > th {
-  background-color: #f5f5f5; }
-
-.table-hover > tbody > tr > td.active:hover,
-.table-hover > tbody > tr > th.active:hover,
-.table-hover > tbody > tr.active:hover > td,
-.table-hover > tbody > tr:hover > .active,
-.table-hover > tbody > tr.active:hover > th {
-  background-color: #e8e8e8; }
-
-.table > thead > tr > td.success,
-.table > thead > tr > th.success,
-.table > thead > tr.success > td,
-.table > thead > tr.success > th,
-.table > tbody > tr > td.success,
-.table > tbody > tr > th.success,
-.table > tbody > tr.success > td,
-.table > tbody > tr.success > th,
-.table > tfoot > tr > td.success,
-.table > tfoot > tr > th.success,
-.table > tfoot > tr.success > td,
-.table > tfoot > tr.success > th {
-  background-color: #f5f8eb; }
-
-.table-hover > tbody > tr > td.success:hover,
-.table-hover > tbody > tr > th.success:hover,
-.table-hover > tbody > tr.success:hover > td,
-.table-hover > tbody > tr:hover > .success,
-.table-hover > tbody > tr.success:hover > th {
-  background-color: #ecf1d8; }
-
-.table > thead > tr > td.info,
-.table > thead > tr > th.info,
-.table > thead > tr.info > td,
-.table > thead > tr.info > th,
-.table > tbody > tr > td.info,
-.table > tbody > tr > th.info,
-.table > tbody > tr.info > td,
-.table > tbody > tr.info > th,
-.table > tfoot > tr > td.info,
-.table > tfoot > tr > th.info,
-.table > tfoot > tr.info > td,
-.table > tfoot > tr.info > th {
-  background-color: #ebf5f9; }
-
-.table-hover > tbody > tr > td.info:hover,
-.table-hover > tbody > tr > th.info:hover,
-.table-hover > tbody > tr.info:hover > td,
-.table-hover > tbody > tr:hover > .info,
-.table-hover > tbody > tr.info:hover > th {
-  background-color: #d7ebf3; }
-
-.table > thead > tr > td.warning,
-.table > thead > tr > th.warning,
-.table > thead > tr.warning > td,
-.table > thead > tr.warning > th,
-.table > tbody > tr > td.warning,
-.table > tbody > tr > th.warning,
-.table > tbody > tr.warning > td,
-.table > tbody > tr.warning > th,
-.table > tfoot > tr > td.warning,
-.table > tfoot > tr > th.warning,
-.table > tfoot > tr.warning > td,
-.table > tfoot > tr.warning > th {
-  background-color: #fdfde9; }
-
-.table-hover > tbody > tr > td.warning:hover,
-.table-hover > tbody > tr > th.warning:hover,
-.table-hover > tbody > tr.warning:hover > td,
-.table-hover > tbody > tr:hover > .warning,
-.table-hover > tbody > tr.warning:hover > th {
-  background-color: #fbfbd2; }
-
-.table > thead > tr > td.danger,
-.table > thead > tr > th.danger,
-.table > thead > tr.danger > td,
-.table > thead > tr.danger > th,
-.table > tbody > tr > td.danger,
-.table > tbody > tr > th.danger,
-.table > tbody > tr.danger > td,
-.table > tbody > tr.danger > th,
-.table > tfoot > tr > td.danger,
-.table > tfoot > tr > th.danger,
-.table > tfoot > tr.danger > td,
-.table > tfoot > tr.danger > th {
-  background-color: #fceae8; }
-
-.table-hover > tbody > tr > td.danger:hover,
-.table-hover > tbody > tr > th.danger:hover,
-.table-hover > tbody > tr.danger:hover > td,
-.table-hover > tbody > tr:hover > .danger,
-.table-hover > tbody > tr.danger:hover > th {
-  background-color: #f9d5d1; }
-
-.table-responsive {
-  overflow-x: auto;
-  min-height: 0.01%; }
-  @media screen and (max-width: 767px) {
-    .table-responsive {
-      width: 100%;
-      margin-bottom: 15px;
-      overflow-y: hidden;
-      -ms-overflow-style: -ms-autohiding-scrollbar;
-      border: 1px solid #ddd; }
-      .table-responsive > .table {
-        margin-bottom: 0; }
-        .table-responsive > .table > thead > tr > th,
-        .table-responsive > .table > thead > tr > td,
-        .table-responsive > .table > tbody > tr > th,
-        .table-responsive > .table > tbody > tr > td,
-        .table-responsive > .table > tfoot > tr > th,
-        .table-responsive > .table > tfoot > tr > td {
-          white-space: nowrap; }
-      .table-responsive > .table-bordered {
-        border: 0; }
-        .table-responsive > .table-bordered > thead > tr > th:first-child,
-        .table-responsive > .table-bordered > thead > tr > td:first-child,
-        .table-responsive > .table-bordered > tbody > tr > th:first-child,
-        .table-responsive > .table-bordered > tbody > tr > td:first-child,
-        .table-responsive > .table-bordered > tfoot > tr > th:first-child,
-        .table-responsive > .table-bordered > tfoot > tr > td:first-child {
-          border-left: 0; }
-        .table-responsive > .table-bordered > thead > tr > th:last-child,
-        .table-responsive > .table-bordered > thead > tr > td:last-child,
-        .table-responsive > .table-bordered > tbody > tr > th:last-child,
-        .table-responsive > .table-bordered > tbody > tr > td:last-child,
-        .table-responsive > .table-bordered > tfoot > tr > th:last-child,
-        .table-responsive > .table-bordered > tfoot > tr > td:last-child {
-          border-right: 0; }
-        .table-responsive > .table-bordered > tbody > tr:last-child > th,
-        .table-responsive > .table-bordered > tbody > tr:last-child > td,
-        .table-responsive > .table-bordered > tfoot > tr:last-child > th,
-        .table-responsive > .table-bordered > tfoot > tr:last-child > td {
-          border-bottom: 0; } }
-
-fieldset {
-  padding: 0;
-  margin: 0;
-  border: 0;
-  min-width: 0; }
-
-legend {
-  display: block;
-  width: 100%;
-  padding: 0;
-  margin-bottom: 20px;
-  font-size: 21px;
-  line-height: inherit;
-  color: #333333;
-  border: 0;
-  border-bottom: 1px solid #e5e5e5; }
-
-label {
-  display: inline-block;
-  max-width: 100%;
-  margin-bottom: 5px;
-  font-weight: bold; }
-
-input[type="search"] {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box; }
-
-input[type="radio"],
-input[type="checkbox"] {
-  margin: 4px 0 0;
-  margin-top: 1px \9;
-  line-height: normal; }
-
-input[type="file"] {
-  display: block; }
-
-input[type="range"] {
-  display: block;
-  width: 100%; }
-
-select[multiple],
-select[size] {
-  height: auto; }
-
-input[type="file"]:focus,
-input[type="radio"]:focus,
-input[type="checkbox"]:focus {
-  outline: thin dotted;
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px; }
-
-output {
-  display: block;
-  padding-top: 7px;
-  font-size: 14px;
-  line-height: 1.42857;
-  color: #666; }
-
-.form-control {
-  display: block;
-  width: 100%;
-  height: 34px;
-  padding: 6px 12px;
-  font-size: 14px;
-  line-height: 1.42857;
-  color: #666;
-  background-color: #fff;
-  background-image: none;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-  -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s; }
-  .form-control:focus {
-    border-color: #66afe9;
-    outline: 0;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6); }
-  .form-control::-moz-placeholder {
-    color: #999999;
-    opacity: 1; }
-  .form-control:-ms-input-placeholder {
-    color: #999999; }
-  .form-control::-webkit-input-placeholder {
-    color: #999999; }
-  .form-control[disabled],
-  .form-control[readonly],
-  fieldset[disabled] .form-control {
-    background-color: #eeeeee;
-    opacity: 1; }
-  .form-control[disabled],
-  fieldset[disabled] .form-control {
-    cursor: not-allowed; }
-
-textarea.form-control {
-  height: auto; }
-
-input[type="search"] {
-  -webkit-appearance: none; }
-
-@media screen and (-webkit-min-device-pixel-ratio: 0) {
-  input[type="date"],
-  input[type="time"],
-  input[type="datetime-local"],
-  input[type="month"] {
-    line-height: 34px; }
-    input[type="date"].input-sm,
-    .input-group-sm > input[type="date"].form-control,
-    .input-group-sm > input[type="date"].input-group-addon,
-    .input-group-sm > .input-group-btn > input[type="date"].btn,
-    .input-group-sm > .input-group-btn > input[type="date"].btn-ghost,
-    .input-group-sm input[type="date"],
-    input[type="time"].input-sm,
-    .input-group-sm > input[type="time"].form-control,
-    .input-group-sm > input[type="time"].input-group-addon,
-    .input-group-sm > .input-group-btn > input[type="time"].btn,
-    .input-group-sm > .input-group-btn > input[type="time"].btn-ghost,
-    .input-group-sm input[type="time"],
-    input[type="datetime-local"].input-sm,
-    .input-group-sm > input[type="datetime-local"].form-control,
-    .input-group-sm > input[type="datetime-local"].input-group-addon,
-    .input-group-sm > .input-group-btn > input[type="datetime-local"].btn,
-    .input-group-sm > .input-group-btn > input[type="datetime-local"].btn-ghost,
-    .input-group-sm input[type="datetime-local"],
-    input[type="month"].input-sm,
-    .input-group-sm > input[type="month"].form-control,
-    .input-group-sm > input[type="month"].input-group-addon,
-    .input-group-sm > .input-group-btn > input[type="month"].btn,
-    .input-group-sm > .input-group-btn > input[type="month"].btn-ghost,
-    .input-group-sm input[type="month"] {
-      line-height: 30px; }
-    input[type="date"].input-lg,
-    .input-group-lg > input[type="date"].form-control,
-    .input-group-lg > input[type="date"].input-group-addon,
-    .input-group-lg > .input-group-btn > input[type="date"].btn,
-    .input-group-lg > .input-group-btn > input[type="date"].btn-ghost,
-    .input-group-lg input[type="date"],
-    input[type="time"].input-lg,
-    .input-group-lg > input[type="time"].form-control,
-    .input-group-lg > input[type="time"].input-group-addon,
-    .input-group-lg > .input-group-btn > input[type="time"].btn,
-    .input-group-lg > .input-group-btn > input[type="time"].btn-ghost,
-    .input-group-lg input[type="time"],
-    input[type="datetime-local"].input-lg,
-    .input-group-lg > input[type="datetime-local"].form-control,
-    .input-group-lg > input[type="datetime-local"].input-group-addon,
-    .input-group-lg > .input-group-btn > input[type="datetime-local"].btn,
-    .input-group-lg > .input-group-btn > input[type="datetime-local"].btn-ghost,
-    .input-group-lg input[type="datetime-local"],
-    input[type="month"].input-lg,
-    .input-group-lg > input[type="month"].form-control,
-    .input-group-lg > input[type="month"].input-group-addon,
-    .input-group-lg > .input-group-btn > input[type="month"].btn,
-    .input-group-lg > .input-group-btn > input[type="month"].btn-ghost,
-    .input-group-lg input[type="month"] {
-      line-height: 46px; } }
-
-.form-group {
-  margin-bottom: 15px; }
-
-.radio,
-.checkbox {
-  position: relative;
-  display: block;
-  margin-top: 10px;
-  margin-bottom: 10px; }
-  .radio label,
-  .checkbox label {
-    min-height: 20px;
-    padding-left: 20px;
-    margin-bottom: 0;
-    font-weight: normal;
-    cursor: pointer; }
-
-.radio input[type="radio"],
-.radio-inline input[type="radio"],
-.checkbox input[type="checkbox"],
-.checkbox-inline input[type="checkbox"] {
-  position: absolute;
-  margin-left: -20px;
-  margin-top: 4px \9; }
-
-.radio + .radio,
-.checkbox + .checkbox {
-  margin-top: -5px; }
-
-.radio-inline,
-.checkbox-inline {
-  position: relative;
-  display: inline-block;
-  padding-left: 20px;
-  margin-bottom: 0;
-  vertical-align: middle;
-  font-weight: normal;
-  cursor: pointer; }
-
-.radio-inline + .radio-inline,
-.checkbox-inline + .checkbox-inline {
-  margin-top: 0;
-  margin-left: 10px; }
-
-input[type="radio"][disabled],
-input[type="radio"].disabled,
-fieldset[disabled] input[type="radio"],
-input[type="checkbox"][disabled],
-input[type="checkbox"].disabled,
-fieldset[disabled] input[type="checkbox"] {
-  cursor: not-allowed; }
-
-.radio-inline.disabled,
-fieldset[disabled] .radio-inline,
-.checkbox-inline.disabled,
-fieldset[disabled] .checkbox-inline {
-  cursor: not-allowed; }
-
-.radio.disabled label,
-fieldset[disabled] .radio label,
-.checkbox.disabled label,
-fieldset[disabled] .checkbox label {
-  cursor: not-allowed; }
-
-.form-control-static {
-  padding-top: 7px;
-  padding-bottom: 7px;
-  margin-bottom: 0;
-  min-height: 34px; }
-  .form-control-static.input-lg,
-  .input-group-lg > .form-control-static.form-control,
-  .input-group-lg > .form-control-static.input-group-addon,
-  .input-group-lg > .input-group-btn > .form-control-static.btn,
-  .input-group-lg > .input-group-btn > .form-control-static.btn-ghost,
-  .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control,
-  .input-group-sm > .form-control-static.input-group-addon,
-  .input-group-sm > .input-group-btn > .form-control-static.btn, .input-group-sm > .input-group-btn > .form-control-static.btn-ghost {
-    padding-left: 0;
-    padding-right: 0; }
-
-.input-sm, .input-group-sm > .form-control,
-.input-group-sm > .input-group-addon,
-.input-group-sm > .input-group-btn > .btn, .input-group-sm > .input-group-btn > .btn-ghost {
-  height: 30px;
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px; }
-
-select.input-sm, .input-group-sm > select.form-control,
-.input-group-sm > select.input-group-addon,
-.input-group-sm > .input-group-btn > select.btn, .input-group-sm > .input-group-btn > select.btn-ghost {
-  height: 30px;
-  line-height: 30px; }
-
-textarea.input-sm,
-.input-group-sm > textarea.form-control,
-.input-group-sm > textarea.input-group-addon,
-.input-group-sm > .input-group-btn > textarea.btn,
-.input-group-sm > .input-group-btn > textarea.btn-ghost,
-select[multiple].input-sm, .input-group-sm > select[multiple].form-control,
-.input-group-sm > select[multiple].input-group-addon,
-.input-group-sm > .input-group-btn > select[multiple].btn, .input-group-sm > .input-group-btn > select[multiple].btn-ghost {
-  height: auto; }
-
-.form-group-sm .form-control {
-  height: 30px;
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px; }
-
-.form-group-sm select.form-control {
-  height: 30px;
-  line-height: 30px; }
-
-.form-group-sm textarea.form-control,
-.form-group-sm select[multiple].form-control {
-  height: auto; }
-
-.form-group-sm .form-control-static {
-  height: 30px;
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  min-height: 32px; }
-
-.input-lg, .input-group-lg > .form-control,
-.input-group-lg > .input-group-addon,
-.input-group-lg > .input-group-btn > .btn, .input-group-lg > .input-group-btn > .btn-ghost {
-  height: 46px;
-  padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.33;
-  border-radius: 6px; }
-
-select.input-lg, .input-group-lg > select.form-control,
-.input-group-lg > select.input-group-addon,
-.input-group-lg > .input-group-btn > select.btn, .input-group-lg > .input-group-btn > select.btn-ghost {
-  height: 46px;
-  line-height: 46px; }
-
-textarea.input-lg,
-.input-group-lg > textarea.form-control,
-.input-group-lg > textarea.input-group-addon,
-.input-group-lg > .input-group-btn > textarea.btn,
-.input-group-lg > .input-group-btn > textarea.btn-ghost,
-select[multiple].input-lg, .input-group-lg > select[multiple].form-control,
-.input-group-lg > select[multiple].input-group-addon,
-.input-group-lg > .input-group-btn > select[multiple].btn, .input-group-lg > .input-group-btn > select[multiple].btn-ghost {
-  height: auto; }
-
-.form-group-lg .form-control {
-  height: 46px;
-  padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.33;
-  border-radius: 6px; }
-
-.form-group-lg select.form-control {
-  height: 46px;
-  line-height: 46px; }
-
-.form-group-lg textarea.form-control,
-.form-group-lg select[multiple].form-control {
-  height: auto; }
-
-.form-group-lg .form-control-static {
-  height: 46px;
-  padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.33;
-  min-height: 38px; }
-
-.has-feedback {
-  position: relative; }
-  .has-feedback .form-control {
-    padding-right: 42.5px; }
-
-.form-control-feedback {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 2;
-  display: block;
-  width: 34px;
-  height: 34px;
-  line-height: 34px;
-  text-align: center;
-  pointer-events: none; }
-
-.input-lg + .form-control-feedback, .input-group-lg > .form-control + .form-control-feedback,
-.input-group-lg > .input-group-addon + .form-control-feedback,
-.input-group-lg > .input-group-btn > .btn + .form-control-feedback, .input-group-lg > .input-group-btn > .btn-ghost + .form-control-feedback {
-  width: 46px;
-  height: 46px;
-  line-height: 46px; }
-
-.input-sm + .form-control-feedback, .input-group-sm > .form-control + .form-control-feedback,
-.input-group-sm > .input-group-addon + .form-control-feedback,
-.input-group-sm > .input-group-btn > .btn + .form-control-feedback, .input-group-sm > .input-group-btn > .btn-ghost + .form-control-feedback {
-  width: 30px;
-  height: 30px;
-  line-height: 30px; }
-
-.has-success .help-block,
-.has-success .control-label,
-.has-success .radio,
-.has-success .checkbox,
-.has-success .radio-inline,
-.has-success .checkbox-inline,
-.has-success.radio label,
-.has-success.checkbox label,
-.has-success.radio-inline label,
-.has-success.checkbox-inline label {
-  color: #9bb83a; }
-
-.has-success .form-control {
-  border-color: #9bb83a;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
-  .has-success .form-control:focus {
-    border-color: #7a912e;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781; }
-
-.has-success .input-group-addon {
-  color: #9bb83a;
-  border-color: #9bb83a;
-  background-color: #f5f8eb; }
-
-.has-success .form-control-feedback {
-  color: #9bb83a; }
-
-.has-warning .help-block,
-.has-warning .control-label,
-.has-warning .radio,
-.has-warning .checkbox,
-.has-warning .radio-inline,
-.has-warning .checkbox-inline,
-.has-warning.radio label,
-.has-warning.checkbox label,
-.has-warning.radio-inline label,
-.has-warning.checkbox-inline label {
-  color: #e5d321; }
-
-.has-warning .form-control {
-  border-color: #e5d321;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
-  .has-warning .form-control:focus {
-    border-color: #bdae16;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c; }
-
-.has-warning .input-group-addon {
-  color: #e5d321;
-  border-color: #e5d321;
-  background-color: #fdfde9; }
-
-.has-warning .form-control-feedback {
-  color: #e5d321; }
-
-.has-error .help-block,
-.has-error .control-label,
-.has-error .radio,
-.has-error .checkbox,
-.has-error .radio-inline,
-.has-error .checkbox-inline,
-.has-error.radio label,
-.has-error.checkbox label,
-.has-error.radio-inline label,
-.has-error.checkbox-inline label {
-  color: #e53221; }
-
-.has-error .form-control {
-  border-color: #e53221;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
-  .has-error .form-control:focus {
-    border-color: #bd2516;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c; }
-
-.has-error .input-group-addon {
-  color: #e53221;
-  border-color: #e53221;
-  background-color: #fceae8; }
-
-.has-error .form-control-feedback {
-  color: #e53221; }
-
-.has-feedback label ~ .form-control-feedback {
-  top: 25px; }
-
-.has-feedback label.sr-only ~ .form-control-feedback {
-  top: 0; }
-
-.help-block {
-  display: block;
-  margin-top: 5px;
-  margin-bottom: 10px;
-  color: #a6a6a6; }
-
-@media (min-width: 768px) {
-  .form-inline .form-group {
-    display: inline-block;
-    margin-bottom: 0;
-    vertical-align: middle; }
-  .form-inline .form-control {
-    display: inline-block;
-    width: auto;
-    vertical-align: middle; }
-  .form-inline .form-control-static {
-    display: inline-block; }
-  .form-inline .input-group {
-    display: inline-table;
-    vertical-align: middle; }
-    .form-inline .input-group .input-group-addon,
-    .form-inline .input-group .input-group-btn,
-    .form-inline .input-group .form-control {
-      width: auto; }
-  .form-inline .input-group > .form-control {
-    width: 100%; }
-  .form-inline .control-label {
-    margin-bottom: 0;
-    vertical-align: middle; }
-  .form-inline .radio,
-  .form-inline .checkbox {
-    display: inline-block;
-    margin-top: 0;
-    margin-bottom: 0;
-    vertical-align: middle; }
-    .form-inline .radio label,
-    .form-inline .checkbox label {
-      padding-left: 0; }
-  .form-inline .radio input[type="radio"],
-  .form-inline .checkbox input[type="checkbox"] {
-    position: relative;
-    margin-left: 0; }
-  .form-inline .has-feedback .form-control-feedback {
-    top: 0; } }
-
-.form-horizontal .radio,
-.form-horizontal .checkbox,
-.form-horizontal .radio-inline,
-.form-horizontal .checkbox-inline {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 7px; }
-
-.form-horizontal .radio,
-.form-horizontal .checkbox {
-  min-height: 27px; }
-
-.form-horizontal .form-group {
-  margin-left: -15px;
-  margin-right: -15px; }
-  .form-horizontal .form-group:before,
-  .form-horizontal .form-group:after {
-    content: " ";
-    display: table; }
-  .form-horizontal .form-group:after {
-    clear: both; }
-
-@media (min-width: 768px) {
-  .form-horizontal .control-label {
-    text-align: right;
-    margin-bottom: 0;
-    padding-top: 7px; } }
-
-.form-horizontal .has-feedback .form-control-feedback {
-  right: 15px; }
-
-@media (min-width: 768px) {
-  .form-horizontal .form-group-lg .control-label {
-    padding-top: 14.3px; } }
-
-@media (min-width: 768px) {
-  .form-horizontal .form-group-sm .control-label {
-    padding-top: 6px; } }
-
-.btn, .btn-ghost {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: 400;
-  text-align: center;
-  vertical-align: middle;
-  touch-action: manipulation;
-  cursor: pointer;
-  background-image: none;
-  border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 14px;
-  line-height: 1.42857;
-  border-radius: 4px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none; }
-  .btn:focus,
-  .btn-ghost:focus,
-  .btn.focus,
-  .focus.btn-ghost,
-  .btn:active:focus,
-  .btn-ghost:active:focus,
-  .btn:active.focus,
-  .btn-ghost:active.focus,
-  .btn.active:focus,
-  .active.btn-ghost:focus,
-  .btn.active.focus, .active.focus.btn-ghost {
-    outline: thin dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px; }
-  .btn:hover,
-  .btn-ghost:hover,
-  .btn:focus,
-  .btn-ghost:focus,
-  .btn.focus, .focus.btn-ghost {
-    color: #555;
-    text-decoration: none; }
-  .btn:active,
-  .btn-ghost:active,
-  .btn.active, .active.btn-ghost {
-    outline: 0;
-    background-image: none;
-    -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
-  .btn.disabled,
-  .disabled.btn-ghost,
-  .btn[disabled],
-  [disabled].btn-ghost,
-  fieldset[disabled] .btn, fieldset[disabled] .btn-ghost {
-    cursor: not-allowed;
-    pointer-events: none;
-    opacity: 0.65;
-    filter: alpha(opacity=65);
-    -webkit-box-shadow: none;
-    box-shadow: none; }
-
-.btn-default {
-  color: #555;
-  background-color: #f4f5f6;
-  border-color: #b1b6bf; }
-  .btn-default:hover,
-  .btn-default:focus,
-  .btn-default.focus,
-  .btn-default:active,
-  .btn-default.active,
-  .open > .btn-default.dropdown-toggle {
-    color: #555;
-    background-color: #d8dcdf;
-    border-color: #8f97a3; }
-  .btn-default:active,
-  .btn-default.active,
-  .open > .btn-default.dropdown-toggle {
-    background-image: none; }
-  .btn-default.disabled,
-  .btn-default.disabled:hover,
-  .btn-default.disabled:focus,
-  .btn-default.disabled.focus,
-  .btn-default.disabled:active,
-  .btn-default.disabled.active,
-  .btn-default[disabled],
-  .btn-default[disabled]:hover,
-  .btn-default[disabled]:focus,
-  .btn-default[disabled].focus,
-  .btn-default[disabled]:active,
-  .btn-default[disabled].active,
-  fieldset[disabled] .btn-default,
-  fieldset[disabled] .btn-default:hover,
-  fieldset[disabled] .btn-default:focus,
-  fieldset[disabled] .btn-default.focus,
-  fieldset[disabled] .btn-default:active,
-  fieldset[disabled] .btn-default.active {
-    background-color: #f4f5f6;
-    border-color: #b1b6bf; }
-  .btn-default .badge {
-    color: #f4f5f6;
-    background-color: #555; }
-
-.btn-primary {
-  color: #fff;
-  background-color: #9bb83a;
-  border-color: #70842a; }
-  .btn-primary:hover,
-  .btn-primary:focus,
-  .btn-primary.focus,
-  .btn-primary:active,
-  .btn-primary.active,
-  .open > .btn-primary.dropdown-toggle {
-    color: #fff;
-    background-color: #7a912e;
-    border-color: #48561b; }
-  .btn-primary:active,
-  .btn-primary.active,
-  .open > .btn-primary.dropdown-toggle {
-    background-image: none; }
-  .btn-primary.disabled,
-  .btn-primary.disabled:hover,
-  .btn-primary.disabled:focus,
-  .btn-primary.disabled.focus,
-  .btn-primary.disabled:active,
-  .btn-primary.disabled.active,
-  .btn-primary[disabled],
-  .btn-primary[disabled]:hover,
-  .btn-primary[disabled]:focus,
-  .btn-primary[disabled].focus,
-  .btn-primary[disabled]:active,
-  .btn-primary[disabled].active,
-  fieldset[disabled] .btn-primary,
-  fieldset[disabled] .btn-primary:hover,
-  fieldset[disabled] .btn-primary:focus,
-  fieldset[disabled] .btn-primary.focus,
-  fieldset[disabled] .btn-primary:active,
-  fieldset[disabled] .btn-primary.active {
-    background-color: #9bb83a;
-    border-color: #70842a; }
-  .btn-primary .badge {
-    color: #9bb83a;
-    background-color: #fff; }
-
-.btn-success {
-  color: #fff;
-  background-color: #9bb83a;
-  border-color: #5a6a22; }
-  .btn-success:hover,
-  .btn-success:focus,
-  .btn-success.focus,
-  .btn-success:active,
-  .btn-success.active,
-  .open > .btn-success.dropdown-toggle {
-    color: #fff;
-    background-color: #7a912e;
-    border-color: #323c13; }
-  .btn-success:active,
-  .btn-success.active,
-  .open > .btn-success.dropdown-toggle {
-    background-image: none; }
-  .btn-success.disabled,
-  .btn-success.disabled:hover,
-  .btn-success.disabled:focus,
-  .btn-success.disabled.focus,
-  .btn-success.disabled:active,
-  .btn-success.disabled.active,
-  .btn-success[disabled],
-  .btn-success[disabled]:hover,
-  .btn-success[disabled]:focus,
-  .btn-success[disabled].focus,
-  .btn-success[disabled]:active,
-  .btn-success[disabled].active,
-  fieldset[disabled] .btn-success,
-  fieldset[disabled] .btn-success:hover,
-  fieldset[disabled] .btn-success:focus,
-  fieldset[disabled] .btn-success.focus,
-  fieldset[disabled] .btn-success:active,
-  fieldset[disabled] .btn-success.active {
-    background-color: #9bb83a;
-    border-color: #5a6a22; }
-  .btn-success .badge {
-    color: #9bb83a;
-    background-color: #fff; }
-
-.btn-info {
-  color: #fff;
-  background-color: #389Bc9;
-  border-color: #215e7a; }
-  .btn-info:hover,
-  .btn-info:focus,
-  .btn-info.focus,
-  .btn-info:active,
-  .btn-info.active,
-  .open > .btn-info.dropdown-toggle {
-    color: #fff;
-    background-color: #2c7da2;
-    border-color: #14394a; }
-  .btn-info:active,
-  .btn-info.active,
-  .open > .btn-info.dropdown-toggle {
-    background-image: none; }
-  .btn-info.disabled,
-  .btn-info.disabled:hover,
-  .btn-info.disabled:focus,
-  .btn-info.disabled.focus,
-  .btn-info.disabled:active,
-  .btn-info.disabled.active,
-  .btn-info[disabled],
-  .btn-info[disabled]:hover,
-  .btn-info[disabled]:focus,
-  .btn-info[disabled].focus,
-  .btn-info[disabled]:active,
-  .btn-info[disabled].active,
-  fieldset[disabled] .btn-info,
-  fieldset[disabled] .btn-info:hover,
-  fieldset[disabled] .btn-info:focus,
-  fieldset[disabled] .btn-info.focus,
-  fieldset[disabled] .btn-info:active,
-  fieldset[disabled] .btn-info.active {
-    background-color: #389Bc9;
-    border-color: #215e7a; }
-  .btn-info .badge {
-    color: #389Bc9;
-    background-color: #fff; }
-
-.btn-warning {
-  color: #fff;
-  background-color: #e5d321;
-  border-color: #8f8411; }
-  .btn-warning:hover,
-  .btn-warning:focus,
-  .btn-warning.focus,
-  .btn-warning:active,
-  .btn-warning.active,
-  .open > .btn-warning.dropdown-toggle {
-    color: #fff;
-    background-color: #bdae16;
-    border-color: #58510a; }
-  .btn-warning:active,
-  .btn-warning.active,
-  .open > .btn-warning.dropdown-toggle {
-    background-image: none; }
-  .btn-warning.disabled,
-  .btn-warning.disabled:hover,
-  .btn-warning.disabled:focus,
-  .btn-warning.disabled.focus,
-  .btn-warning.disabled:active,
-  .btn-warning.disabled.active,
-  .btn-warning[disabled],
-  .btn-warning[disabled]:hover,
-  .btn-warning[disabled]:focus,
-  .btn-warning[disabled].focus,
-  .btn-warning[disabled]:active,
-  .btn-warning[disabled].active,
-  fieldset[disabled] .btn-warning,
-  fieldset[disabled] .btn-warning:hover,
-  fieldset[disabled] .btn-warning:focus,
-  fieldset[disabled] .btn-warning.focus,
-  fieldset[disabled] .btn-warning:active,
-  fieldset[disabled] .btn-warning.active {
-    background-color: #e5d321;
-    border-color: #8f8411; }
-  .btn-warning .badge {
-    color: #e5d321;
-    background-color: #fff; }
-
-.btn-danger, .btn-primary-alt {
-  color: #fff;
-  background-color: #e53221;
-  border-color: #8f1c11; }
-  .btn-danger:hover,
-  .btn-primary-alt:hover,
-  .btn-danger:focus,
-  .btn-primary-alt:focus,
-  .btn-danger.focus,
-  .focus.btn-primary-alt,
-  .btn-danger:active,
-  .btn-primary-alt:active,
-  .btn-danger.active,
-  .active.btn-primary-alt,
-  .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt {
-    color: #fff;
-    background-color: #bd2516;
-    border-color: #58110a; }
-  .btn-danger:active,
-  .btn-primary-alt:active,
-  .btn-danger.active,
-  .active.btn-primary-alt,
-  .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt {
-    background-image: none; }
-  .btn-danger.disabled,
-  .disabled.btn-primary-alt,
-  .btn-danger.disabled:hover,
-  .disabled.btn-primary-alt:hover,
-  .btn-danger.disabled:focus,
-  .disabled.btn-primary-alt:focus,
-  .btn-danger.disabled.focus,
-  .disabled.focus.btn-primary-alt,
-  .btn-danger.disabled:active,
-  .disabled.btn-primary-alt:active,
-  .btn-danger.disabled.active,
-  .disabled.active.btn-primary-alt,
-  .btn-danger[disabled],
-  [disabled].btn-primary-alt,
-  .btn-danger[disabled]:hover,
-  [disabled].btn-primary-alt:hover,
-  .btn-danger[disabled]:focus,
-  [disabled].btn-primary-alt:focus,
-  .btn-danger[disabled].focus,
-  [disabled].focus.btn-primary-alt,
-  .btn-danger[disabled]:active,
-  [disabled].btn-primary-alt:active,
-  .btn-danger[disabled].active,
-  [disabled].active.btn-primary-alt,
-  fieldset[disabled] .btn-danger,
-  fieldset[disabled] .btn-primary-alt,
-  fieldset[disabled] .btn-danger:hover,
-  fieldset[disabled] .btn-primary-alt:hover,
-  fieldset[disabled] .btn-danger:focus,
-  fieldset[disabled] .btn-primary-alt:focus,
-  fieldset[disabled] .btn-danger.focus,
-  fieldset[disabled] .focus.btn-primary-alt,
-  fieldset[disabled] .btn-danger:active,
-  fieldset[disabled] .btn-primary-alt:active,
-  fieldset[disabled] .btn-danger.active, fieldset[disabled] .active.btn-primary-alt {
-    background-color: #e53221;
-    border-color: #8f1c11; }
-  .btn-danger .badge, .btn-primary-alt .badge {
-    color: #e53221;
-    background-color: #fff; }
-
-.btn-link, .btn-secondary {
-  color: #2e88be;
-  font-weight: normal;
-  border-radius: 0; }
-  .btn-link,
-  .btn-secondary,
-  .btn-link:active,
-  .btn-secondary:active,
-  .btn-link.active,
-  .active.btn-secondary,
-  .btn-link[disabled],
-  [disabled].btn-secondary,
-  fieldset[disabled] .btn-link, fieldset[disabled] .btn-secondary {
-    background-color: transparent;
-    -webkit-box-shadow: none;
-    box-shadow: none; }
-  .btn-link,
-  .btn-secondary,
-  .btn-link:hover,
-  .btn-secondary:hover,
-  .btn-link:focus,
-  .btn-secondary:focus,
-  .btn-link:active, .btn-secondary:active {
-    border-color: transparent; }
-  .btn-link:hover,
-  .btn-secondary:hover,
-  .btn-link:focus, .btn-secondary:focus {
-    color: #1f5c80;
-    text-decoration: underline;
-    background-color: transparent; }
-  .btn-link[disabled]:hover,
-  [disabled].btn-secondary:hover,
-  .btn-link[disabled]:focus,
-  [disabled].btn-secondary:focus,
-  fieldset[disabled] .btn-link:hover,
-  fieldset[disabled] .btn-secondary:hover,
-  fieldset[disabled] .btn-link:focus, fieldset[disabled] .btn-secondary:focus {
-    color: #999999;
-    text-decoration: none; }
-
-.btn-lg, .btn-group-lg > .btn, .btn-group-lg > .btn-ghost {
-  padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.33;
-  border-radius: 6px; }
-
-.btn-sm, .btn-group-sm > .btn, .btn-group-sm > .btn-ghost {
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px; }
-
-.btn-xs, .btn-group-xs > .btn, .btn-group-xs > .btn-ghost {
-  padding: 1px 5px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px; }
-
-.btn-block {
-  display: block;
-  width: 100%; }
-
-.btn-block + .btn-block {
-  margin-top: 5px; }
-
-input[type="submit"].btn-block,
-input[type="reset"].btn-block,
-input[type="button"].btn-block {
-  width: 100%; }
-
-.fade {
-  opacity: 0;
-  -webkit-transition: opacity 0.15s linear;
-  -o-transition: opacity 0.15s linear;
-  transition: opacity 0.15s linear; }
-  .fade.in {
-    opacity: 1; }
-
-.collapse {
-  display: none; }
-  .collapse.in {
-    display: block; }
-
-tr.collapse.in {
-  display: table-row; }
-
-tbody.collapse.in {
-  display: table-row-group; }
-
-.collapsing {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  -webkit-transition-property: height, visibility;
-  transition-property: height, visibility;
-  -webkit-transition-duration: 0.35s;
-  transition-duration: 0.35s;
-  -webkit-transition-timing-function: ease;
-  transition-timing-function: ease; }
-
-.caret {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  margin-left: 2px;
-  vertical-align: middle;
-  border-top: 4px dashed;
-  border-right: 4px solid transparent;
-  border-left: 4px solid transparent; }
-
-.dropup,
-.dropdown {
-  position: relative; }
-
-.dropdown-toggle:focus {
-  outline: 0; }
-
-.dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 1000;
-  display: none;
-  float: left;
-  min-width: 160px;
-  padding: 5px 0;
-  margin: 2px 0 0;
-  list-style: none;
-  font-size: 14px;
-  text-align: left;
-  background-color: #fff;
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  background-clip: padding-box; }
-  .dropdown-menu.pull-right {
-    right: 0;
-    left: auto; }
-  .dropdown-menu .divider {
-    height: 1px;
-    margin: 9px 0;
-    overflow: hidden;
-    background-color: #e5e5e5; }
-  .dropdown-menu > li > a {
-    display: block;
-    padding: 3px 20px;
-    clear: both;
-    font-weight: normal;
-    line-height: 1.42857;
-    color: #333333;
-    white-space: nowrap; }
-
-.dropdown-menu > li > a:hover,
-.dropdown-menu > li > a:focus {
-  text-decoration: none;
-  color: #262626;
-  background-color: #f1f1f1; }
-
-.dropdown-menu > .active > a,
-.dropdown-menu > .active > a:hover,
-.dropdown-menu > .active > a:focus {
-  color: #666;
-  text-decoration: none;
-  outline: 0;
-  background-color: #f1f1f1; }
-
-.dropdown-menu > .disabled > a,
-.dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
-  color: #999999; }
-
-.dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
-  text-decoration: none;
-  background-color: transparent;
-  background-image: none;
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-  cursor: not-allowed; }
-
-.open > .dropdown-menu {
-  display: block; }
-
-.open > a {
-  outline: 0; }
-
-.dropdown-menu-right {
-  left: auto;
-  right: 0; }
-
-.dropdown-menu-left {
-  left: 0;
-  right: auto; }
-
-.dropdown-header {
-  display: block;
-  padding: 3px 20px;
-  font-size: 12px;
-  line-height: 1.42857;
-  color: #999999;
-  white-space: nowrap; }
-
-.dropdown-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-  z-index: 990; }
-
-.pull-right > .dropdown-menu {
-  right: 0;
-  left: auto; }
-
-.dropup .caret,
-.navbar-fixed-bottom .dropdown .caret {
-  border-top: 0;
-  border-bottom: 4px solid;
-  content: ""; }
-
-.dropup .dropdown-menu,
-.navbar-fixed-bottom .dropdown .dropdown-menu {
-  top: auto;
-  bottom: 100%;
-  margin-bottom: 2px; }
-
-@media (min-width: 768px) {
-  .navbar-right .dropdown-menu {
-    right: 0;
-    left: auto; }
-  .navbar-right .dropdown-menu-left {
-    left: 0;
-    right: auto; } }
-
-.btn-group,
-.btn-group-vertical {
-  position: relative;
-  display: inline-block;
-  vertical-align: middle; }
-  .btn-group > .btn,
-  .btn-group > .btn-ghost,
-  .btn-group-vertical > .btn, .btn-group-vertical > .btn-ghost {
-    position: relative;
-    float: left; }
-    .btn-group > .btn:hover,
-    .btn-group > .btn-ghost:hover,
-    .btn-group > .btn:focus,
-    .btn-group > .btn-ghost:focus,
-    .btn-group > .btn:active,
-    .btn-group > .btn-ghost:active,
-    .btn-group > .btn.active,
-    .btn-group > .active.btn-ghost,
-    .btn-group-vertical > .btn:hover,
-    .btn-group-vertical > .btn-ghost:hover,
-    .btn-group-vertical > .btn:focus,
-    .btn-group-vertical > .btn-ghost:focus,
-    .btn-group-vertical > .btn:active,
-    .btn-group-vertical > .btn-ghost:active,
-    .btn-group-vertical > .btn.active, .btn-group-vertical > .active.btn-ghost {
-      z-index: 2; }
-
-.btn-group .btn + .btn,
-.btn-group .btn-ghost + .btn,
-.btn-group .btn + .btn-ghost,
-.btn-group .btn-ghost + .btn-ghost,
-.btn-group .btn + .btn-group,
-.btn-group .btn-ghost + .btn-group,
-.btn-group .btn-group + .btn,
-.btn-group .btn-group + .btn-ghost,
-.btn-group .btn-group + .btn-group {
-  margin-left: -1px; }
-
-.btn-toolbar {
-  margin-left: -5px; }
-  .btn-toolbar:before,
-  .btn-toolbar:after {
-    content: " ";
-    display: table; }
-  .btn-toolbar:after {
-    clear: both; }
-  .btn-toolbar .btn-group,
-  .btn-toolbar .input-group {
-    float: left; }
-  .btn-toolbar > .btn,
-  .btn-toolbar > .btn-ghost,
-  .btn-toolbar > .btn-group,
-  .btn-toolbar > .input-group {
-    margin-left: 5px; }
-
-.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:not(:first-child):not(:last-child):not(.dropdown-toggle) {
-  border-radius: 0; }
-
-.btn-group > .btn:first-child, .btn-group > .btn-ghost:first-child {
-  margin-left: 0; }
-  .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:first-child:not(:last-child):not(.dropdown-toggle) {
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0; }
-
-.btn-group > .btn:last-child:not(:first-child),
-.btn-group > .btn-ghost:last-child:not(:first-child),
-.btn-group > .dropdown-toggle:not(:first-child) {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0; }
-
-.btn-group > .btn-group {
-  float: left; }
-
-.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn, .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn-ghost {
-  border-radius: 0; }
-
-.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child,
-.btn-group > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child,
-.btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0; }
-
-.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child, .btn-group > .btn-group:last-child:not(:first-child) > .btn-ghost:first-child {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0; }
-
-.btn-group .dropdown-toggle:active,
-.btn-group.open .dropdown-toggle {
-  outline: 0; }
-
-.btn-group > .btn + .dropdown-toggle, .btn-group > .btn-ghost + .dropdown-toggle {
-  padding-left: 8px;
-  padding-right: 8px; }
-
-.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle, .btn-group-lg.btn-group > .btn-ghost + .dropdown-toggle {
-  padding-left: 12px;
-  padding-right: 12px; }
-
-.btn-group.open .dropdown-toggle {
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
-  .btn-group.open .dropdown-toggle.btn-link, .btn-group.open .dropdown-toggle.btn-secondary {
-    -webkit-box-shadow: none;
-    box-shadow: none; }
-
-.btn .caret, .btn-ghost .caret {
-  margin-left: 0; }
-
-.btn-lg .caret, .btn-group-lg > .btn .caret, .btn-group-lg > .btn-ghost .caret {
-  border-width: 5px 5px 0;
-  border-bottom-width: 0; }
-
-.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .btn-group-lg > .btn-ghost .caret {
-  border-width: 0 5px 5px; }
-
-.btn-group-vertical > .btn,
-.btn-group-vertical > .btn-ghost,
-.btn-group-vertical > .btn-group,
-.btn-group-vertical > .btn-group > .btn, .btn-group-vertical > .btn-group > .btn-ghost {
-  display: block;
-  float: none;
-  width: 100%;
-  max-width: 100%; }
-
-.btn-group-vertical > .btn-group:before,
-.btn-group-vertical > .btn-group:after {
-  content: " ";
-  display: table; }
-
-.btn-group-vertical > .btn-group:after {
-  clear: both; }
-
-.btn-group-vertical > .btn-group > .btn, .btn-group-vertical > .btn-group > .btn-ghost {
-  float: none; }
-
-.btn-group-vertical > .btn + .btn,
-.btn-group-vertical > .btn-ghost + .btn,
-.btn-group-vertical > .btn + .btn-ghost,
-.btn-group-vertical > .btn-ghost + .btn-ghost,
-.btn-group-vertical > .btn + .btn-group,
-.btn-group-vertical > .btn-ghost + .btn-group,
-.btn-group-vertical > .btn-group + .btn,
-.btn-group-vertical > .btn-group + .btn-ghost,
-.btn-group-vertical > .btn-group + .btn-group {
-  margin-top: -1px;
-  margin-left: 0; }
-
-.btn-group-vertical > .btn:not(:first-child):not(:last-child), .btn-group-vertical > .btn-ghost:not(:first-child):not(:last-child) {
-  border-radius: 0; }
-
-.btn-group-vertical > .btn:first-child:not(:last-child), .btn-group-vertical > .btn-ghost:first-child:not(:last-child) {
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.btn-group-vertical > .btn:last-child:not(:first-child), .btn-group-vertical > .btn-ghost:last-child:not(:first-child) {
-  border-bottom-left-radius: 4px;
-  border-top-right-radius: 0;
-  border-top-left-radius: 0; }
-
-.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn, .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn-ghost {
-  border-radius: 0; }
-
-.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child,
-.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child,
-.btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child, .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn-ghost:first-child {
-  border-top-right-radius: 0;
-  border-top-left-radius: 0; }
-
-.btn-group-justified {
-  display: table;
-  width: 100%;
-  table-layout: fixed;
-  border-collapse: separate; }
-  .btn-group-justified > .btn,
-  .btn-group-justified > .btn-ghost,
-  .btn-group-justified > .btn-group {
-    float: none;
-    display: table-cell;
-    width: 1%; }
-  .btn-group-justified > .btn-group .btn, .btn-group-justified > .btn-group .btn-ghost {
-    width: 100%; }
-  .btn-group-justified > .btn-group .dropdown-menu {
-    left: auto; }
-
-[data-toggle="buttons"] > .btn input[type="radio"],
-[data-toggle="buttons"] > .btn-ghost input[type="radio"],
-[data-toggle="buttons"] > .btn input[type="checkbox"],
-[data-toggle="buttons"] > .btn-ghost input[type="checkbox"],
-[data-toggle="buttons"] > .btn-group > .btn input[type="radio"],
-[data-toggle="buttons"] > .btn-group > .btn-ghost input[type="radio"],
-[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"], [data-toggle="buttons"] > .btn-group > .btn-ghost input[type="checkbox"] {
-  position: absolute;
-  clip: rect(0, 0, 0, 0);
-  pointer-events: none; }
-
-.input-group {
-  position: relative;
-  display: table;
-  border-collapse: separate; }
-  .input-group[class*="col-"] {
-    float: none;
-    padding-left: 0;
-    padding-right: 0; }
-  .input-group .form-control {
-    position: relative;
-    z-index: 2;
-    float: left;
-    width: 100%;
-    margin-bottom: 0; }
-
-.input-group-addon,
-.input-group-btn,
-.input-group .form-control {
-  display: table-cell; }
-  .input-group-addon:not(:first-child):not(:last-child),
-  .input-group-btn:not(:first-child):not(:last-child),
-  .input-group .form-control:not(:first-child):not(:last-child) {
-    border-radius: 0; }
-
-.input-group-addon,
-.input-group-btn {
-  width: 1%;
-  white-space: nowrap;
-  vertical-align: middle; }
-
-.input-group-addon {
-  padding: 6px 12px;
-  font-size: 14px;
-  font-weight: normal;
-  line-height: 1;
-  color: #666;
-  text-align: center;
-  background-color: #eeeeee;
-  border: 1px solid #ccc;
-  border-radius: 4px; }
-  .input-group-addon.input-sm, .input-group-sm > .input-group-addon,
-  .input-group-sm > .input-group-btn > .input-group-addon.btn, .input-group-sm > .input-group-btn > .input-group-addon.btn-ghost {
-    padding: 5px 10px;
-    font-size: 12px;
-    border-radius: 3px; }
-  .input-group-addon.input-lg, .input-group-lg > .input-group-addon,
-  .input-group-lg > .input-group-btn > .input-group-addon.btn, .input-group-lg > .input-group-btn > .input-group-addon.btn-ghost {
-    padding: 10px 16px;
-    font-size: 18px;
-    border-radius: 6px; }
-  .input-group-addon input[type="radio"],
-  .input-group-addon input[type="checkbox"] {
-    margin-top: 0; }
-
-.input-group .form-control:first-child,
-.input-group-addon:first-child,
-.input-group-btn:first-child > .btn,
-.input-group-btn:first-child > .btn-ghost,
-.input-group-btn:first-child > .btn-group > .btn,
-.input-group-btn:first-child > .btn-group > .btn-ghost,
-.input-group-btn:first-child > .dropdown-toggle,
-.input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
-.input-group-btn:last-child > .btn-ghost:not(:last-child):not(.dropdown-toggle),
-.input-group-btn:last-child > .btn-group:not(:last-child) > .btn, .input-group-btn:last-child > .btn-group:not(:last-child) > .btn-ghost {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0; }
-
-.input-group-addon:first-child {
-  border-right: 0; }
-
-.input-group .form-control:last-child,
-.input-group-addon:last-child,
-.input-group-btn:last-child > .btn,
-.input-group-btn:last-child > .btn-ghost,
-.input-group-btn:last-child > .btn-group > .btn,
-.input-group-btn:last-child > .btn-group > .btn-ghost,
-.input-group-btn:last-child > .dropdown-toggle,
-.input-group-btn:first-child > .btn:not(:first-child),
-.input-group-btn:first-child > .btn-ghost:not(:first-child),
-.input-group-btn:first-child > .btn-group:not(:first-child) > .btn, .input-group-btn:first-child > .btn-group:not(:first-child) > .btn-ghost {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0; }
-
-.input-group-addon:last-child {
-  border-left: 0; }
-
-.input-group-btn {
-  position: relative;
-  font-size: 0;
-  white-space: nowrap; }
-  .input-group-btn > .btn, .input-group-btn > .btn-ghost {
-    position: relative; }
-    .input-group-btn > .btn + .btn, .input-group-btn > .btn-ghost + .btn, .input-group-btn > .btn + .btn-ghost, .input-group-btn > .btn-ghost + .btn-ghost {
-      margin-left: -1px; }
-    .input-group-btn > .btn:hover,
-    .input-group-btn > .btn-ghost:hover,
-    .input-group-btn > .btn:focus,
-    .input-group-btn > .btn-ghost:focus,
-    .input-group-btn > .btn:active, .input-group-btn > .btn-ghost:active {
-      z-index: 2; }
-  .input-group-btn:first-child > .btn,
-  .input-group-btn:first-child > .btn-ghost,
-  .input-group-btn:first-child > .btn-group {
-    margin-right: -1px; }
-  .input-group-btn:last-child > .btn,
-  .input-group-btn:last-child > .btn-ghost,
-  .input-group-btn:last-child > .btn-group {
-    margin-left: -1px; }
-
-.nav {
-  margin-bottom: 0;
-  padding-left: 0;
-  list-style: none; }
-  .nav:before,
-  .nav:after {
-    content: " ";
-    display: table; }
-  .nav:after {
-    clear: both; }
-  .nav > li {
-    position: relative;
-    display: block; }
-    .nav > li > a {
-      position: relative;
-      display: block;
-      padding: 10px 15px; }
-      .nav > li > a:hover,
-      .nav > li > a:focus {
-        text-decoration: none;
-        background-color: #eeeeee; }
-    .nav > li.disabled > a {
-      color: #999999; }
-      .nav > li.disabled > a:hover,
-      .nav > li.disabled > a:focus {
-        color: #999999;
-        text-decoration: none;
-        background-color: transparent;
-        cursor: not-allowed; }
-  .nav .open > a,
-  .nav .open > a:hover,
-  .nav .open > a:focus {
-    background-color: #eeeeee;
-    border-color: #2e88be; }
-  .nav .nav-divider {
-    height: 1px;
-    margin: 9px 0;
-    overflow: hidden;
-    background-color: #e5e5e5; }
-  .nav > li > a > img {
-    max-width: none; }
-
-.nav-tabs {
-  border-bottom: 1px solid #ddd; }
-  .nav-tabs > li {
-    float: left;
-    margin-bottom: -1px; }
-    .nav-tabs > li > a {
-      margin-right: 2px;
-      line-height: 1.42857;
-      border: 1px solid transparent;
-      border-radius: 4px 4px 0 0; }
-      .nav-tabs > li > a:hover {
-        border-color: #eeeeee #eeeeee #ddd; }
-    .nav-tabs > li.active > a,
-    .nav-tabs > li.active > a:hover,
-    .nav-tabs > li.active > a:focus {
-      color: #666;
-      background-color: #fff;
-      border: 1px solid #ddd;
-      border-bottom-color: transparent;
-      cursor: default; }
-
-.nav-pills > li {
-  float: left; }
-  .nav-pills > li > a {
-    border-radius: 4px; }
-  .nav-pills > li + li {
-    margin-left: 2px; }
-  .nav-pills > li.active > a,
-  .nav-pills > li.active > a:hover,
-  .nav-pills > li.active > a:focus {
-    color: #666;
-    background-color: #f1f1f1; }
-
-.nav-stacked > li {
-  float: none; }
-  .nav-stacked > li + li {
-    margin-top: 2px;
-    margin-left: 0; }
-
-.nav-justified, .nav-tabs.nav-justified {
-  width: 100%; }
-  .nav-justified > li, .nav-tabs.nav-justified > li {
-    float: none; }
-    .nav-justified > li > a, .nav-tabs.nav-justified > li > a {
-      text-align: center;
-      margin-bottom: 5px; }
-  .nav-justified > .dropdown .dropdown-menu {
-    top: auto;
-    left: auto; }
-  @media (min-width: 768px) {
-    .nav-justified > li, .nav-tabs.nav-justified > li {
-      display: table-cell;
-      width: 1%; }
-      .nav-justified > li > a, .nav-tabs.nav-justified > li > a {
-        margin-bottom: 0; } }
-
-.nav-tabs-justified, .nav-tabs.nav-justified {
-  border-bottom: 0; }
-  .nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a {
-    margin-right: 0;
-    border-radius: 4px; }
-  .nav-tabs-justified > .active > a,
-  .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover,
-  .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus {
-    border: 1px solid #ddd; }
-  @media (min-width: 768px) {
-    .nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a {
-      border-bottom: 1px solid #ddd;
-      border-radius: 4px 4px 0 0; }
-    .nav-tabs-justified > .active > a,
-    .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover,
-    .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus {
-      border-bottom-color: #fff; } }
-
-.tab-content > .tab-pane {
-  display: none; }
-
-.tab-content > .active {
-  display: block; }
-
-.nav-tabs .dropdown-menu {
-  margin-top: -1px;
-  border-top-right-radius: 0;
-  border-top-left-radius: 0; }
-
-.navbar {
-  position: relative;
-  min-height: 50px;
-  margin-bottom: 20px;
-  border: 1px solid transparent; }
-  .navbar:before,
-  .navbar:after {
-    content: " ";
-    display: table; }
-  .navbar:after {
-    clear: both; }
-  @media (min-width: 768px) {
-    .navbar {
-      border-radius: 4px; } }
-
-.navbar-header:before,
-.navbar-header:after {
-  content: " ";
-  display: table; }
-
-.navbar-header:after {
-  clear: both; }
-
-@media (min-width: 768px) {
-  .navbar-header {
-    float: left; } }
-
-.navbar-collapse {
-  overflow-x: visible;
-  padding-right: 15px;
-  padding-left: 15px;
-  border-top: 1px solid transparent;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  -webkit-overflow-scrolling: touch; }
-  .navbar-collapse:before,
-  .navbar-collapse:after {
-    content: " ";
-    display: table; }
-  .navbar-collapse:after {
-    clear: both; }
-  .navbar-collapse.in {
-    overflow-y: auto; }
-  @media (min-width: 768px) {
-    .navbar-collapse {
-      width: auto;
-      border-top: 0;
-      box-shadow: none; }
-      .navbar-collapse.collapse {
-        display: block !important;
-        height: auto !important;
-        padding-bottom: 0;
-        overflow: visible !important; }
-      .navbar-collapse.in {
-        overflow-y: visible; }
-      .navbar-fixed-top .navbar-collapse,
-      .navbar-static-top .navbar-collapse,
-      .navbar-fixed-bottom .navbar-collapse {
-        padding-left: 0;
-        padding-right: 0; } }
-
-.navbar-fixed-top .navbar-collapse,
-.navbar-fixed-bottom .navbar-collapse {
-  max-height: 340px; }
-  @media (max-device-width: 480px) and (orientation: landscape) {
-    .navbar-fixed-top .navbar-collapse,
-    .navbar-fixed-bottom .navbar-collapse {
-      max-height: 200px; } }
-
-.container > .navbar-header,
-.container > .navbar-collapse,
-.container-fluid > .navbar-header,
-.container-fluid > .navbar-collapse {
-  margin-right: -15px;
-  margin-left: -15px; }
-  @media (min-width: 768px) {
-    .container > .navbar-header,
-    .container > .navbar-collapse,
-    .container-fluid > .navbar-header,
-    .container-fluid > .navbar-collapse {
-      margin-right: 0;
-      margin-left: 0; } }
-
-.navbar-static-top {
-  z-index: 1000;
-  border-width: 0 0 1px; }
-  @media (min-width: 768px) {
-    .navbar-static-top {
-      border-radius: 0; } }
-
-.navbar-fixed-top,
-.navbar-fixed-bottom {
-  position: fixed;
-  right: 0;
-  left: 0;
-  z-index: 1030; }
-  @media (min-width: 768px) {
-    .navbar-fixed-top,
-    .navbar-fixed-bottom {
-      border-radius: 0; } }
-
-.navbar-fixed-top {
-  top: 0;
-  border-width: 0 0 1px; }
-
-.navbar-fixed-bottom {
-  bottom: 0;
-  margin-bottom: 0;
-  border-width: 1px 0 0; }
-
-.navbar-brand {
-  float: left;
-  padding: 15px 15px;
-  font-size: 18px;
-  line-height: 20px;
-  height: 50px; }
-  .navbar-brand:hover,
-  .navbar-brand:focus {
-    text-decoration: none; }
-  .navbar-brand > img {
-    display: block; }
-  @media (min-width: 768px) {
-    .navbar > .container .navbar-brand,
-    .navbar > .container-fluid .navbar-brand {
-      margin-left: -15px; } }
-
-.navbar-toggle {
-  position: relative;
-  float: right;
-  margin-right: 15px;
-  padding: 9px 10px;
-  margin-top: 8px;
-  margin-bottom: 8px;
-  background-color: transparent;
-  background-image: none;
-  border: 1px solid transparent;
-  border-radius: 4px; }
-  .navbar-toggle:focus {
-    outline: 0; }
-  .navbar-toggle .icon-bar {
-    display: block;
-    width: 22px;
-    height: 2px;
-    border-radius: 1px; }
-  .navbar-toggle .icon-bar + .icon-bar {
-    margin-top: 4px; }
-  @media (min-width: 768px) {
-    .navbar-toggle {
-      display: none; } }
-
-.navbar-nav {
-  margin: 7.5px -15px; }
-  .navbar-nav > li > a {
-    padding-top: 10px;
-    padding-bottom: 10px;
-    line-height: 20px; }
-  @media (max-width: 767px) {
-    .navbar-nav .open .dropdown-menu {
-      position: static;
-      float: none;
-      width: auto;
-      margin-top: 0;
-      background-color: transparent;
-      border: 0;
-      box-shadow: none; }
-      .navbar-nav .open .dropdown-menu > li > a,
-      .navbar-nav .open .dropdown-menu .dropdown-header {
-        padding: 5px 15px 5px 25px; }
-      .navbar-nav .open .dropdown-menu > li > a {
-        line-height: 20px; }
-        .navbar-nav .open .dropdown-menu > li > a:hover,
-        .navbar-nav .open .dropdown-menu > li > a:focus {
-          background-image: none; } }
-  @media (min-width: 768px) {
-    .navbar-nav {
-      float: left;
-      margin: 0; }
-      .navbar-nav > li {
-        float: left; }
-        .navbar-nav > li > a {
-          padding-top: 15px;
-          padding-bottom: 15px; } }
-
-.navbar-form {
-  margin-left: -15px;
-  margin-right: -15px;
-  padding: 10px 15px;
-  border-top: 1px solid transparent;
-  border-bottom: 1px solid transparent;
-  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
-  margin-top: 8px;
-  margin-bottom: 8px; }
-  @media (min-width: 768px) {
-    .navbar-form .form-group {
-      display: inline-block;
-      margin-bottom: 0;
-      vertical-align: middle; }
-    .navbar-form .form-control {
-      display: inline-block;
-      width: auto;
-      vertical-align: middle; }
-    .navbar-form .form-control-static {
-      display: inline-block; }
-    .navbar-form .input-group {
-      display: inline-table;
-      vertical-align: middle; }
-      .navbar-form .input-group .input-group-addon,
-      .navbar-form .input-group .input-group-btn,
-      .navbar-form .input-group .form-control {
-        width: auto; }
-    .navbar-form .input-group > .form-control {
-      width: 100%; }
-    .navbar-form .control-label {
-      margin-bottom: 0;
-      vertical-align: middle; }
-    .navbar-form .radio,
-    .navbar-form .checkbox {
-      display: inline-block;
-      margin-top: 0;
-      margin-bottom: 0;
-      vertical-align: middle; }
-      .navbar-form .radio label,
-      .navbar-form .checkbox label {
-        padding-left: 0; }
-    .navbar-form .radio input[type="radio"],
-    .navbar-form .checkbox input[type="checkbox"] {
-      position: relative;
-      margin-left: 0; }
-    .navbar-form .has-feedback .form-control-feedback {
-      top: 0; } }
-  @media (max-width: 767px) {
-    .navbar-form .form-group {
-      margin-bottom: 5px; }
-      .navbar-form .form-group:last-child {
-        margin-bottom: 0; } }
-  @media (min-width: 768px) {
-    .navbar-form {
-      width: auto;
-      border: 0;
-      margin-left: 0;
-      margin-right: 0;
-      padding-top: 0;
-      padding-bottom: 0;
-      -webkit-box-shadow: none;
-      box-shadow: none; } }
-
-.navbar-nav > li > .dropdown-menu {
-  margin-top: 0;
-  border-top-right-radius: 0;
-  border-top-left-radius: 0; }
-
-.navbar-fixed-bottom .navbar-nav > li > .dropdown-menu {
-  margin-bottom: 0;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.navbar-btn {
-  margin-top: 8px;
-  margin-bottom: 8px; }
-  .navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn, .btn-group-sm > .navbar-btn.btn-ghost {
-    margin-top: 10px;
-    margin-bottom: 10px; }
-  .navbar-btn.btn-xs, .btn-group-xs > .navbar-btn.btn, .btn-group-xs > .navbar-btn.btn-ghost {
-    margin-top: 14px;
-    margin-bottom: 14px; }
-
-.navbar-text {
-  margin-top: 15px;
-  margin-bottom: 15px; }
-  @media (min-width: 768px) {
-    .navbar-text {
-      float: left;
-      margin-left: 15px;
-      margin-right: 15px; } }
-
-@media (min-width: 768px) {
-  .navbar-left {
-    float: left !important; }
-  .navbar-right {
-    float: right !important;
-    margin-right: -15px; }
-    .navbar-right ~ .navbar-right {
-      margin-right: 0; } }
-
-.navbar-default {
-  background-color: #fff;
-  border-color: #eeeeee; }
-  .navbar-default .navbar-brand {
-    color: #666; }
-    .navbar-default .navbar-brand:hover,
-    .navbar-default .navbar-brand:focus {
-      color: #4d4d4d;
-      background-color: transparent; }
-  .navbar-default .navbar-text {
-    color: #666; }
-  .navbar-default .navbar-nav > li > a {
-    color: #666; }
-    .navbar-default .navbar-nav > li > a:hover,
-    .navbar-default .navbar-nav > li > a:focus {
-      color: #333;
-      background-color: transparent; }
-  .navbar-default .navbar-nav > .active > a,
-  .navbar-default .navbar-nav > .active > a:hover,
-  .navbar-default .navbar-nav > .active > a:focus {
-    color: #e53221;
-    background-color: #f9f9f9; }
-  .navbar-default .navbar-nav > .disabled > a,
-  .navbar-default .navbar-nav > .disabled > a:hover,
-  .navbar-default .navbar-nav > .disabled > a:focus {
-    color: #ccc;
-    background-color: transparent; }
-  .navbar-default .navbar-toggle {
-    border-color: #ddd; }
-    .navbar-default .navbar-toggle:hover,
-    .navbar-default .navbar-toggle:focus {
-      background-color: #eee; }
-    .navbar-default .navbar-toggle .icon-bar {
-      background-color: #999; }
-  .navbar-default .navbar-collapse,
-  .navbar-default .navbar-form {
-    border-color: #eeeeee; }
-  .navbar-default .navbar-nav > .open > a,
-  .navbar-default .navbar-nav > .open > a:hover,
-  .navbar-default .navbar-nav > .open > a:focus {
-    background-color: #f9f9f9;
-    color: #e53221; }
-  @media (max-width: 767px) {
-    .navbar-default .navbar-nav .open .dropdown-menu > li > a {
-      color: #666; }
-      .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
-      .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
-        color: #333;
-        background-color: transparent; }
-    .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
-    .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
-    .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
-      color: #e53221;
-      background-color: #f9f9f9; }
-    .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
-    .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
-    .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
-      color: #ccc;
-      background-color: transparent; } }
-  .navbar-default .navbar-link {
-    color: #666; }
-    .navbar-default .navbar-link:hover {
-      color: #333; }
-  .navbar-default .btn-link, .navbar-default .btn-secondary {
-    color: #666; }
-    .navbar-default .btn-link:hover,
-    .navbar-default .btn-secondary:hover,
-    .navbar-default .btn-link:focus, .navbar-default .btn-secondary:focus {
-      color: #333; }
-    .navbar-default .btn-link[disabled]:hover,
-    .navbar-default [disabled].btn-secondary:hover,
-    .navbar-default .btn-link[disabled]:focus,
-    .navbar-default [disabled].btn-secondary:focus,
-    fieldset[disabled] .navbar-default .btn-link:hover,
-    fieldset[disabled] .navbar-default .btn-secondary:hover,
-    fieldset[disabled] .navbar-default .btn-link:focus, fieldset[disabled] .navbar-default .btn-secondary:focus {
-      color: #ccc; }
-
-.navbar-inverse {
-  background-color: #222;
-  border-color: #090909; }
-  .navbar-inverse .navbar-brand {
-    color: #999999; }
-    .navbar-inverse .navbar-brand:hover,
-    .navbar-inverse .navbar-brand:focus {
-      color: #fff;
-      background-color: transparent; }
-  .navbar-inverse .navbar-text {
-    color: #999999; }
-  .navbar-inverse .navbar-nav > li > a {
-    color: #999999; }
-    .navbar-inverse .navbar-nav > li > a:hover,
-    .navbar-inverse .navbar-nav > li > a:focus {
-      color: #fff;
-      background-color: transparent; }
-  .navbar-inverse .navbar-nav > .active > a,
-  .navbar-inverse .navbar-nav > .active > a:hover,
-  .navbar-inverse .navbar-nav > .active > a:focus {
-    color: #fff;
-    background-color: #090909; }
-  .navbar-inverse .navbar-nav > .disabled > a,
-  .navbar-inverse .navbar-nav > .disabled > a:hover,
-  .navbar-inverse .navbar-nav > .disabled > a:focus {
-    color: #444;
-    background-color: transparent; }
-  .navbar-inverse .navbar-toggle {
-    border-color: #333; }
-    .navbar-inverse .navbar-toggle:hover,
-    .navbar-inverse .navbar-toggle:focus {
-      background-color: #333; }
-    .navbar-inverse .navbar-toggle .icon-bar {
-      background-color: #fff; }
-  .navbar-inverse .navbar-collapse,
-  .navbar-inverse .navbar-form {
-    border-color: #101010; }
-  .navbar-inverse .navbar-nav > .open > a,
-  .navbar-inverse .navbar-nav > .open > a:hover,
-  .navbar-inverse .navbar-nav > .open > a:focus {
-    background-color: #090909;
-    color: #fff; }
-  @media (max-width: 767px) {
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
-      border-color: #090909; }
-    .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
-      background-color: #090909; }
-    .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
-      color: #999999; }
-      .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
-      .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
-        color: #fff;
-        background-color: transparent; }
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a,
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover,
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
-      color: #fff;
-      background-color: #090909; }
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a,
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover,
-    .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
-      color: #444;
-      background-color: transparent; } }
-  .navbar-inverse .navbar-link {
-    color: #999999; }
-    .navbar-inverse .navbar-link:hover {
-      color: #fff; }
-  .navbar-inverse .btn-link, .navbar-inverse .btn-secondary {
-    color: #999999; }
-    .navbar-inverse .btn-link:hover,
-    .navbar-inverse .btn-secondary:hover,
-    .navbar-inverse .btn-link:focus, .navbar-inverse .btn-secondary:focus {
-      color: #fff; }
-    .navbar-inverse .btn-link[disabled]:hover,
-    .navbar-inverse [disabled].btn-secondary:hover,
-    .navbar-inverse .btn-link[disabled]:focus,
-    .navbar-inverse [disabled].btn-secondary:focus,
-    fieldset[disabled] .navbar-inverse .btn-link:hover,
-    fieldset[disabled] .navbar-inverse .btn-secondary:hover,
-    fieldset[disabled] .navbar-inverse .btn-link:focus, fieldset[disabled] .navbar-inverse .btn-secondary:focus {
-      color: #444; }
-
-.breadcrumb {
-  padding: 8px 15px;
-  margin-bottom: 20px;
-  list-style: none;
-  background-color: #f5f5f5;
-  border-radius: 4px; }
-  .breadcrumb > li {
-    display: inline-block; }
-    .breadcrumb > li + li:before {
-      content: "/\\00a0";
-      padding: 0 5px;
-      color: #ccc; }
-  .breadcrumb > .active {
-    color: #999999; }
-
-.pagination {
-  display: inline-block;
-  padding-left: 0;
-  margin: 20px 0;
-  border-radius: 4px; }
-  .pagination > li {
-    display: inline; }
-    .pagination > li > a,
-    .pagination > li > span {
-      position: relative;
-      float: left;
-      padding: 6px 12px;
-      line-height: 1.42857;
-      text-decoration: none;
-      color: #2e88be;
-      background-color: #fff;
-      border: 1px solid #ddd;
-      margin-left: -1px; }
-    .pagination > li:first-child > a,
-    .pagination > li:first-child > span {
-      margin-left: 0;
-      border-bottom-left-radius: 4px;
-      border-top-left-radius: 4px; }
-    .pagination > li:last-child > a,
-    .pagination > li:last-child > span {
-      border-bottom-right-radius: 4px;
-      border-top-right-radius: 4px; }
-  .pagination > li > a:hover,
-  .pagination > li > a:focus,
-  .pagination > li > span:hover,
-  .pagination > li > span:focus {
-    color: #1f5c80;
-    background-color: #eeeeee;
-    border-color: #ddd; }
-  .pagination > .active > a,
-  .pagination > .active > a:hover,
-  .pagination > .active > a:focus,
-  .pagination > .active > span,
-  .pagination > .active > span:hover,
-  .pagination > .active > span:focus {
-    z-index: 2;
-    color: #fff;
-    background-color: #f1f1f1;
-    border-color: #f1f1f1;
-    cursor: default; }
-  .pagination > .disabled > span,
-  .pagination > .disabled > span:hover,
-  .pagination > .disabled > span:focus,
-  .pagination > .disabled > a,
-  .pagination > .disabled > a:hover,
-  .pagination > .disabled > a:focus {
-    color: #999999;
-    background-color: #fff;
-    border-color: #ddd;
-    cursor: not-allowed; }
-
-.pagination-lg > li > a,
-.pagination-lg > li > span {
-  padding: 10px 16px;
-  font-size: 18px; }
-
-.pagination-lg > li:first-child > a,
-.pagination-lg > li:first-child > span {
-  border-bottom-left-radius: 6px;
-  border-top-left-radius: 6px; }
-
-.pagination-lg > li:last-child > a,
-.pagination-lg > li:last-child > span {
-  border-bottom-right-radius: 6px;
-  border-top-right-radius: 6px; }
-
-.pagination-sm > li > a,
-.pagination-sm > li > span {
-  padding: 5px 10px;
-  font-size: 12px; }
-
-.pagination-sm > li:first-child > a,
-.pagination-sm > li:first-child > span {
-  border-bottom-left-radius: 3px;
-  border-top-left-radius: 3px; }
-
-.pagination-sm > li:last-child > a,
-.pagination-sm > li:last-child > span {
-  border-bottom-right-radius: 3px;
-  border-top-right-radius: 3px; }
-
-.pager {
-  padding-left: 0;
-  margin: 20px 0;
-  list-style: none;
-  text-align: center; }
-  .pager:before,
-  .pager:after {
-    content: " ";
-    display: table; }
-  .pager:after {
-    clear: both; }
-  .pager li {
-    display: inline; }
-    .pager li > a,
-    .pager li > span {
-      display: inline-block;
-      padding: 5px 14px;
-      background-color: #fff;
-      border: 1px solid #ddd;
-      border-radius: 15px; }
-    .pager li > a:hover,
-    .pager li > a:focus {
-      text-decoration: none;
-      background-color: #eeeeee; }
-  .pager .next > a,
-  .pager .next > span {
-    float: right; }
-  .pager .previous > a,
-  .pager .previous > span {
-    float: left; }
-  .pager .disabled > a,
-  .pager .disabled > a:hover,
-  .pager .disabled > a:focus,
-  .pager .disabled > span {
-    color: #999999;
-    background-color: #fff;
-    cursor: not-allowed; }
-
-.label {
-  display: inline;
-  padding: 0.2em 0.6em 0.3em;
-  font-size: 75%;
-  font-weight: bold;
-  line-height: 1;
-  color: #fff;
-  text-align: center;
-  white-space: nowrap;
-  vertical-align: baseline;
-  border-radius: .25em; }
-  .label:empty {
-    display: none; }
-  .btn .label, .btn-ghost .label {
-    position: relative;
-    top: -1px; }
-
-a.label:hover,
-a.label:focus {
-  color: #fff;
-  text-decoration: none;
-  cursor: pointer; }
-
-.label-default {
-  background-color: #999999; }
-  .label-default[href]:hover,
-  .label-default[href]:focus {
-    background-color: gray; }
-
-.label-primary {
-  background-color: #f1f1f1; }
-  .label-primary[href]:hover,
-  .label-primary[href]:focus {
-    background-color: #d7d7d7; }
-
-.label-success {
-  background-color: #9bb83a; }
-  .label-success[href]:hover,
-  .label-success[href]:focus {
-    background-color: #7a912e; }
-
-.label-info {
-  background-color: #389Bc9; }
-  .label-info[href]:hover,
-  .label-info[href]:focus {
-    background-color: #2c7da2; }
-
-.label-warning {
-  background-color: #e5d321; }
-  .label-warning[href]:hover,
-  .label-warning[href]:focus {
-    background-color: #bdae16; }
-
-.label-danger {
-  background-color: #e53221; }
-  .label-danger[href]:hover,
-  .label-danger[href]:focus {
-    background-color: #bd2516; }
-
-.badge {
-  display: inline-block;
-  min-width: 10px;
-  padding: 3px 7px;
-  font-size: 12px;
-  font-weight: bold;
-  color: #fff;
-  line-height: 1;
-  vertical-align: baseline;
-  white-space: nowrap;
-  text-align: center;
-  background-color: #999999;
-  border-radius: 10px; }
-  .badge:empty {
-    display: none; }
-  .btn .badge, .btn-ghost .badge {
-    position: relative;
-    top: -1px; }
-  .btn-xs .badge,
-  .btn-group-xs > .btn .badge,
-  .btn-group-xs > .btn-ghost .badge,
-  .btn-group-xs > .btn .badge, .btn-group-xs > .btn-ghost .badge {
-    top: 0;
-    padding: 1px 5px; }
-  .list-group-item.active > .badge,
-  .nav-pills > .active > a > .badge {
-    color: #2e88be;
-    background-color: #fff; }
-  .list-group-item > .badge {
-    float: right; }
-  .list-group-item > .badge + .badge {
-    margin-right: 5px; }
-  .nav-pills > li > a > .badge {
-    margin-left: 3px; }
-
-a.badge:hover,
-a.badge:focus {
-  color: #fff;
-  text-decoration: none;
-  cursor: pointer; }
-
-.jumbotron {
-  padding: 30px 15px;
-  margin-bottom: 30px;
-  color: inherit;
-  background-color: #eeeeee; }
-  .jumbotron h1,
-  .jumbotron .h1 {
-    color: inherit; }
-  .jumbotron p {
-    margin-bottom: 15px;
-    font-size: 21px;
-    font-weight: 200; }
-  .jumbotron > hr {
-    border-top-color: #d5d5d5; }
-  .container .jumbotron,
-  .container-fluid .jumbotron {
-    border-radius: 6px; }
-  .jumbotron .container {
-    max-width: 100%; }
-  @media screen and (min-width: 768px) {
-    .jumbotron {
-      padding: 48px 0; }
-      .container .jumbotron,
-      .container-fluid .jumbotron {
-        padding-left: 60px;
-        padding-right: 60px; }
-      .jumbotron h1,
-      .jumbotron .h1 {
-        font-size: 63px; } }
-
-.thumbnail {
-  display: block;
-  padding: 4px;
-  margin-bottom: 20px;
-  line-height: 1.42857;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  -webkit-transition: border 0.2s ease-in-out;
-  -o-transition: border 0.2s ease-in-out;
-  transition: border 0.2s ease-in-out; }
-  .thumbnail > img,
-  .thumbnail a > img {
-    display: block;
-    max-width: 100%;
-    height: auto;
-    margin-left: auto;
-    margin-right: auto; }
-  .thumbnail .caption {
-    padding: 9px;
-    color: #666; }
-
-a.thumbnail:hover,
-a.thumbnail:focus,
-a.thumbnail.active {
-  border-color: #2e88be; }
-
-.alert {
-  padding: 15px;
-  margin-bottom: 20px;
-  border: 1px solid transparent;
-  border-radius: 4px; }
-  .alert h4 {
-    margin-top: 0;
-    color: inherit; }
-  .alert .alert-link {
-    font-weight: bold; }
-  .alert > p,
-  .alert > ul {
-    margin-bottom: 0; }
-  .alert > p + p {
-    margin-top: 5px; }
-
-.alert-dismissable, .alert-dismissible {
-  padding-right: 35px; }
-  .alert-dismissable .close, .alert-dismissible .close {
-    position: relative;
-    top: -2px;
-    right: -21px;
-    color: inherit; }
-
-.alert-success {
-  background-color: #ebf1d8;
-  border-color: #cddc9d;
-  color: #4e5c1d; }
-  .alert-success hr {
-    border-top-color: #c3d58a; }
-  .alert-success .alert-link {
-    color: #2d3511; }
-
-.alert-info {
-  background-color: #d7ebf4;
-  border-color: #9ccde4;
-  color: #1c4e65; }
-  .alert-info hr {
-    border-top-color: #88c3df; }
-  .alert-info .alert-link {
-    color: #112f3d; }
-
-.alert-warning {
-  background-color: #faf6d3;
-  border-color: #f2e990;
-  color: #736a11; }
-  .alert-warning hr {
-    border-top-color: #efe479; }
-  .alert-warning .alert-link {
-    color: #47410a; }
-
-.alert-danger {
-  background-color: #fad6d3;
-  border-color: #f29990;
-  color: #731911; }
-  .alert-danger hr {
-    border-top-color: #ef8479; }
-  .alert-danger .alert-link {
-    color: #470f0a; }
-
-@-webkit-keyframes progress-bar-stripes {
-  from {
-    background-position: 40px 0; }
-  to {
-    background-position: 0 0; } }
-
-@keyframes progress-bar-stripes {
-  from {
-    background-position: 40px 0; }
-  to {
-    background-position: 0 0; } }
-
-.progress {
-  overflow: hidden;
-  height: 20px;
-  margin-bottom: 20px;
-  background-color: #f5f5f5;
-  border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); }
-
-.progress-bar {
-  float: left;
-  width: 0%;
-  height: 100%;
-  font-size: 12px;
-  line-height: 20px;
-  color: #fff;
-  text-align: center;
-  background-color: #f1f1f1;
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-  -webkit-transition: width 0.6s ease;
-  -o-transition: width 0.6s ease;
-  transition: width 0.6s ease; }
-
-.progress-striped .progress-bar,
-.progress-bar-striped {
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-size: 40px 40px; }
-
-.progress.active .progress-bar,
-.progress-bar.active {
-  -webkit-animation: progress-bar-stripes 2s linear infinite;
-  -o-animation: progress-bar-stripes 2s linear infinite;
-  animation: progress-bar-stripes 2s linear infinite; }
-
-.progress-bar-success {
-  background-color: #9bb83a; }
-  .progress-striped .progress-bar-success {
-    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
-
-.progress-bar-info {
-  background-color: #389Bc9; }
-  .progress-striped .progress-bar-info {
-    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
-
-.progress-bar-warning {
-  background-color: #e5d321; }
-  .progress-striped .progress-bar-warning {
-    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
-
-.progress-bar-danger {
-  background-color: #e53221; }
-  .progress-striped .progress-bar-danger {
-    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
-
-.media {
-  margin-top: 15px; }
-  .media:first-child {
-    margin-top: 0; }
-
-.media,
-.media-body {
-  zoom: 1;
-  overflow: hidden; }
-
-.media-body {
-  width: 10000px; }
-
-.media-object {
-  display: block; }
-
-.media-right,
-.media > .pull-right {
-  padding-left: 10px; }
-
-.media-left,
-.media > .pull-left {
-  padding-right: 10px; }
-
-.media-left,
-.media-right,
-.media-body {
-  display: table-cell;
-  vertical-align: top; }
-
-.media-middle {
-  vertical-align: middle; }
-
-.media-bottom {
-  vertical-align: bottom; }
-
-.media-heading {
-  margin-top: 0;
-  margin-bottom: 5px; }
-
-.media-list {
-  padding-left: 0;
-  list-style: none; }
-
-.list-group {
-  margin-bottom: 20px;
-  padding-left: 0; }
-
-.list-group-item {
-  position: relative;
-  display: block;
-  padding: 10px 15px;
-  margin-bottom: -1px;
-  background-color: #fff;
-  border: 1px solid #ddd; }
-  .list-group-item:first-child {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px; }
-  .list-group-item:last-child {
-    margin-bottom: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px; }
-
-a.list-group-item {
-  color: #555; }
-  a.list-group-item .list-group-item-heading {
-    color: #333; }
-  a.list-group-item:hover,
-  a.list-group-item:focus {
-    text-decoration: none;
-    color: #555;
-    background-color: #f5f5f5; }
-
-.list-group-item.disabled,
-.list-group-item.disabled:hover,
-.list-group-item.disabled:focus {
-  background-color: #eeeeee;
-  color: #999999;
-  cursor: not-allowed; }
-  .list-group-item.disabled .list-group-item-heading,
-  .list-group-item.disabled:hover .list-group-item-heading,
-  .list-group-item.disabled:focus .list-group-item-heading {
-    color: inherit; }
-  .list-group-item.disabled .list-group-item-text,
-  .list-group-item.disabled:hover .list-group-item-text,
-  .list-group-item.disabled:focus .list-group-item-text {
-    color: #999999; }
-
-.list-group-item.active,
-.list-group-item.active:hover,
-.list-group-item.active:focus {
-  z-index: 2;
-  color: #666;
-  background-color: #f1f1f1;
-  border-color: #f1f1f1; }
-  .list-group-item.active .list-group-item-heading,
-  .list-group-item.active .list-group-item-heading > small,
-  .list-group-item.active .list-group-item-heading > .small,
-  .list-group-item.active:hover .list-group-item-heading,
-  .list-group-item.active:hover .list-group-item-heading > small,
-  .list-group-item.active:hover .list-group-item-heading > .small,
-  .list-group-item.active:focus .list-group-item-heading,
-  .list-group-item.active:focus .list-group-item-heading > small,
-  .list-group-item.active:focus .list-group-item-heading > .small {
-    color: inherit; }
-  .list-group-item.active .list-group-item-text,
-  .list-group-item.active:hover .list-group-item-text,
-  .list-group-item.active:focus .list-group-item-text {
-    color: white; }
-
-.list-group-item-success {
-  color: #9bb83a;
-  background-color: #f5f8eb; }
-
-a.list-group-item-success {
-  color: #9bb83a; }
-  a.list-group-item-success .list-group-item-heading {
-    color: inherit; }
-  a.list-group-item-success:hover,
-  a.list-group-item-success:focus {
-    color: #9bb83a;
-    background-color: #ecf1d8; }
-  a.list-group-item-success.active,
-  a.list-group-item-success.active:hover,
-  a.list-group-item-success.active:focus {
-    color: #fff;
-    background-color: #9bb83a;
-    border-color: #9bb83a; }
-
-.list-group-item-info {
-  color: #389Bc9;
-  background-color: #ebf5f9; }
-
-a.list-group-item-info {
-  color: #389Bc9; }
-  a.list-group-item-info .list-group-item-heading {
-    color: inherit; }
-  a.list-group-item-info:hover,
-  a.list-group-item-info:focus {
-    color: #389Bc9;
-    background-color: #d7ebf3; }
-  a.list-group-item-info.active,
-  a.list-group-item-info.active:hover,
-  a.list-group-item-info.active:focus {
-    color: #fff;
-    background-color: #389Bc9;
-    border-color: #389Bc9; }
-
-.list-group-item-warning {
-  color: #e5d321;
-  background-color: #fdfde9; }
-
-a.list-group-item-warning {
-  color: #e5d321; }
-  a.list-group-item-warning .list-group-item-heading {
-    color: inherit; }
-  a.list-group-item-warning:hover,
-  a.list-group-item-warning:focus {
-    color: #e5d321;
-    background-color: #fbfbd2; }
-  a.list-group-item-warning.active,
-  a.list-group-item-warning.active:hover,
-  a.list-group-item-warning.active:focus {
-    color: #fff;
-    background-color: #e5d321;
-    border-color: #e5d321; }
-
-.list-group-item-danger {
-  color: #e53221;
-  background-color: #fceae8; }
-
-a.list-group-item-danger {
-  color: #e53221; }
-  a.list-group-item-danger .list-group-item-heading {
-    color: inherit; }
-  a.list-group-item-danger:hover,
-  a.list-group-item-danger:focus {
-    color: #e53221;
-    background-color: #f9d5d1; }
-  a.list-group-item-danger.active,
-  a.list-group-item-danger.active:hover,
-  a.list-group-item-danger.active:focus {
-    color: #fff;
-    background-color: #e53221;
-    border-color: #e53221; }
-
-.list-group-item-heading {
-  margin-top: 0;
-  margin-bottom: 5px; }
-
-.list-group-item-text {
-  margin-bottom: 0;
-  line-height: 1.3; }
-
-.panel {
-  margin-bottom: 20px;
-  background-color: #fff;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05); }
-
-.panel-body {
-  padding: 15px; }
-  .panel-body:before,
-  .panel-body:after {
-    content: " ";
-    display: table; }
-  .panel-body:after {
-    clear: both; }
-
-.panel-heading {
-  padding: 10px 15px;
-  border-bottom: 1px solid transparent;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px; }
-  .panel-heading > .dropdown .dropdown-toggle {
-    color: inherit; }
-
-.panel-title {
-  margin-top: 0;
-  margin-bottom: 0;
-  font-size: 16px;
-  color: inherit; }
-  .panel-title > a,
-  .panel-title > small,
-  .panel-title > .small,
-  .panel-title > small > a,
-  .panel-title > .small > a {
-    color: inherit; }
-
-.panel-footer {
-  padding: 10px 15px;
-  background-color: #f5f5f5;
-  border-top: 1px solid #ddd;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px; }
-
-.panel > .list-group,
-.panel > .panel-collapse > .list-group {
-  margin-bottom: 0; }
-  .panel > .list-group .list-group-item,
-  .panel > .panel-collapse > .list-group .list-group-item {
-    border-width: 1px 0;
-    border-radius: 0; }
-  .panel > .list-group:first-child .list-group-item:first-child,
-  .panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
-    border-top: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px; }
-  .panel > .list-group:last-child .list-group-item:last-child,
-  .panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
-    border-bottom: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px; }
-
-.panel-heading + .list-group .list-group-item:first-child {
-  border-top-width: 0; }
-
-.list-group + .panel-footer {
-  border-top-width: 0; }
-
-.panel > .table,
-.panel > .table-responsive > .table,
-.panel > .panel-collapse > .table {
-  margin-bottom: 0; }
-  .panel > .table caption,
-  .panel > .table-responsive > .table caption,
-  .panel > .panel-collapse > .table caption {
-    padding-left: 15px;
-    padding-right: 15px; }
-
-.panel > .table:first-child,
-.panel > .table-responsive:first-child > .table:first-child {
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px; }
-  .panel > .table:first-child > thead:first-child > tr:first-child,
-  .panel > .table:first-child > tbody:first-child > tr:first-child,
-  .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child,
-  .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px; }
-    .panel > .table:first-child > thead:first-child > tr:first-child td:first-child,
-    .panel > .table:first-child > thead:first-child > tr:first-child th:first-child,
-    .panel > .table:first-child > tbody:first-child > tr:first-child td:first-child,
-    .panel > .table:first-child > tbody:first-child > tr:first-child th:first-child,
-    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:first-child,
-    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:first-child,
-    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:first-child,
-    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child {
-      border-top-left-radius: 3px; }
-    .panel > .table:first-child > thead:first-child > tr:first-child td:last-child,
-    .panel > .table:first-child > thead:first-child > tr:first-child th:last-child,
-    .panel > .table:first-child > tbody:first-child > tr:first-child td:last-child,
-    .panel > .table:first-child > tbody:first-child > tr:first-child th:last-child,
-    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:last-child,
-    .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:last-child,
-    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:last-child,
-    .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child {
-      border-top-right-radius: 3px; }
-
-.panel > .table:last-child,
-.panel > .table-responsive:last-child > .table:last-child {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px; }
-  .panel > .table:last-child > tbody:last-child > tr:last-child,
-  .panel > .table:last-child > tfoot:last-child > tr:last-child,
-  .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child,
-  .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px; }
-    .panel > .table:last-child > tbody:last-child > tr:last-child td:first-child,
-    .panel > .table:last-child > tbody:last-child > tr:last-child th:first-child,
-    .panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
-    .panel > .table:last-child > tfoot:last-child > tr:last-child th:first-child,
-    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:first-child,
-    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:first-child,
-    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
-    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child {
-      border-bottom-left-radius: 3px; }
-    .panel > .table:last-child > tbody:last-child > tr:last-child td:last-child,
-    .panel > .table:last-child > tbody:last-child > tr:last-child th:last-child,
-    .panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
-    .panel > .table:last-child > tfoot:last-child > tr:last-child th:last-child,
-    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:last-child,
-    .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:last-child,
-    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
-    .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child {
-      border-bottom-right-radius: 3px; }
-
-.panel > .panel-body + .table,
-.panel > .panel-body + .table-responsive,
-.panel > .table + .panel-body,
-.panel > .table-responsive + .panel-body {
-  border-top: 1px solid #ddd; }
-
-.panel > .table > tbody:first-child > tr:first-child th,
-.panel > .table > tbody:first-child > tr:first-child td {
-  border-top: 0; }
-
-.panel > .table-bordered,
-.panel > .table-responsive > .table-bordered {
-  border: 0; }
-  .panel > .table-bordered > thead > tr > th:first-child,
-  .panel > .table-bordered > thead > tr > td:first-child,
-  .panel > .table-bordered > tbody > tr > th:first-child,
-  .panel > .table-bordered > tbody > tr > td:first-child,
-  .panel > .table-bordered > tfoot > tr > th:first-child,
-  .panel > .table-bordered > tfoot > tr > td:first-child,
-  .panel > .table-responsive > .table-bordered > thead > tr > th:first-child,
-  .panel > .table-responsive > .table-bordered > thead > tr > td:first-child,
-  .panel > .table-responsive > .table-bordered > tbody > tr > th:first-child,
-  .panel > .table-responsive > .table-bordered > tbody > tr > td:first-child,
-  .panel > .table-responsive > .table-bordered > tfoot > tr > th:first-child,
-  .panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child {
-    border-left: 0; }
-  .panel > .table-bordered > thead > tr > th:last-child,
-  .panel > .table-bordered > thead > tr > td:last-child,
-  .panel > .table-bordered > tbody > tr > th:last-child,
-  .panel > .table-bordered > tbody > tr > td:last-child,
-  .panel > .table-bordered > tfoot > tr > th:last-child,
-  .panel > .table-bordered > tfoot > tr > td:last-child,
-  .panel > .table-responsive > .table-bordered > thead > tr > th:last-child,
-  .panel > .table-responsive > .table-bordered > thead > tr > td:last-child,
-  .panel > .table-responsive > .table-bordered > tbody > tr > th:last-child,
-  .panel > .table-responsive > .table-bordered > tbody > tr > td:last-child,
-  .panel > .table-responsive > .table-bordered > tfoot > tr > th:last-child,
-  .panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child {
-    border-right: 0; }
-  .panel > .table-bordered > thead > tr:first-child > td,
-  .panel > .table-bordered > thead > tr:first-child > th,
-  .panel > .table-bordered > tbody > tr:first-child > td,
-  .panel > .table-bordered > tbody > tr:first-child > th,
-  .panel > .table-responsive > .table-bordered > thead > tr:first-child > td,
-  .panel > .table-responsive > .table-bordered > thead > tr:first-child > th,
-  .panel > .table-responsive > .table-bordered > tbody > tr:first-child > td,
-  .panel > .table-responsive > .table-bordered > tbody > tr:first-child > th {
-    border-bottom: 0; }
-  .panel > .table-bordered > tbody > tr:last-child > td,
-  .panel > .table-bordered > tbody > tr:last-child > th,
-  .panel > .table-bordered > tfoot > tr:last-child > td,
-  .panel > .table-bordered > tfoot > tr:last-child > th,
-  .panel > .table-responsive > .table-bordered > tbody > tr:last-child > td,
-  .panel > .table-responsive > .table-bordered > tbody > tr:last-child > th,
-  .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > td,
-  .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th {
-    border-bottom: 0; }
-
-.panel > .table-responsive {
-  border: 0;
-  margin-bottom: 0; }
-
-.panel-group {
-  margin-bottom: 20px; }
-  .panel-group .panel {
-    margin-bottom: 0;
-    border-radius: 4px; }
-    .panel-group .panel + .panel {
-      margin-top: 5px; }
-  .panel-group .panel-heading {
-    border-bottom: 0; }
-    .panel-group .panel-heading + .panel-collapse > .panel-body,
-    .panel-group .panel-heading + .panel-collapse > .list-group {
-      border-top: 1px solid #ddd; }
-  .panel-group .panel-footer {
-    border-top: 0; }
-    .panel-group .panel-footer + .panel-collapse .panel-body {
-      border-bottom: 1px solid #ddd; }
-
-.panel-default {
-  border-color: #ddd; }
-  .panel-default > .panel-heading {
-    color: #333333;
-    background-color: #f5f5f5;
-    border-color: #ddd; }
-    .panel-default > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #ddd; }
-    .panel-default > .panel-heading .badge {
-      color: #f5f5f5;
-      background-color: #333333; }
-  .panel-default > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #ddd; }
-
-.panel-primary {
-  border-color: #f1f1f1; }
-  .panel-primary > .panel-heading {
-    color: #fff;
-    background-color: #f1f1f1;
-    border-color: #f1f1f1; }
-    .panel-primary > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #f1f1f1; }
-    .panel-primary > .panel-heading .badge {
-      color: #f1f1f1;
-      background-color: #fff; }
-  .panel-primary > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #f1f1f1; }
-
-.panel-success {
-  border-color: #f5f8eb; }
-  .panel-success > .panel-heading {
-    color: #9bb83a;
-    background-color: #f5f8eb;
-    border-color: #f5f8eb; }
-    .panel-success > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #f5f8eb; }
-    .panel-success > .panel-heading .badge {
-      color: #f5f8eb;
-      background-color: #9bb83a; }
-  .panel-success > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #f5f8eb; }
-
-.panel-info {
-  border-color: #ebf5f9; }
-  .panel-info > .panel-heading {
-    color: #389Bc9;
-    background-color: #ebf5f9;
-    border-color: #ebf5f9; }
-    .panel-info > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #ebf5f9; }
-    .panel-info > .panel-heading .badge {
-      color: #ebf5f9;
-      background-color: #389Bc9; }
-  .panel-info > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #ebf5f9; }
-
-.panel-warning {
-  border-color: #fdfde9; }
-  .panel-warning > .panel-heading {
-    color: #e5d321;
-    background-color: #fdfde9;
-    border-color: #fdfde9; }
-    .panel-warning > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #fdfde9; }
-    .panel-warning > .panel-heading .badge {
-      color: #fdfde9;
-      background-color: #e5d321; }
-  .panel-warning > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #fdfde9; }
-
-.panel-danger {
-  border-color: #fceae8; }
-  .panel-danger > .panel-heading {
-    color: #e53221;
-    background-color: #fceae8;
-    border-color: #fceae8; }
-    .panel-danger > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #fceae8; }
-    .panel-danger > .panel-heading .badge {
-      color: #fceae8;
-      background-color: #e53221; }
-  .panel-danger > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #fceae8; }
-
-.embed-responsive {
-  position: relative;
-  display: block;
-  height: 0;
-  padding: 0;
-  overflow: hidden; }
-  .embed-responsive .embed-responsive-item,
-  .embed-responsive iframe,
-  .embed-responsive embed,
-  .embed-responsive object,
-  .embed-responsive video {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    height: 100%;
-    width: 100%;
-    border: 0; }
-
-.embed-responsive-16by9 {
-  padding-bottom: 56.25%; }
-
-.embed-responsive-4by3 {
-  padding-bottom: 75%; }
-
-.well {
-  min-height: 20px;
-  padding: 19px;
-  margin-bottom: 20px;
-  background-color: #f5f5f5;
-  border: 1px solid #e3e3e3;
-  border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); }
-  .well blockquote {
-    border-color: #ddd;
-    border-color: rgba(0, 0, 0, 0.15); }
-
-.well-lg {
-  padding: 24px;
-  border-radius: 6px; }
-
-.well-sm {
-  padding: 9px;
-  border-radius: 3px; }
-
-.close {
-  float: right;
-  font-size: 21px;
-  font-weight: bold;
-  line-height: 1;
-  color: #000;
-  text-shadow: 0 1px 0 #fff;
-  opacity: 0.2;
-  filter: alpha(opacity=20); }
-  .close:hover,
-  .close:focus {
-    color: #000;
-    text-decoration: none;
-    cursor: pointer;
-    opacity: 0.5;
-    filter: alpha(opacity=50); }
-
-button.close {
-  padding: 0;
-  cursor: pointer;
-  background: transparent;
-  border: 0;
-  -webkit-appearance: none; }
-
-.modal-open {
-  overflow: hidden; }
-
-.modal {
-  display: none;
-  overflow: hidden;
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1050;
-  -webkit-overflow-scrolling: touch;
-  outline: 0; }
-  .modal.fade .modal-dialog {
-    -webkit-transform: translate(0, -25%);
-    -ms-transform: translate(0, -25%);
-    -o-transform: translate(0, -25%);
-    transform: translate(0, -25%);
-    -webkit-transition: -webkit-transform 0.3s ease-out;
-    -moz-transition: -moz-transform 0.3s ease-out;
-    -o-transition: -o-transform 0.3s ease-out;
-    transition: transform 0.3s ease-out; }
-  .modal.in .modal-dialog {
-    -webkit-transform: translate(0, 0);
-    -ms-transform: translate(0, 0);
-    -o-transform: translate(0, 0);
-    transform: translate(0, 0); }
-
-.modal-open .modal {
-  overflow-x: hidden;
-  overflow-y: auto; }
-
-.modal-dialog {
-  position: relative;
-  width: auto;
-  margin: 10px; }
-
-.modal-content {
-  position: relative;
-  background-color: #fff;
-  border: 1px solid #999;
-  border: 1px solid #bbb;
-  border-radius: 6px;
-  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-  background-clip: padding-box;
-  outline: 0; }
-
-.modal-backdrop {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1040;
-  background-color: #000; }
-  .modal-backdrop.fade {
-    opacity: 0;
-    filter: alpha(opacity=0); }
-  .modal-backdrop.in {
-    opacity: 0.5;
-    filter: alpha(opacity=50); }
-
-.modal-header {
-  padding: 15px;
-  border-bottom: 1px solid #ddd;
-  min-height: 16.42857px; }
-
-.modal-header .close {
-  margin-top: -2px; }
-
-.modal-title {
-  margin: 0;
-  line-height: 1.42857; }
-
-.modal-body {
-  position: relative;
-  padding: 15px; }
-
-.modal-footer {
-  padding: 15px;
-  text-align: right;
-  border-top: 1px solid #ddd; }
-  .modal-footer:before,
-  .modal-footer:after {
-    content: " ";
-    display: table; }
-  .modal-footer:after {
-    clear: both; }
-  .modal-footer .btn + .btn, .modal-footer .btn-ghost + .btn, .modal-footer .btn + .btn-ghost, .modal-footer .btn-ghost + .btn-ghost {
-    margin-left: 5px;
-    margin-bottom: 0; }
-  .modal-footer .btn-group .btn + .btn, .modal-footer .btn-group .btn-ghost + .btn, .modal-footer .btn-group .btn + .btn-ghost, .modal-footer .btn-group .btn-ghost + .btn-ghost {
-    margin-left: -1px; }
-  .modal-footer .btn-block + .btn-block {
-    margin-left: 0; }
-
-.modal-scrollbar-measure {
-  position: absolute;
-  top: -9999px;
-  width: 50px;
-  height: 50px;
-  overflow: scroll; }
-
-@media (min-width: 768px) {
-  .modal-dialog {
-    width: 600px;
-    margin: 30px auto; }
-  .modal-content {
-    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
-  .modal-sm {
-    width: 300px; } }
-
-@media (min-width: 992px) {
-  .modal-lg {
-    width: 900px; } }
-
-.tooltip {
-  position: absolute;
-  z-index: 1070;
-  display: block;
-  font-family: "Source Sans Pro", Arial, sans-serif;
-  font-size: 12px;
-  font-weight: normal;
-  line-height: 1.4;
-  opacity: 0;
-  filter: alpha(opacity=0); }
-  .tooltip.in {
-    opacity: 0.9;
-    filter: alpha(opacity=90); }
-  .tooltip.top {
-    margin-top: -3px;
-    padding: 5px 0; }
-  .tooltip.right {
-    margin-left: 3px;
-    padding: 0 5px; }
-  .tooltip.bottom {
-    margin-top: 3px;
-    padding: 5px 0; }
-  .tooltip.left {
-    margin-left: -3px;
-    padding: 0 5px; }
-
-.tooltip-inner {
-  max-width: 200px;
-  padding: 3px 8px;
-  color: #fff;
-  text-align: center;
-  text-decoration: none;
-  background-color: #000;
-  border-radius: 4px; }
-
-.tooltip-arrow {
-  position: absolute;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid; }
-
-.tooltip.top .tooltip-arrow {
-  bottom: 0;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px 5px 0;
-  border-top-color: #000; }
-
-.tooltip.top-left .tooltip-arrow {
-  bottom: 0;
-  right: 5px;
-  margin-bottom: -5px;
-  border-width: 5px 5px 0;
-  border-top-color: #000; }
-
-.tooltip.top-right .tooltip-arrow {
-  bottom: 0;
-  left: 5px;
-  margin-bottom: -5px;
-  border-width: 5px 5px 0;
-  border-top-color: #000; }
-
-.tooltip.right .tooltip-arrow {
-  top: 50%;
-  left: 0;
-  margin-top: -5px;
-  border-width: 5px 5px 5px 0;
-  border-right-color: #000; }
-
-.tooltip.left .tooltip-arrow {
-  top: 50%;
-  right: 0;
-  margin-top: -5px;
-  border-width: 5px 0 5px 5px;
-  border-left-color: #000; }
-
-.tooltip.bottom .tooltip-arrow {
-  top: 0;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 0 5px 5px;
-  border-bottom-color: #000; }
-
-.tooltip.bottom-left .tooltip-arrow {
-  top: 0;
-  right: 5px;
-  margin-top: -5px;
-  border-width: 0 5px 5px;
-  border-bottom-color: #000; }
-
-.tooltip.bottom-right .tooltip-arrow {
-  top: 0;
-  left: 5px;
-  margin-top: -5px;
-  border-width: 0 5px 5px;
-  border-bottom-color: #000; }
-
-.popover {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1060;
-  display: none;
-  max-width: 276px;
-  padding: 1px;
-  font-family: "Source Sans Pro", Arial, sans-serif;
-  font-size: 14px;
-  font-weight: normal;
-  line-height: 1.42857;
-  text-align: left;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  border-radius: 6px;
-  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  white-space: normal; }
-  .popover.top {
-    margin-top: -10px; }
-  .popover.right {
-    margin-left: 10px; }
-  .popover.bottom {
-    margin-top: 10px; }
-  .popover.left {
-    margin-left: -10px; }
-
-.popover-title {
-  margin: 0;
-  padding: 8px 14px;
-  font-size: 14px;
-  background-color: #f7f7f7;
-  border-bottom: 1px solid #ebebeb;
-  border-radius: 5px 5px 0 0; }
-
-.popover-content {
-  padding: 9px 14px; }
-
-.popover > .arrow,
-.popover > .arrow:after {
-  position: absolute;
-  display: block;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid; }
-
-.popover > .arrow {
-  border-width: 11px; }
-
-.popover > .arrow:after {
-  border-width: 10px;
-  content: ""; }
-
-.popover.top > .arrow {
-  left: 50%;
-  margin-left: -11px;
-  border-bottom-width: 0;
-  border-top-color: #999999;
-  border-top-color: rgba(0, 0, 0, 0.05);
-  bottom: -11px; }
-  .popover.top > .arrow:after {
-    content: " ";
-    bottom: 1px;
-    margin-left: -10px;
-    border-bottom-width: 0;
-    border-top-color: #fff; }
-
-.popover.right > .arrow {
-  top: 50%;
-  left: -11px;
-  margin-top: -11px;
-  border-left-width: 0;
-  border-right-color: #999999;
-  border-right-color: rgba(0, 0, 0, 0.05); }
-  .popover.right > .arrow:after {
-    content: " ";
-    left: 1px;
-    bottom: -10px;
-    border-left-width: 0;
-    border-right-color: #fff; }
-
-.popover.bottom > .arrow {
-  left: 50%;
-  margin-left: -11px;
-  border-top-width: 0;
-  border-bottom-color: #999999;
-  border-bottom-color: rgba(0, 0, 0, 0.05);
-  top: -11px; }
-  .popover.bottom > .arrow:after {
-    content: " ";
-    top: 1px;
-    margin-left: -10px;
-    border-top-width: 0;
-    border-bottom-color: #fff; }
-
-.popover.left > .arrow {
-  top: 50%;
-  right: -11px;
-  margin-top: -11px;
-  border-right-width: 0;
-  border-left-color: #999999;
-  border-left-color: rgba(0, 0, 0, 0.05); }
-  .popover.left > .arrow:after {
-    content: " ";
-    right: 1px;
-    border-right-width: 0;
-    border-left-color: #fff;
-    bottom: -10px; }
-
-.carousel {
-  position: relative; }
-
-.carousel-inner {
-  position: relative;
-  overflow: hidden;
-  width: 100%; }
-  .carousel-inner > .item {
-    display: none;
-    position: relative;
-    -webkit-transition: 0.6s ease-in-out left;
-    -o-transition: 0.6s ease-in-out left;
-    transition: 0.6s ease-in-out left; }
-    .carousel-inner > .item > img,
-    .carousel-inner > .item > a > img {
-      display: block;
-      max-width: 100%;
-      height: auto;
-      line-height: 1; }
-    @media all and (transform-3d), (-webkit-transform-3d) {
-      .carousel-inner > .item {
-        -webkit-transition: -webkit-transform 0.6s ease-in-out;
-        -moz-transition: -moz-transform 0.6s ease-in-out;
-        -o-transition: -o-transform 0.6s ease-in-out;
-        transition: transform 0.6s ease-in-out;
-        -webkit-backface-visibility: hidden;
-        -moz-backface-visibility: hidden;
-        backface-visibility: hidden;
-        -webkit-perspective: 1000;
-        -moz-perspective: 1000;
-        perspective: 1000; }
-        .carousel-inner > .item.next,
-        .carousel-inner > .item.active.right {
-          -webkit-transform: translate3d(100%, 0, 0);
-          transform: translate3d(100%, 0, 0);
-          left: 0; }
-        .carousel-inner > .item.prev,
-        .carousel-inner > .item.active.left {
-          -webkit-transform: translate3d(-100%, 0, 0);
-          transform: translate3d(-100%, 0, 0);
-          left: 0; }
-        .carousel-inner > .item.next.left,
-        .carousel-inner > .item.prev.right,
-        .carousel-inner > .item.active {
-          -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0);
-          left: 0; } }
-  .carousel-inner > .active,
-  .carousel-inner > .next,
-  .carousel-inner > .prev {
-    display: block; }
-  .carousel-inner > .active {
-    left: 0; }
-  .carousel-inner > .next,
-  .carousel-inner > .prev {
-    position: absolute;
-    top: 0;
-    width: 100%; }
-  .carousel-inner > .next {
-    left: 100%; }
-  .carousel-inner > .prev {
-    left: -100%; }
-  .carousel-inner > .next.left,
-  .carousel-inner > .prev.right {
-    left: 0; }
-  .carousel-inner > .active.left {
-    left: -100%; }
-  .carousel-inner > .active.right {
-    left: 100%; }
-
-.carousel-control {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 15%;
-  opacity: 0.5;
-  filter: alpha(opacity=50);
-  font-size: 20px;
-  color: #fff;
-  text-align: center;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
-  .carousel-control.left {
-    background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
-    background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
-    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
-    background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1); }
-  .carousel-control.right {
-    left: auto;
-    right: 0;
-    background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
-    background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
-    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
-    background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1); }
-  .carousel-control:hover,
-  .carousel-control:focus {
-    outline: 0;
-    color: #fff;
-    text-decoration: none;
-    opacity: 0.9;
-    filter: alpha(opacity=90); }
-  .carousel-control .icon-prev,
-  .carousel-control .icon-next,
-  .carousel-control .glyphicon-chevron-left,
-  .carousel-control .glyphicon-chevron-right {
-    position: absolute;
-    top: 50%;
-    z-index: 5;
-    display: inline-block; }
-  .carousel-control .icon-prev,
-  .carousel-control .glyphicon-chevron-left {
-    left: 50%;
-    margin-left: -10px; }
-  .carousel-control .icon-next,
-  .carousel-control .glyphicon-chevron-right {
-    right: 50%;
-    margin-right: -10px; }
-  .carousel-control .icon-prev,
-  .carousel-control .icon-next {
-    width: 20px;
-    height: 20px;
-    margin-top: -10px;
-    line-height: 1;
-    font-family: serif; }
-  .carousel-control .icon-prev:before {
-    content: '\2039'; }
-  .carousel-control .icon-next:before {
-    content: '\203a'; }
-
-.carousel-indicators {
-  position: absolute;
-  bottom: 10px;
-  left: 50%;
-  z-index: 15;
-  width: 60%;
-  margin-left: -30%;
-  padding-left: 0;
-  list-style: none;
-  text-align: center; }
-  .carousel-indicators li {
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    margin: 1px;
-    text-indent: -999px;
-    border: 1px solid #fff;
-    border-radius: 10px;
-    cursor: pointer;
-    background-color: #000 \9;
-    background-color: transparent; }
-  .carousel-indicators .active {
-    margin: 0;
-    width: 12px;
-    height: 12px;
-    background-color: #fff; }
-
-.carousel-caption {
-  position: absolute;
-  left: 15%;
-  right: 15%;
-  bottom: 20px;
-  z-index: 10;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  color: #fff;
-  text-align: center;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
-  .carousel-caption .btn, .carousel-caption .btn-ghost {
-    text-shadow: none; }
-
-@media screen and (min-width: 768px) {
-  .carousel-control .glyphicon-chevron-left,
-  .carousel-control .glyphicon-chevron-right,
-  .carousel-control .icon-prev,
-  .carousel-control .icon-next {
-    width: 30px;
-    height: 30px;
-    margin-top: -15px;
-    font-size: 30px; }
-  .carousel-control .glyphicon-chevron-left,
-  .carousel-control .icon-prev {
-    margin-left: -15px; }
-  .carousel-control .glyphicon-chevron-right,
-  .carousel-control .icon-next {
-    margin-right: -15px; }
-  .carousel-caption {
-    left: 20%;
-    right: 20%;
-    padding-bottom: 30px; }
-  .carousel-indicators {
-    bottom: 20px; } }
-
-.clearfix:before,
-.clearfix:after {
-  content: " ";
-  display: table; }
-
-.clearfix:after {
-  clear: both; }
-
-.center-block {
-  display: block;
-  margin-left: auto;
-  margin-right: auto; }
-
-.pull-right {
-  float: right !important; }
-
-.pull-left {
-  float: left !important; }
-
-.hide {
-  display: none !important; }
-
-.show {
-  display: block !important; }
-
-.invisible {
-  visibility: hidden; }
-
-.text-hide {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0; }
-
-.hidden {
-  display: none !important; }
-
-.affix {
-  position: fixed; }
-
-@-ms-viewport {
-  width: device-width; }
-
-.visible-xs {
-  display: none !important; }
-
-.visible-sm {
-  display: none !important; }
-
-.visible-md {
-  display: none !important; }
-
-.visible-lg {
-  display: none !important; }
-
-.visible-xs-block,
-.visible-xs-inline,
-.visible-xs-inline-block,
-.visible-sm-block,
-.visible-sm-inline,
-.visible-sm-inline-block,
-.visible-md-block,
-.visible-md-inline,
-.visible-md-inline-block,
-.visible-lg-block,
-.visible-lg-inline,
-.visible-lg-inline-block {
-  display: none !important; }
-
-@media (max-width: 767px) {
-  .visible-xs {
-    display: block !important; }
-  table.visible-xs {
-    display: table; }
-  tr.visible-xs {
-    display: table-row !important; }
-  th.visible-xs,
-  td.visible-xs {
-    display: table-cell !important; } }
-
-@media (max-width: 767px) {
-  .visible-xs-block {
-    display: block !important; } }
-
-@media (max-width: 767px) {
-  .visible-xs-inline {
-    display: inline !important; } }
-
-@media (max-width: 767px) {
-  .visible-xs-inline-block {
-    display: inline-block !important; } }
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .visible-sm {
-    display: block !important; }
-  table.visible-sm {
-    display: table; }
-  tr.visible-sm {
-    display: table-row !important; }
-  th.visible-sm,
-  td.visible-sm {
-    display: table-cell !important; } }
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .visible-sm-block {
-    display: block !important; } }
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .visible-sm-inline {
-    display: inline !important; } }
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .visible-sm-inline-block {
-    display: inline-block !important; } }
-
-@media (min-width: 992px) and (max-width: 1199px) {
-  .visible-md {
-    display: block !important; }
-  table.visible-md {
-    display: table; }
-  tr.visible-md {
-    display: table-row !important; }
-  th.visible-md,
-  td.visible-md {
-    display: table-cell !important; } }
-
-@media (min-width: 992px) and (max-width: 1199px) {
-  .visible-md-block {
-    display: block !important; } }
-
-@media (min-width: 992px) and (max-width: 1199px) {
-  .visible-md-inline {
-    display: inline !important; } }
-
-@media (min-width: 992px) and (max-width: 1199px) {
-  .visible-md-inline-block {
-    display: inline-block !important; } }
-
-@media (min-width: 1200px) {
-  .visible-lg {
-    display: block !important; }
-  table.visible-lg {
-    display: table; }
-  tr.visible-lg {
-    display: table-row !important; }
-  th.visible-lg,
-  td.visible-lg {
-    display: table-cell !important; } }
-
-@media (min-width: 1200px) {
-  .visible-lg-block {
-    display: block !important; } }
-
-@media (min-width: 1200px) {
-  .visible-lg-inline {
-    display: inline !important; } }
-
-@media (min-width: 1200px) {
-  .visible-lg-inline-block {
-    display: inline-block !important; } }
-
-@media (max-width: 767px) {
-  .hidden-xs {
-    display: none !important; } }
-
-@media (min-width: 768px) and (max-width: 991px) {
-  .hidden-sm {
-    display: none !important; } }
-
-@media (min-width: 992px) and (max-width: 1199px) {
-  .hidden-md {
-    display: none !important; } }
-
-@media (min-width: 1200px) {
-  .hidden-lg {
-    display: none !important; } }
-
-.visible-print {
-  display: none !important; }
-
-@media print {
-  .visible-print {
-    display: block !important; }
-  table.visible-print {
-    display: table; }
-  tr.visible-print {
-    display: table-row !important; }
-  th.visible-print,
-  td.visible-print {
-    display: table-cell !important; } }
-
-.visible-print-block {
-  display: none !important; }
-  @media print {
-    .visible-print-block {
-      display: block !important; } }
-
-.visible-print-inline {
-  display: none !important; }
-  @media print {
-    .visible-print-inline {
-      display: inline !important; } }
-
-.visible-print-inline-block {
-  display: none !important; }
-  @media print {
-    .visible-print-inline-block {
-      display: inline-block !important; } }
-
-@media print {
-  .hidden-print {
-    display: none !important; } }
-
-/*doc
- ---
- title: Units extended
- name: units_extended
- category: Variables
- ---
-
- Those are the units that you can use
-<div class="clearfix">
-  <div class="variable-box">
-    <span>$base-unit = $base-unit // 14px</span>
-  </div>
-  <div class="variable-box">
-    <span>$base-unit-x2 = $base-unit-x2</span>
-  </div>
-  <div class="variable-box">
-    <span>$base-unit-x3 = $base-unit-x3</span>
-  </div>
-  <div class="variable-box">
-    <span>$space = 10px</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-small = $space / 2</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-large = $space * 2</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-larger = $space * 4</span>
-  </div>
-  <div class="variable-box">
-    <span>$font-size-larger = 38px</span>
-  </div>
-</div>
- */
-/*doc
- ---
- title: Colors extended
- name: colors_extended
- category: Variables
- ---
-
- Those are the colors that you can use
-<div class="clearfix">
-  <div class="color-box gray-lighten">
-    <span>$gray-lighten</span>
-  </div>
-  <div class="color-box gray-lightest">
-    <span>$gray-lightest</span>
-  </div>
-  <div class="color-box white">
-    <span>$white</span>
-  </div>
-  <div class="color-box brand-primary-custom">
-    <span>$brand-primary-custom</span>
-  </div>
-  <div class="color-box blue-light">
-    <span>$blue-light</span>
-  </div>
-</div>
- */
-body {
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility; }
-  body #sb-site a[name] {
-    content: "";
-    display: block;
-    height: 76px;
-    margin-top: -76px; }
-
-/*doc
- ---
- title: Units extended
- name: units_extended
- category: Variables
- ---
-
- Those are the units that you can use
-<div class="clearfix">
-  <div class="variable-box">
-    <span>$base-unit = $base-unit // 14px</span>
-  </div>
-  <div class="variable-box">
-    <span>$base-unit-x2 = $base-unit-x2</span>
-  </div>
-  <div class="variable-box">
-    <span>$base-unit-x3 = $base-unit-x3</span>
-  </div>
-  <div class="variable-box">
-    <span>$space = 10px</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-small = $space / 2</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-large = $space * 2</span>
-  </div>
-  <div class="variable-box">
-    <span>$space-larger = $space * 4</span>
-  </div>
-  <div class="variable-box">
-    <span>$font-size-larger = 38px</span>
-  </div>
-</div>
- */
-/*doc
- ---
- title: Colors extended
- name: colors_extended
- category: Variables
- ---
-
- Those are the colors that you can use
-<div class="clearfix">
-  <div class="color-box gray-lighten">
-    <span>$gray-lighten</span>
-  </div>
-  <div class="color-box gray-lightest">
-    <span>$gray-lightest</span>
-  </div>
-  <div class="color-box white">
-    <span>$white</span>
-  </div>
-  <div class="color-box brand-primary-custom">
-    <span>$brand-primary-custom</span>
-  </div>
-  <div class="color-box blue-light">
-    <span>$blue-light</span>
-  </div>
-</div>
- */
-/*doc
- ---
- title: Colors
- name: colors
- category: Variables
- ---
-
- Those are the colors that you can use
-<div class="clearfix">
-  <div class="color-box gray-darker">
-    <span>$gray-darker</span>
-  </div>
-  <div class="color-box gray-dark">
-    <span>$gray-dark</span>
-  </div>
-  <div class="color-box gray">
-    <span>$gray</span>
-  </div>
-  <div class="color-box gray-light">
-    <span>$gray-light</span>
-  </div>
-  <div class="color-box gray-lighter">
-    <span>$gray-lighter</span>
-  </div>
-  <div class="color-box brand-primary">
-    <span>$brand-primary</span>
-  </div>
-  <div class="color-box brand-success">
-    <span>$brand-success</span>
-  </div>
-  <div class="color-box brand-info">
-    <span>$brand-info</span>
-  </div>
-  <div class="color-box brand-warning">
-    <span>$brand-warning</span>
-  </div>
-  <div class="color-box brand-danger">
-    <span>$brand-danger</span>
-  </div>
-</div>
- */
-.table tbody > tr > td.vert-align {
-  vertical-align: middle; }
-
-@media screen and (min-width: 768px) {
-  .text-left-sm {
-    text-align: left; } }
-
-@media screen and (min-width: 992px) {
-  .text-left-md {
-    text-align: left; } }
-
-@media screen and (min-width: 1200px) {
-  .text-left-lg {
-    text-align: left; } }
-
-/*doc
----
-title: Buttons
-name: Buttons
-category: CSS
----
-
-```html_example_table
-<p><button class="btn btn-default btn-lg">Large</button></p>
-<p><button class="btn btn-default">Normal</button></p>
-<p><button class="btn btn-default btn-sm">Small</button></p>
-<p><button class="btn btn-default btn-xs">Extra Small</button></p>
-
-<p><button class="btn btn-default">Default</button></p>
-<p><button class="btn btn-primary">Primary</button></p>
-<p><button class="btn btn-primary-alt">Primary Alt</button></p>
-<p><button class="btn btn-danger">Danger</button></p>
-<p><button class="btn btn-secondary">Secondary</button></p>
-
-<p><button class="btn-ghost btn-default">Default Ghost</button></p>
-<p><button class="btn-ghost btn-primary">Primary Ghost</button></p>
-<p><button class="btn-ghost btn-primary-alt">Primary Alt Ghost</button></p>
-<p><button class="btn-ghost btn-danger">Danger Ghost</button></p>
-```
- */
-.btn-default:hover {
-  background-color: #f9fafb;
-  color: #999999; }
-
-.btn-primary:hover {
-  background: #89a334; }
-
-.btn-secondary {
-  color: #666; }
-  .btn-secondary:hover {
-    color: #333333;
-    text-decoration: none; }
-
-.btn-ghost {
-  background-color: transparent; }
-  .btn-ghost.btn-default {
-    border-color: #999999;
-    color: #999999; }
-    .btn-ghost.btn-default:hover {
-      color: #fff;
-      background-color: #999999; }
-  .btn-ghost.btn-primary {
-    border-color: #9bb83a;
-    color: #9bb83a; }
-    .btn-ghost.btn-primary:hover {
-      color: #fff; }
-  .btn-ghost.btn-primary-alt {
-    border-color: #e53221;
-    color: #e53221; }
-    .btn-ghost.btn-primary-alt:hover {
-      color: #fff; }
-  .btn-ghost.btn-danger, .btn-ghost.btn-primary-alt {
-    border-color: #e53221;
-    color: #e53221; }
-    .btn-ghost.btn-danger:hover, .btn-ghost.btn-primary-alt:hover {
-      color: #fff; }
+.col-xs-pull-3 { right: 25%; }
+
+.col-xs-pull-4 { right: 33.33333%; }
+
+.col-xs-pull-5 { right: 41.66667%; }
+
+.col-xs-pull-6 { right: 50%; }
+
+.col-xs-pull-7 { right: 58.33333%; }
+
+.col-xs-pull-8 { right: 66.66667%; }
+
+.col-xs-pull-9 { right: 75%; }
+
+.col-xs-pull-10 { right: 83.33333%; }
+
+.col-xs-pull-11 { right: 91.66667%; }
+
+.col-xs-pull-12 { right: 100%; }
+
+.col-xs-push-0 { left: auto; }
+
+.col-xs-push-1 { left: 8.33333%; }
+
+.col-xs-push-2 { left: 16.66667%; }
+
+.col-xs-push-3 { left: 25%; }
+
+.col-xs-push-4 { left: 33.33333%; }
+
+.col-xs-push-5 { left: 41.66667%; }
+
+.col-xs-push-6 { left: 50%; }
+
+.col-xs-push-7 { left: 58.33333%; }
+
+.col-xs-push-8 { left: 66.66667%; }
+
+.col-xs-push-9 { left: 75%; }
+
+.col-xs-push-10 { left: 83.33333%; }
+
+.col-xs-push-11 { left: 91.66667%; }
+
+.col-xs-push-12 { left: 100%; }
+
+.col-xs-offset-0 { margin-left: 0%; }
+
+.col-xs-offset-1 { margin-left: 8.33333%; }
+
+.col-xs-offset-2 { margin-left: 16.66667%; }
+
+.col-xs-offset-3 { margin-left: 25%; }
+
+.col-xs-offset-4 { margin-left: 33.33333%; }
+
+.col-xs-offset-5 { margin-left: 41.66667%; }
+
+.col-xs-offset-6 { margin-left: 50%; }
+
+.col-xs-offset-7 { margin-left: 58.33333%; }
+
+.col-xs-offset-8 { margin-left: 66.66667%; }
+
+.col-xs-offset-9 { margin-left: 75%; }
+
+.col-xs-offset-10 { margin-left: 83.33333%; }
+
+.col-xs-offset-11 { margin-left: 91.66667%; }
+
+.col-xs-offset-12 { margin-left: 100%; }
+
+@media (min-width: 768px) { .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 { float: left; }
+  .col-sm-1 { width: 8.33333%; }
+  .col-sm-2 { width: 16.66667%; }
+  .col-sm-3 { width: 25%; }
+  .col-sm-4 { width: 33.33333%; }
+  .col-sm-5 { width: 41.66667%; }
+  .col-sm-6 { width: 50%; }
+  .col-sm-7 { width: 58.33333%; }
+  .col-sm-8 { width: 66.66667%; }
+  .col-sm-9 { width: 75%; }
+  .col-sm-10 { width: 83.33333%; }
+  .col-sm-11 { width: 91.66667%; }
+  .col-sm-12 { width: 100%; }
+  .col-sm-pull-0 { right: auto; }
+  .col-sm-pull-1 { right: 8.33333%; }
+  .col-sm-pull-2 { right: 16.66667%; }
+  .col-sm-pull-3 { right: 25%; }
+  .col-sm-pull-4 { right: 33.33333%; }
+  .col-sm-pull-5 { right: 41.66667%; }
+  .col-sm-pull-6 { right: 50%; }
+  .col-sm-pull-7 { right: 58.33333%; }
+  .col-sm-pull-8 { right: 66.66667%; }
+  .col-sm-pull-9 { right: 75%; }
+  .col-sm-pull-10 { right: 83.33333%; }
+  .col-sm-pull-11 { right: 91.66667%; }
+  .col-sm-pull-12 { right: 100%; }
+  .col-sm-push-0 { left: auto; }
+  .col-sm-push-1 { left: 8.33333%; }
+  .col-sm-push-2 { left: 16.66667%; }
+  .col-sm-push-3 { left: 25%; }
+  .col-sm-push-4 { left: 33.33333%; }
+  .col-sm-push-5 { left: 41.66667%; }
+  .col-sm-push-6 { left: 50%; }
+  .col-sm-push-7 { left: 58.33333%; }
+  .col-sm-push-8 { left: 66.66667%; }
+  .col-sm-push-9 { left: 75%; }
+  .col-sm-push-10 { left: 83.33333%; }
+  .col-sm-push-11 { left: 91.66667%; }
+  .col-sm-push-12 { left: 100%; }
+  .col-sm-offset-0 { margin-left: 0%; }
+  .col-sm-offset-1 { margin-left: 8.33333%; }
+  .col-sm-offset-2 { margin-left: 16.66667%; }
+  .col-sm-offset-3 { margin-left: 25%; }
+  .col-sm-offset-4 { margin-left: 33.33333%; }
+  .col-sm-offset-5 { margin-left: 41.66667%; }
+  .col-sm-offset-6 { margin-left: 50%; }
+  .col-sm-offset-7 { margin-left: 58.33333%; }
+  .col-sm-offset-8 { margin-left: 66.66667%; }
+  .col-sm-offset-9 { margin-left: 75%; }
+  .col-sm-offset-10 { margin-left: 83.33333%; }
+  .col-sm-offset-11 { margin-left: 91.66667%; }
+  .col-sm-offset-12 { margin-left: 100%; } }
+
+@media (min-width: 992px) { .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 { float: left; }
+  .col-md-1 { width: 8.33333%; }
+  .col-md-2 { width: 16.66667%; }
+  .col-md-3 { width: 25%; }
+  .col-md-4 { width: 33.33333%; }
+  .col-md-5 { width: 41.66667%; }
+  .col-md-6 { width: 50%; }
+  .col-md-7 { width: 58.33333%; }
+  .col-md-8 { width: 66.66667%; }
+  .col-md-9 { width: 75%; }
+  .col-md-10 { width: 83.33333%; }
+  .col-md-11 { width: 91.66667%; }
+  .col-md-12 { width: 100%; }
+  .col-md-pull-0 { right: auto; }
+  .col-md-pull-1 { right: 8.33333%; }
+  .col-md-pull-2 { right: 16.66667%; }
+  .col-md-pull-3 { right: 25%; }
+  .col-md-pull-4 { right: 33.33333%; }
+  .col-md-pull-5 { right: 41.66667%; }
+  .col-md-pull-6 { right: 50%; }
+  .col-md-pull-7 { right: 58.33333%; }
+  .col-md-pull-8 { right: 66.66667%; }
+  .col-md-pull-9 { right: 75%; }
+  .col-md-pull-10 { right: 83.33333%; }
+  .col-md-pull-11 { right: 91.66667%; }
+  .col-md-pull-12 { right: 100%; }
+  .col-md-push-0 { left: auto; }
+  .col-md-push-1 { left: 8.33333%; }
+  .col-md-push-2 { left: 16.66667%; }
+  .col-md-push-3 { left: 25%; }
+  .col-md-push-4 { left: 33.33333%; }
+  .col-md-push-5 { left: 41.66667%; }
+  .col-md-push-6 { left: 50%; }
+  .col-md-push-7 { left: 58.33333%; }
+  .col-md-push-8 { left: 66.66667%; }
+  .col-md-push-9 { left: 75%; }
+  .col-md-push-10 { left: 83.33333%; }
+  .col-md-push-11 { left: 91.66667%; }
+  .col-md-push-12 { left: 100%; }
+  .col-md-offset-0 { margin-left: 0%; }
+  .col-md-offset-1 { margin-left: 8.33333%; }
+  .col-md-offset-2 { margin-left: 16.66667%; }
+  .col-md-offset-3 { margin-left: 25%; }
+  .col-md-offset-4 { margin-left: 33.33333%; }
+  .col-md-offset-5 { margin-left: 41.66667%; }
+  .col-md-offset-6 { margin-left: 50%; }
+  .col-md-offset-7 { margin-left: 58.33333%; }
+  .col-md-offset-8 { margin-left: 66.66667%; }
+  .col-md-offset-9 { margin-left: 75%; }
+  .col-md-offset-10 { margin-left: 83.33333%; }
+  .col-md-offset-11 { margin-left: 91.66667%; }
+  .col-md-offset-12 { margin-left: 100%; } }
+
+@media (min-width: 1200px) { .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 { float: left; }
+  .col-lg-1 { width: 8.33333%; }
+  .col-lg-2 { width: 16.66667%; }
+  .col-lg-3 { width: 25%; }
+  .col-lg-4 { width: 33.33333%; }
+  .col-lg-5 { width: 41.66667%; }
+  .col-lg-6 { width: 50%; }
+  .col-lg-7 { width: 58.33333%; }
+  .col-lg-8 { width: 66.66667%; }
+  .col-lg-9 { width: 75%; }
+  .col-lg-10 { width: 83.33333%; }
+  .col-lg-11 { width: 91.66667%; }
+  .col-lg-12 { width: 100%; }
+  .col-lg-pull-0 { right: auto; }
+  .col-lg-pull-1 { right: 8.33333%; }
+  .col-lg-pull-2 { right: 16.66667%; }
+  .col-lg-pull-3 { right: 25%; }
+  .col-lg-pull-4 { right: 33.33333%; }
+  .col-lg-pull-5 { right: 41.66667%; }
+  .col-lg-pull-6 { right: 50%; }
+  .col-lg-pull-7 { right: 58.33333%; }
+  .col-lg-pull-8 { right: 66.66667%; }
+  .col-lg-pull-9 { right: 75%; }
+  .col-lg-pull-10 { right: 83.33333%; }
+  .col-lg-pull-11 { right: 91.66667%; }
+  .col-lg-pull-12 { right: 100%; }
+  .col-lg-push-0 { left: auto; }
+  .col-lg-push-1 { left: 8.33333%; }
+  .col-lg-push-2 { left: 16.66667%; }
+  .col-lg-push-3 { left: 25%; }
+  .col-lg-push-4 { left: 33.33333%; }
+  .col-lg-push-5 { left: 41.66667%; }
+  .col-lg-push-6 { left: 50%; }
+  .col-lg-push-7 { left: 58.33333%; }
+  .col-lg-push-8 { left: 66.66667%; }
+  .col-lg-push-9 { left: 75%; }
+  .col-lg-push-10 { left: 83.33333%; }
+  .col-lg-push-11 { left: 91.66667%; }
+  .col-lg-push-12 { left: 100%; }
+  .col-lg-offset-0 { margin-left: 0%; }
+  .col-lg-offset-1 { margin-left: 8.33333%; }
+  .col-lg-offset-2 { margin-left: 16.66667%; }
+  .col-lg-offset-3 { margin-left: 25%; }
+  .col-lg-offset-4 { margin-left: 33.33333%; }
+  .col-lg-offset-5 { margin-left: 41.66667%; }
+  .col-lg-offset-6 { margin-left: 50%; }
+  .col-lg-offset-7 { margin-left: 58.33333%; }
+  .col-lg-offset-8 { margin-left: 66.66667%; }
+  .col-lg-offset-9 { margin-left: 75%; }
+  .col-lg-offset-10 { margin-left: 83.33333%; }
+  .col-lg-offset-11 { margin-left: 91.66667%; }
+  .col-lg-offset-12 { margin-left: 100%; } }
+
+table { background-color: transparent; }
+
+caption { padding-top: 20px; padding-bottom: 20px; color: #999999; text-align: left; }
+
+th { text-align: left; }
+
+.table { width: 100%; max-width: 100%; margin-bottom: 20px; }
+
+.table > thead > tr > th, .table > thead > tr > td, .table > tbody > tr > th, .table > tbody > tr > td, .table > tfoot > tr > th, .table > tfoot > tr > td { padding: 20px; line-height: 1.42857; vertical-align: top; border-top: 1px solid #ddd; }
+
+.table > thead > tr > th { vertical-align: bottom; border-bottom: 2px solid #ddd; }
+
+.table > caption + thead > tr:first-child > th, .table > caption + thead > tr:first-child > td, .table > colgroup + thead > tr:first-child > th, .table > colgroup + thead > tr:first-child > td, .table > thead:first-child > tr:first-child > th, .table > thead:first-child > tr:first-child > td { border-top: 0; }
+
+.table > tbody + tbody { border-top: 2px solid #ddd; }
+
+.table .table { background-color: #fff; }
+
+.table-condensed > thead > tr > th, .table-condensed > thead > tr > td, .table-condensed > tbody > tr > th, .table-condensed > tbody > tr > td, .table-condensed > tfoot > tr > th, .table-condensed > tfoot > tr > td { padding: 5px; }
+
+.table-bordered { border: 1px solid #ddd; }
+
+.table-bordered > thead > tr > th, .table-bordered > thead > tr > td, .table-bordered > tbody > tr > th, .table-bordered > tbody > tr > td, .table-bordered > tfoot > tr > th, .table-bordered > tfoot > tr > td { border: 1px solid #ddd; }
+
+.table-bordered > thead > tr > th, .table-bordered > thead > tr > td { border-bottom-width: 2px; }
+
+.table-striped > tbody > tr:nth-of-type(odd) { background-color: #f1f8fb; }
+
+.table-hover > tbody > tr:hover { background-color: #f5f5f5; }
+
+table col[class*="col-"] { position: static; float: none; display: table-column; }
+
+table td[class*="col-"], table th[class*="col-"] { position: static; float: none; display: table-cell; }
+
+.table > thead > tr > td.active, .table > thead > tr > th.active, .table > thead > tr.active > td, .table > thead > tr.active > th, .table > tbody > tr > td.active, .table > tbody > tr > th.active, .table > tbody > tr.active > td, .table > tbody > tr.active > th, .table > tfoot > tr > td.active, .table > tfoot > tr > th.active, .table > tfoot > tr.active > td, .table > tfoot > tr.active > th { background-color: #f5f5f5; }
+
+.table-hover > tbody > tr > td.active:hover, .table-hover > tbody > tr > th.active:hover, .table-hover > tbody > tr.active:hover > td, .table-hover > tbody > tr:hover > .active, .table-hover > tbody > tr.active:hover > th { background-color: #e8e8e8; }
+
+.table > thead > tr > td.success, .table > thead > tr > th.success, .table > thead > tr.success > td, .table > thead > tr.success > th, .table > tbody > tr > td.success, .table > tbody > tr > th.success, .table > tbody > tr.success > td, .table > tbody > tr.success > th, .table > tfoot > tr > td.success, .table > tfoot > tr > th.success, .table > tfoot > tr.success > td, .table > tfoot > tr.success > th { background-color: #f5f8eb; }
+
+.table-hover > tbody > tr > td.success:hover, .table-hover > tbody > tr > th.success:hover, .table-hover > tbody > tr.success:hover > td, .table-hover > tbody > tr:hover > .success, .table-hover > tbody > tr.success:hover > th { background-color: #ecf1d8; }
+
+.table > thead > tr > td.info, .table > thead > tr > th.info, .table > thead > tr.info > td, .table > thead > tr.info > th, .table > tbody > tr > td.info, .table > tbody > tr > th.info, .table > tbody > tr.info > td, .table > tbody > tr.info > th, .table > tfoot > tr > td.info, .table > tfoot > tr > th.info, .table > tfoot > tr.info > td, .table > tfoot > tr.info > th { background-color: #ebf5f9; }
+
+.table-hover > tbody > tr > td.info:hover, .table-hover > tbody > tr > th.info:hover, .table-hover > tbody > tr.info:hover > td, .table-hover > tbody > tr:hover > .info, .table-hover > tbody > tr.info:hover > th { background-color: #d7ebf3; }
+
+.table > thead > tr > td.warning, .table > thead > tr > th.warning, .table > thead > tr.warning > td, .table > thead > tr.warning > th, .table > tbody > tr > td.warning, .table > tbody > tr > th.warning, .table > tbody > tr.warning > td, .table > tbody > tr.warning > th, .table > tfoot > tr > td.warning, .table > tfoot > tr > th.warning, .table > tfoot > tr.warning > td, .table > tfoot > tr.warning > th { background-color: #fdfde9; }
+
+.table-hover > tbody > tr > td.warning:hover, .table-hover > tbody > tr > th.warning:hover, .table-hover > tbody > tr.warning:hover > td, .table-hover > tbody > tr:hover > .warning, .table-hover > tbody > tr.warning:hover > th { background-color: #fbfbd2; }
+
+.table > thead > tr > td.danger, .table > thead > tr > th.danger, .table > thead > tr.danger > td, .table > thead > tr.danger > th, .table > tbody > tr > td.danger, .table > tbody > tr > th.danger, .table > tbody > tr.danger > td, .table > tbody > tr.danger > th, .table > tfoot > tr > td.danger, .table > tfoot > tr > th.danger, .table > tfoot > tr.danger > td, .table > tfoot > tr.danger > th { background-color: #fceae8; }
+
+.table-hover > tbody > tr > td.danger:hover, .table-hover > tbody > tr > th.danger:hover, .table-hover > tbody > tr.danger:hover > td, .table-hover > tbody > tr:hover > .danger, .table-hover > tbody > tr.danger:hover > th { background-color: #f9d5d1; }
+
+.table-responsive { overflow-x: auto; min-height: 0.01%; }
+
+@media screen and (max-width: 767px) { .table-responsive { width: 100%; margin-bottom: 15px; overflow-y: hidden; -ms-overflow-style: -ms-autohiding-scrollbar; border: 1px solid #ddd; }
+  .table-responsive > .table { margin-bottom: 0; }
+  .table-responsive > .table > thead > tr > th, .table-responsive > .table > thead > tr > td, .table-responsive > .table > tbody > tr > th, .table-responsive > .table > tbody > tr > td, .table-responsive > .table > tfoot > tr > th, .table-responsive > .table > tfoot > tr > td { white-space: nowrap; }
+  .table-responsive > .table-bordered { border: 0; }
+  .table-responsive > .table-bordered > thead > tr > th:first-child, .table-responsive > .table-bordered > thead > tr > td:first-child, .table-responsive > .table-bordered > tbody > tr > th:first-child, .table-responsive > .table-bordered > tbody > tr > td:first-child, .table-responsive > .table-bordered > tfoot > tr > th:first-child, .table-responsive > .table-bordered > tfoot > tr > td:first-child { border-left: 0; }
+  .table-responsive > .table-bordered > thead > tr > th:last-child, .table-responsive > .table-bordered > thead > tr > td:last-child, .table-responsive > .table-bordered > tbody > tr > th:last-child, .table-responsive > .table-bordered > tbody > tr > td:last-child, .table-responsive > .table-bordered > tfoot > tr > th:last-child, .table-responsive > .table-bordered > tfoot > tr > td:last-child { border-right: 0; }
+  .table-responsive > .table-bordered > tbody > tr:last-child > th, .table-responsive > .table-bordered > tbody > tr:last-child > td, .table-responsive > .table-bordered > tfoot > tr:last-child > th, .table-responsive > .table-bordered > tfoot > tr:last-child > td { border-bottom: 0; } }
+
+fieldset { padding: 0; margin: 0; border: 0; min-width: 0; }
+
+legend { display: block; width: 100%; padding: 0; margin-bottom: 20px; font-size: 21px; line-height: inherit; color: #333333; border: 0; border-bottom: 1px solid #e5e5e5; }
+
+label { display: inline-block; max-width: 100%; margin-bottom: 5px; font-weight: bold; }
+
+input[type="search"] { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
+
+input[type="radio"], input[type="checkbox"] { margin: 4px 0 0; margin-top: 1px \9; line-height: normal; }
+
+input[type="file"] { display: block; }
+
+input[type="range"] { display: block; width: 100%; }
+
+select[multiple], select[size] { height: auto; }
+
+input[type="file"]:focus, input[type="radio"]:focus, input[type="checkbox"]:focus { outline: thin dotted; outline: 5px auto -webkit-focus-ring-color; outline-offset: -2px; }
+
+output { display: block; padding-top: 7px; font-size: 14px; line-height: 1.42857; color: #666; }
+
+.form-control { display: block; width: 100%; height: 34px; padding: 6px 12px; font-size: 14px; line-height: 1.42857; color: #666; background-color: #fff; background-image: none; border: 1px solid #ccc; border-radius: 4px; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s; -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s; transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s; }
+
+.form-control:focus { border-color: #66afe9; outline: 0; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6); }
+
+.form-control::-moz-placeholder { color: #999999; opacity: 1; }
+
+.form-control:-ms-input-placeholder { color: #999999; }
+
+.form-control::-webkit-input-placeholder { color: #999999; }
+
+.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control { background-color: #eeeeee; opacity: 1; }
+
+.form-control[disabled], fieldset[disabled] .form-control { cursor: not-allowed; }
+
+textarea.form-control { height: auto; }
+
+input[type="search"] { -webkit-appearance: none; }
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) { input[type="date"], input[type="time"], input[type="datetime-local"], input[type="month"] { line-height: 34px; }
+  input[type="date"].input-sm, .input-group-sm > input[type="date"].form-control, .input-group-sm > input[type="date"].input-group-addon, .input-group-sm > .input-group-btn > input[type="date"].btn, .input-group-sm > .input-group-btn > input[type="date"].btn-ghost, .input-group-sm input[type="date"], input[type="time"].input-sm, .input-group-sm > input[type="time"].form-control, .input-group-sm > input[type="time"].input-group-addon, .input-group-sm > .input-group-btn > input[type="time"].btn, .input-group-sm > .input-group-btn > input[type="time"].btn-ghost, .input-group-sm input[type="time"], input[type="datetime-local"].input-sm, .input-group-sm > input[type="datetime-local"].form-control, .input-group-sm > input[type="datetime-local"].input-group-addon, .input-group-sm > .input-group-btn > input[type="datetime-local"].btn, .input-group-sm > .input-group-btn > input[type="datetime-local"].btn-ghost, .input-group-sm input[type="datetime-local"], input[type="month"].input-sm, .input-group-sm > input[type="month"].form-control, .input-group-sm > input[type="month"].input-group-addon, .input-group-sm > .input-group-btn > input[type="month"].btn, .input-group-sm > .input-group-btn > input[type="month"].btn-ghost, .input-group-sm input[type="month"] { line-height: 30px; }
+  input[type="date"].input-lg, .input-group-lg > input[type="date"].form-control, .input-group-lg > input[type="date"].input-group-addon, .input-group-lg > .input-group-btn > input[type="date"].btn, .input-group-lg > .input-group-btn > input[type="date"].btn-ghost, .input-group-lg input[type="date"], input[type="time"].input-lg, .input-group-lg > input[type="time"].form-control, .input-group-lg > input[type="time"].input-group-addon, .input-group-lg > .input-group-btn > input[type="time"].btn, .input-group-lg > .input-group-btn > input[type="time"].btn-ghost, .input-group-lg input[type="time"], input[type="datetime-local"].input-lg, .input-group-lg > input[type="datetime-local"].form-control, .input-group-lg > input[type="datetime-local"].input-group-addon, .input-group-lg > .input-group-btn > input[type="datetime-local"].btn, .input-group-lg > .input-group-btn > input[type="datetime-local"].btn-ghost, .input-group-lg input[type="datetime-local"], input[type="month"].input-lg, .input-group-lg > input[type="month"].form-control, .input-group-lg > input[type="month"].input-group-addon, .input-group-lg > .input-group-btn > input[type="month"].btn, .input-group-lg > .input-group-btn > input[type="month"].btn-ghost, .input-group-lg input[type="month"] { line-height: 46px; } }
+
+.form-group { margin-bottom: 15px; }
+
+.radio, .checkbox { position: relative; display: block; margin-top: 10px; margin-bottom: 10px; }
+
+.radio label, .checkbox label { min-height: 20px; padding-left: 20px; margin-bottom: 0; font-weight: normal; cursor: pointer; }
+
+.radio input[type="radio"], .radio-inline input[type="radio"], .checkbox input[type="checkbox"], .checkbox-inline input[type="checkbox"] { position: absolute; margin-left: -20px; margin-top: 4px \9; }
+
+.radio + .radio, .checkbox + .checkbox { margin-top: -5px; }
+
+.radio-inline, .checkbox-inline { position: relative; display: inline-block; padding-left: 20px; margin-bottom: 0; vertical-align: middle; font-weight: normal; cursor: pointer; }
+
+.radio-inline + .radio-inline, .checkbox-inline + .checkbox-inline { margin-top: 0; margin-left: 10px; }
+
+input[type="radio"][disabled], input[type="radio"].disabled, fieldset[disabled] input[type="radio"], input[type="checkbox"][disabled], input[type="checkbox"].disabled, fieldset[disabled] input[type="checkbox"] { cursor: not-allowed; }
+
+.radio-inline.disabled, fieldset[disabled] .radio-inline, .checkbox-inline.disabled, fieldset[disabled] .checkbox-inline { cursor: not-allowed; }
+
+.radio.disabled label, fieldset[disabled] .radio label, .checkbox.disabled label, fieldset[disabled] .checkbox label { cursor: not-allowed; }
+
+.form-control-static { padding-top: 7px; padding-bottom: 7px; margin-bottom: 0; min-height: 34px; }
+
+.form-control-static.input-lg, .input-group-lg > .form-control-static.form-control, .input-group-lg > .form-control-static.input-group-addon, .input-group-lg > .input-group-btn > .form-control-static.btn, .input-group-lg > .input-group-btn > .form-control-static.btn-ghost, .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control, .input-group-sm > .form-control-static.input-group-addon, .input-group-sm > .input-group-btn > .form-control-static.btn, .input-group-sm > .input-group-btn > .form-control-static.btn-ghost { padding-left: 0; padding-right: 0; }
+
+.input-sm, .input-group-sm > .form-control, .input-group-sm > .input-group-addon, .input-group-sm > .input-group-btn > .btn, .input-group-sm > .input-group-btn > .btn-ghost { height: 30px; padding: 5px 10px; font-size: 12px; line-height: 1.5; border-radius: 3px; }
+
+select.input-sm, .input-group-sm > select.form-control, .input-group-sm > select.input-group-addon, .input-group-sm > .input-group-btn > select.btn, .input-group-sm > .input-group-btn > select.btn-ghost { height: 30px; line-height: 30px; }
+
+textarea.input-sm, .input-group-sm > textarea.form-control, .input-group-sm > textarea.input-group-addon, .input-group-sm > .input-group-btn > textarea.btn, .input-group-sm > .input-group-btn > textarea.btn-ghost, select[multiple].input-sm, .input-group-sm > select[multiple].form-control, .input-group-sm > select[multiple].input-group-addon, .input-group-sm > .input-group-btn > select[multiple].btn, .input-group-sm > .input-group-btn > select[multiple].btn-ghost { height: auto; }
+
+.form-group-sm .form-control { height: 30px; padding: 5px 10px; font-size: 12px; line-height: 1.5; border-radius: 3px; }
+
+.form-group-sm select.form-control { height: 30px; line-height: 30px; }
+
+.form-group-sm textarea.form-control, .form-group-sm select[multiple].form-control { height: auto; }
+
+.form-group-sm .form-control-static { height: 30px; padding: 5px 10px; font-size: 12px; line-height: 1.5; min-height: 32px; }
+
+.input-lg, .input-group-lg > .form-control, .input-group-lg > .input-group-addon, .input-group-lg > .input-group-btn > .btn, .input-group-lg > .input-group-btn > .btn-ghost { height: 46px; padding: 10px 16px; font-size: 18px; line-height: 1.33; border-radius: 6px; }
+
+select.input-lg, .input-group-lg > select.form-control, .input-group-lg > select.input-group-addon, .input-group-lg > .input-group-btn > select.btn, .input-group-lg > .input-group-btn > select.btn-ghost { height: 46px; line-height: 46px; }
+
+textarea.input-lg, .input-group-lg > textarea.form-control, .input-group-lg > textarea.input-group-addon, .input-group-lg > .input-group-btn > textarea.btn, .input-group-lg > .input-group-btn > textarea.btn-ghost, select[multiple].input-lg, .input-group-lg > select[multiple].form-control, .input-group-lg > select[multiple].input-group-addon, .input-group-lg > .input-group-btn > select[multiple].btn, .input-group-lg > .input-group-btn > select[multiple].btn-ghost { height: auto; }
+
+.form-group-lg .form-control { height: 46px; padding: 10px 16px; font-size: 18px; line-height: 1.33; border-radius: 6px; }
+
+.form-group-lg select.form-control { height: 46px; line-height: 46px; }
+
+.form-group-lg textarea.form-control, .form-group-lg select[multiple].form-control { height: auto; }
+
+.form-group-lg .form-control-static { height: 46px; padding: 10px 16px; font-size: 18px; line-height: 1.33; min-height: 38px; }
+
+.has-feedback { position: relative; }
+
+.has-feedback .form-control { padding-right: 42.5px; }
+
+.form-control-feedback { position: absolute; top: 0; right: 0; z-index: 2; display: block; width: 34px; height: 34px; line-height: 34px; text-align: center; pointer-events: none; }
+
+.input-lg + .form-control-feedback, .input-group-lg > .form-control + .form-control-feedback, .input-group-lg > .input-group-addon + .form-control-feedback, .input-group-lg > .input-group-btn > .btn + .form-control-feedback, .input-group-lg > .input-group-btn > .btn-ghost + .form-control-feedback { width: 46px; height: 46px; line-height: 46px; }
+
+.input-sm + .form-control-feedback, .input-group-sm > .form-control + .form-control-feedback, .input-group-sm > .input-group-addon + .form-control-feedback, .input-group-sm > .input-group-btn > .btn + .form-control-feedback, .input-group-sm > .input-group-btn > .btn-ghost + .form-control-feedback { width: 30px; height: 30px; line-height: 30px; }
+
+.has-success .help-block, .has-success .control-label, .has-success .radio, .has-success .checkbox, .has-success .radio-inline, .has-success .checkbox-inline, .has-success.radio label, .has-success.checkbox label, .has-success.radio-inline label, .has-success.checkbox-inline label { color: #9bb83a; }
+
+.has-success .form-control { border-color: #9bb83a; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
+
+.has-success .form-control:focus { border-color: #7a912e; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781; box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c3d781; }
+
+.has-success .input-group-addon { color: #9bb83a; border-color: #9bb83a; background-color: #f5f8eb; }
+
+.has-success .form-control-feedback { color: #9bb83a; }
+
+.has-warning .help-block, .has-warning .control-label, .has-warning .radio, .has-warning .checkbox, .has-warning .radio-inline, .has-warning .checkbox-inline, .has-warning.radio label, .has-warning.checkbox label, .has-warning.radio-inline label, .has-warning.checkbox-inline label { color: #e5d321; }
+
+.has-warning .form-control { border-color: #e5d321; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
+
+.has-warning .form-control:focus { border-color: #bdae16; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c; box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0e57c; }
+
+.has-warning .input-group-addon { color: #e5d321; border-color: #e5d321; background-color: #fdfde9; }
+
+.has-warning .form-control-feedback { color: #e5d321; }
+
+.has-error .help-block, .has-error .control-label, .has-error .radio, .has-error .checkbox, .has-error .radio-inline, .has-error .checkbox-inline, .has-error.radio label, .has-error.checkbox label, .has-error.radio-inline label, .has-error.checkbox-inline label { color: #e53221; }
+
+.has-error .form-control { border-color: #e53221; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); }
+
+.has-error .form-control:focus { border-color: #bd2516; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c; box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #f0867c; }
+
+.has-error .input-group-addon { color: #e53221; border-color: #e53221; background-color: #fceae8; }
+
+.has-error .form-control-feedback { color: #e53221; }
+
+.has-feedback label ~ .form-control-feedback { top: 25px; }
+
+.has-feedback label.sr-only ~ .form-control-feedback { top: 0; }
+
+.help-block { display: block; margin-top: 5px; margin-bottom: 10px; color: #a6a6a6; }
+
+@media (min-width: 768px) { .form-inline .form-group { display: inline-block; margin-bottom: 0; vertical-align: middle; }
+  .form-inline .form-control { display: inline-block; width: auto; vertical-align: middle; }
+  .form-inline .form-control-static { display: inline-block; }
+  .form-inline .input-group { display: inline-table; vertical-align: middle; }
+  .form-inline .input-group .input-group-addon, .form-inline .input-group .input-group-btn, .form-inline .input-group .form-control { width: auto; }
+  .form-inline .input-group > .form-control { width: 100%; }
+  .form-inline .control-label { margin-bottom: 0; vertical-align: middle; }
+  .form-inline .radio, .form-inline .checkbox { display: inline-block; margin-top: 0; margin-bottom: 0; vertical-align: middle; }
+  .form-inline .radio label, .form-inline .checkbox label { padding-left: 0; }
+  .form-inline .radio input[type="radio"], .form-inline .checkbox input[type="checkbox"] { position: relative; margin-left: 0; }
+  .form-inline .has-feedback .form-control-feedback { top: 0; } }
+
+.form-horizontal .radio, .form-horizontal .checkbox, .form-horizontal .radio-inline, .form-horizontal .checkbox-inline { margin-top: 0; margin-bottom: 0; padding-top: 7px; }
+
+.form-horizontal .radio, .form-horizontal .checkbox { min-height: 27px; }
+
+.form-horizontal .form-group { margin-left: -15px; margin-right: -15px; }
+
+.form-horizontal .form-group:before, .form-horizontal .form-group:after { content: " "; display: table; }
+
+.form-horizontal .form-group:after { clear: both; }
+
+@media (min-width: 768px) { .form-horizontal .control-label { text-align: right; margin-bottom: 0; padding-top: 7px; } }
+
+.form-horizontal .has-feedback .form-control-feedback { right: 15px; }
+
+@media (min-width: 768px) { .form-horizontal .form-group-lg .control-label { padding-top: 14.3px; } }
+
+@media (min-width: 768px) { .form-horizontal .form-group-sm .control-label { padding-top: 6px; } }
+
+.btn, .btn-ghost { display: inline-block; margin-bottom: 0; font-weight: 400; text-align: center; vertical-align: middle; touch-action: manipulation; cursor: pointer; background-image: none; border: 1px solid transparent; white-space: nowrap; padding: 6px 12px; font-size: 14px; line-height: 1.42857; border-radius: 4px; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; }
+
+.btn:focus, .btn-ghost:focus, .btn.focus, .focus.btn-ghost, .btn:active:focus, .btn-ghost:active:focus, .btn:active.focus, .btn-ghost:active.focus, .btn.active:focus, .active.btn-ghost:focus, .btn.active.focus, .active.focus.btn-ghost { outline: thin dotted; outline: 5px auto -webkit-focus-ring-color; outline-offset: -2px; }
+
+.btn:hover, .btn-ghost:hover, .btn:focus, .btn-ghost:focus, .btn.focus, .focus.btn-ghost { color: #555; text-decoration: none; }
+
+.btn:active, .btn-ghost:active, .btn.active, .active.btn-ghost { outline: 0; background-image: none; -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
+
+.btn.disabled, .disabled.btn-ghost, .btn[disabled], [disabled].btn-ghost, fieldset[disabled] .btn, fieldset[disabled] .btn-ghost { cursor: not-allowed; pointer-events: none; opacity: 0.65; filter: alpha(opacity=65); -webkit-box-shadow: none; box-shadow: none; }
+
+.btn-default { color: #555; background-color: #f4f5f6; border-color: #b1b6bf; }
+
+.btn-default:hover, .btn-default:focus, .btn-default.focus, .btn-default:active, .btn-default.active, .open > .btn-default.dropdown-toggle { color: #555; background-color: #d8dcdf; border-color: #8f97a3; }
+
+.btn-default:active, .btn-default.active, .open > .btn-default.dropdown-toggle { background-image: none; }
+
+.btn-default.disabled, .btn-default.disabled:hover, .btn-default.disabled:focus, .btn-default.disabled.focus, .btn-default.disabled:active, .btn-default.disabled.active, .btn-default[disabled], .btn-default[disabled]:hover, .btn-default[disabled]:focus, .btn-default[disabled].focus, .btn-default[disabled]:active, .btn-default[disabled].active, fieldset[disabled] .btn-default, fieldset[disabled] .btn-default:hover, fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default.focus, fieldset[disabled] .btn-default:active, fieldset[disabled] .btn-default.active { background-color: #f4f5f6; border-color: #b1b6bf; }
+
+.btn-default .badge { color: #f4f5f6; background-color: #555; }
+
+.btn-primary { color: #fff; background-color: #9bb83a; border-color: #70842a; }
+
+.btn-primary:hover, .btn-primary:focus, .btn-primary.focus, .btn-primary:active, .btn-primary.active, .open > .btn-primary.dropdown-toggle { color: #fff; background-color: #7a912e; border-color: #48561b; }
+
+.btn-primary:active, .btn-primary.active, .open > .btn-primary.dropdown-toggle { background-image: none; }
+
+.btn-primary.disabled, .btn-primary.disabled:hover, .btn-primary.disabled:focus, .btn-primary.disabled.focus, .btn-primary.disabled:active, .btn-primary.disabled.active, .btn-primary[disabled], .btn-primary[disabled]:hover, .btn-primary[disabled]:focus, .btn-primary[disabled].focus, .btn-primary[disabled]:active, .btn-primary[disabled].active, fieldset[disabled] .btn-primary, fieldset[disabled] .btn-primary:hover, fieldset[disabled] .btn-primary:focus, fieldset[disabled] .btn-primary.focus, fieldset[disabled] .btn-primary:active, fieldset[disabled] .btn-primary.active { background-color: #9bb83a; border-color: #70842a; }
+
+.btn-primary .badge { color: #9bb83a; background-color: #fff; }
+
+.btn-success { color: #fff; background-color: #9bb83a; border-color: #5a6a22; }
+
+.btn-success:hover, .btn-success:focus, .btn-success.focus, .btn-success:active, .btn-success.active, .open > .btn-success.dropdown-toggle { color: #fff; background-color: #7a912e; border-color: #323c13; }
+
+.btn-success:active, .btn-success.active, .open > .btn-success.dropdown-toggle { background-image: none; }
+
+.btn-success.disabled, .btn-success.disabled:hover, .btn-success.disabled:focus, .btn-success.disabled.focus, .btn-success.disabled:active, .btn-success.disabled.active, .btn-success[disabled], .btn-success[disabled]:hover, .btn-success[disabled]:focus, .btn-success[disabled].focus, .btn-success[disabled]:active, .btn-success[disabled].active, fieldset[disabled] .btn-success, fieldset[disabled] .btn-success:hover, fieldset[disabled] .btn-success:focus, fieldset[disabled] .btn-success.focus, fieldset[disabled] .btn-success:active, fieldset[disabled] .btn-success.active { background-color: #9bb83a; border-color: #5a6a22; }
+
+.btn-success .badge { color: #9bb83a; background-color: #fff; }
+
+.btn-info { color: #fff; background-color: #389Bc9; border-color: #215e7a; }
+
+.btn-info:hover, .btn-info:focus, .btn-info.focus, .btn-info:active, .btn-info.active, .open > .btn-info.dropdown-toggle { color: #fff; background-color: #2c7da2; border-color: #14394a; }
+
+.btn-info:active, .btn-info.active, .open > .btn-info.dropdown-toggle { background-image: none; }
+
+.btn-info.disabled, .btn-info.disabled:hover, .btn-info.disabled:focus, .btn-info.disabled.focus, .btn-info.disabled:active, .btn-info.disabled.active, .btn-info[disabled], .btn-info[disabled]:hover, .btn-info[disabled]:focus, .btn-info[disabled].focus, .btn-info[disabled]:active, .btn-info[disabled].active, fieldset[disabled] .btn-info, fieldset[disabled] .btn-info:hover, fieldset[disabled] .btn-info:focus, fieldset[disabled] .btn-info.focus, fieldset[disabled] .btn-info:active, fieldset[disabled] .btn-info.active { background-color: #389Bc9; border-color: #215e7a; }
+
+.btn-info .badge { color: #389Bc9; background-color: #fff; }
+
+.btn-warning { color: #fff; background-color: #e5d321; border-color: #8f8411; }
+
+.btn-warning:hover, .btn-warning:focus, .btn-warning.focus, .btn-warning:active, .btn-warning.active, .open > .btn-warning.dropdown-toggle { color: #fff; background-color: #bdae16; border-color: #58510a; }
+
+.btn-warning:active, .btn-warning.active, .open > .btn-warning.dropdown-toggle { background-image: none; }
+
+.btn-warning.disabled, .btn-warning.disabled:hover, .btn-warning.disabled:focus, .btn-warning.disabled.focus, .btn-warning.disabled:active, .btn-warning.disabled.active, .btn-warning[disabled], .btn-warning[disabled]:hover, .btn-warning[disabled]:focus, .btn-warning[disabled].focus, .btn-warning[disabled]:active, .btn-warning[disabled].active, fieldset[disabled] .btn-warning, fieldset[disabled] .btn-warning:hover, fieldset[disabled] .btn-warning:focus, fieldset[disabled] .btn-warning.focus, fieldset[disabled] .btn-warning:active, fieldset[disabled] .btn-warning.active { background-color: #e5d321; border-color: #8f8411; }
+
+.btn-warning .badge { color: #e5d321; background-color: #fff; }
+
+.btn-danger, .btn-primary-alt { color: #fff; background-color: #e53221; border-color: #8f1c11; }
+
+.btn-danger:hover, .btn-primary-alt:hover, .btn-danger:focus, .btn-primary-alt:focus, .btn-danger.focus, .focus.btn-primary-alt, .btn-danger:active, .btn-primary-alt:active, .btn-danger.active, .active.btn-primary-alt, .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt { color: #fff; background-color: #bd2516; border-color: #58110a; }
+
+.btn-danger:active, .btn-primary-alt:active, .btn-danger.active, .active.btn-primary-alt, .open > .btn-danger.dropdown-toggle, .open > .dropdown-toggle.btn-primary-alt { background-image: none; }
+
+.btn-danger.disabled, .disabled.btn-primary-alt, .btn-danger.disabled:hover, .disabled.btn-primary-alt:hover, .btn-danger.disabled:focus, .disabled.btn-primary-alt:focus, .btn-danger.disabled.focus, .disabled.focus.btn-primary-alt, .btn-danger.disabled:active, .disabled.btn-primary-alt:active, .btn-danger.disabled.active, .disabled.active.btn-primary-alt, .btn-danger[disabled], [disabled].btn-primary-alt, .btn-danger[disabled]:hover, [disabled].btn-primary-alt:hover, .btn-danger[disabled]:focus, [disabled].btn-primary-alt:focus, .btn-danger[disabled].focus, [disabled].focus.btn-primary-alt, .btn-danger[disabled]:active, [disabled].btn-primary-alt:active, .btn-danger[disabled].active, [disabled].active.btn-primary-alt, fieldset[disabled] .btn-danger, fieldset[disabled] .btn-primary-alt, fieldset[disabled] .btn-danger:hover, fieldset[disabled] .btn-primary-alt:hover, fieldset[disabled] .btn-danger:focus, fieldset[disabled] .btn-primary-alt:focus, fieldset[disabled] .btn-danger.focus, fieldset[disabled] .focus.btn-primary-alt, fieldset[disabled] .btn-danger:active, fieldset[disabled] .btn-primary-alt:active, fieldset[disabled] .btn-danger.active, fieldset[disabled] .active.btn-primary-alt { background-color: #e53221; border-color: #8f1c11; }
+
+.btn-danger .badge, .btn-primary-alt .badge { color: #e53221; background-color: #fff; }
+
+.btn-link, .btn-secondary { color: #2e88be; font-weight: normal; border-radius: 0; }
+
+.btn-link, .btn-secondary, .btn-link:active, .btn-secondary:active, .btn-link.active, .active.btn-secondary, .btn-link[disabled], [disabled].btn-secondary, fieldset[disabled] .btn-link, fieldset[disabled] .btn-secondary { background-color: transparent; -webkit-box-shadow: none; box-shadow: none; }
+
+.btn-link, .btn-secondary, .btn-link:hover, .btn-secondary:hover, .btn-link:focus, .btn-secondary:focus, .btn-link:active, .btn-secondary:active { border-color: transparent; }
+
+.btn-link:hover, .btn-secondary:hover, .btn-link:focus, .btn-secondary:focus { color: #1f5c80; text-decoration: underline; background-color: transparent; }
+
+.btn-link[disabled]:hover, [disabled].btn-secondary:hover, .btn-link[disabled]:focus, [disabled].btn-secondary:focus, fieldset[disabled] .btn-link:hover, fieldset[disabled] .btn-secondary:hover, fieldset[disabled] .btn-link:focus, fieldset[disabled] .btn-secondary:focus { color: #999999; text-decoration: none; }
+
+.btn-lg, .btn-group-lg > .btn, .btn-group-lg > .btn-ghost { padding: 10px 16px; font-size: 18px; line-height: 1.33; border-radius: 6px; }
+
+.btn-sm, .btn-group-sm > .btn, .btn-group-sm > .btn-ghost { padding: 5px 10px; font-size: 12px; line-height: 1.5; border-radius: 3px; }
+
+.btn-xs, .btn-group-xs > .btn, .btn-group-xs > .btn-ghost { padding: 1px 5px; font-size: 12px; line-height: 1.5; border-radius: 3px; }
+
+.btn-block { display: block; width: 100%; }
+
+.btn-block + .btn-block { margin-top: 5px; }
+
+input[type="submit"].btn-block, input[type="reset"].btn-block, input[type="button"].btn-block { width: 100%; }
+
+.fade { opacity: 0; -webkit-transition: opacity 0.15s linear; -o-transition: opacity 0.15s linear; transition: opacity 0.15s linear; }
+
+.fade.in { opacity: 1; }
+
+.collapse { display: none; }
+
+.collapse.in { display: block; }
+
+tr.collapse.in { display: table-row; }
+
+tbody.collapse.in { display: table-row-group; }
+
+.collapsing { position: relative; height: 0; overflow: hidden; -webkit-transition-property: height, visibility; transition-property: height, visibility; -webkit-transition-duration: 0.35s; transition-duration: 0.35s; -webkit-transition-timing-function: ease; transition-timing-function: ease; }
+
+.caret { display: inline-block; width: 0; height: 0; margin-left: 2px; vertical-align: middle; border-top: 4px dashed; border-right: 4px solid transparent; border-left: 4px solid transparent; }
+
+.dropup, .dropdown { position: relative; }
+
+.dropdown-toggle:focus { outline: 0; }
+
+.dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 1000; display: none; float: left; min-width: 160px; padding: 5px 0; margin: 2px 0 0; list-style: none; font-size: 14px; text-align: left; background-color: #fff; border: 1px solid #ccc; border: 1px solid rgba(0, 0, 0, 0.15); border-radius: 4px; -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175); box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175); background-clip: padding-box; }
+
+.dropdown-menu.pull-right { right: 0; left: auto; }
+
+.dropdown-menu .divider { height: 1px; margin: 9px 0; overflow: hidden; background-color: #e5e5e5; }
+
+.dropdown-menu > li > a { display: block; padding: 3px 20px; clear: both; font-weight: normal; line-height: 1.42857; color: #333333; white-space: nowrap; }
+
+.dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus { text-decoration: none; color: #262626; background-color: #f1f1f1; }
+
+.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus { color: #666; text-decoration: none; outline: 0; background-color: #f1f1f1; }
+
+.dropdown-menu > .disabled > a, .dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus { color: #999999; }
+
+.dropdown-menu > .disabled > a:hover, .dropdown-menu > .disabled > a:focus { text-decoration: none; background-color: transparent; background-image: none; filter: progid:DXImageTransform.Microsoft.gradient(enabled = false); cursor: not-allowed; }
+
+.open > .dropdown-menu { display: block; }
+
+.open > a { outline: 0; }
+
+.dropdown-menu-right { left: auto; right: 0; }
+
+.dropdown-menu-left { left: 0; right: auto; }
+
+.dropdown-header { display: block; padding: 3px 20px; font-size: 12px; line-height: 1.42857; color: #999999; white-space: nowrap; }
+
+.dropdown-backdrop { position: fixed; left: 0; right: 0; bottom: 0; top: 0; z-index: 990; }
+
+.pull-right > .dropdown-menu { right: 0; left: auto; }
+
+.dropup .caret, .navbar-fixed-bottom .dropdown .caret { border-top: 0; border-bottom: 4px solid; content: ""; }
+
+.dropup .dropdown-menu, .navbar-fixed-bottom .dropdown .dropdown-menu { top: auto; bottom: 100%; margin-bottom: 2px; }
+
+@media (min-width: 768px) { .navbar-right .dropdown-menu { right: 0; left: auto; }
+  .navbar-right .dropdown-menu-left { left: 0; right: auto; } }
+
+.btn-group, .btn-group-vertical { position: relative; display: inline-block; vertical-align: middle; }
+
+.btn-group > .btn, .btn-group > .btn-ghost, .btn-group-vertical > .btn, .btn-group-vertical > .btn-ghost { position: relative; float: left; }
+
+.btn-group > .btn:hover, .btn-group > .btn-ghost:hover, .btn-group > .btn:focus, .btn-group > .btn-ghost:focus, .btn-group > .btn:active, .btn-group > .btn-ghost:active, .btn-group > .btn.active, .btn-group > .active.btn-ghost, .btn-group-vertical > .btn:hover, .btn-group-vertical > .btn-ghost:hover, .btn-group-vertical > .btn:focus, .btn-group-vertical > .btn-ghost:focus, .btn-group-vertical > .btn:active, .btn-group-vertical > .btn-ghost:active, .btn-group-vertical > .btn.active, .btn-group-vertical > .active.btn-ghost { z-index: 2; }
+
+.btn-group .btn + .btn, .btn-group .btn-ghost + .btn, .btn-group .btn + .btn-ghost, .btn-group .btn-ghost + .btn-ghost, .btn-group .btn + .btn-group, .btn-group .btn-ghost + .btn-group, .btn-group .btn-group + .btn, .btn-group .btn-group + .btn-ghost, .btn-group .btn-group + .btn-group { margin-left: -1px; }
+
+.btn-toolbar { margin-left: -5px; }
+
+.btn-toolbar:before, .btn-toolbar:after { content: " "; display: table; }
+
+.btn-toolbar:after { clear: both; }
+
+.btn-toolbar .btn-group, .btn-toolbar .input-group { float: left; }
+
+.btn-toolbar > .btn, .btn-toolbar > .btn-ghost, .btn-toolbar > .btn-group, .btn-toolbar > .input-group { margin-left: 5px; }
+
+.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:not(:first-child):not(:last-child):not(.dropdown-toggle) { border-radius: 0; }
+
+.btn-group > .btn:first-child, .btn-group > .btn-ghost:first-child { margin-left: 0; }
+
+.btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle), .btn-group > .btn-ghost:first-child:not(:last-child):not(.dropdown-toggle) { border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+.btn-group > .btn:last-child:not(:first-child), .btn-group > .btn-ghost:last-child:not(:first-child), .btn-group > .dropdown-toggle:not(:first-child) { border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+.btn-group > .btn-group { float: left; }
+
+.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn, .btn-group > .btn-group:not(:first-child):not(:last-child) > .btn-ghost { border-radius: 0; }
+
+.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child, .btn-group > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child, .btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle { border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child, .btn-group > .btn-group:last-child:not(:first-child) > .btn-ghost:first-child { border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+.btn-group .dropdown-toggle:active, .btn-group.open .dropdown-toggle { outline: 0; }
+
+.btn-group > .btn + .dropdown-toggle, .btn-group > .btn-ghost + .dropdown-toggle { padding-left: 8px; padding-right: 8px; }
+
+.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle, .btn-group-lg.btn-group > .btn-ghost + .dropdown-toggle { padding-left: 12px; padding-right: 12px; }
+
+.btn-group.open .dropdown-toggle { -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
+
+.btn-group.open .dropdown-toggle.btn-link, .btn-group.open .dropdown-toggle.btn-secondary { -webkit-box-shadow: none; box-shadow: none; }
+
+.btn .caret, .btn-ghost .caret { margin-left: 0; }
+
+.btn-lg .caret, .btn-group-lg > .btn .caret, .btn-group-lg > .btn-ghost .caret { border-width: 5px 5px 0; border-bottom-width: 0; }
+
+.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .btn-group-lg > .btn-ghost .caret { border-width: 0 5px 5px; }
+
+.btn-group-vertical > .btn, .btn-group-vertical > .btn-ghost, .btn-group-vertical > .btn-group, .btn-group-vertical > .btn-group > .btn, .btn-group-vertical > .btn-group > .btn-ghost { display: block; float: none; width: 100%; max-width: 100%; }
+
+.btn-group-vertical > .btn-group:before, .btn-group-vertical > .btn-group:after { content: " "; display: table; }
+
+.btn-group-vertical > .btn-group:after { clear: both; }
+
+.btn-group-vertical > .btn-group > .btn, .btn-group-vertical > .btn-group > .btn-ghost { float: none; }
+
+.btn-group-vertical > .btn + .btn, .btn-group-vertical > .btn-ghost + .btn, .btn-group-vertical > .btn + .btn-ghost, .btn-group-vertical > .btn-ghost + .btn-ghost, .btn-group-vertical > .btn + .btn-group, .btn-group-vertical > .btn-ghost + .btn-group, .btn-group-vertical > .btn-group + .btn, .btn-group-vertical > .btn-group + .btn-ghost, .btn-group-vertical > .btn-group + .btn-group { margin-top: -1px; margin-left: 0; }
+
+.btn-group-vertical > .btn:not(:first-child):not(:last-child), .btn-group-vertical > .btn-ghost:not(:first-child):not(:last-child) { border-radius: 0; }
+
+.btn-group-vertical > .btn:first-child:not(:last-child), .btn-group-vertical > .btn-ghost:first-child:not(:last-child) { border-top-right-radius: 4px; border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.btn-group-vertical > .btn:last-child:not(:first-child), .btn-group-vertical > .btn-ghost:last-child:not(:first-child) { border-bottom-left-radius: 4px; border-top-right-radius: 0; border-top-left-radius: 0; }
+
+.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn, .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn-ghost { border-radius: 0; }
+
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child, .btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn-ghost:last-child, .btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle { border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child, .btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn-ghost:first-child { border-top-right-radius: 0; border-top-left-radius: 0; }
+
+.btn-group-justified { display: table; width: 100%; table-layout: fixed; border-collapse: separate; }
+
+.btn-group-justified > .btn, .btn-group-justified > .btn-ghost, .btn-group-justified > .btn-group { float: none; display: table-cell; width: 1%; }
+
+.btn-group-justified > .btn-group .btn, .btn-group-justified > .btn-group .btn-ghost { width: 100%; }
+
+.btn-group-justified > .btn-group .dropdown-menu { left: auto; }
+
+[data-toggle="buttons"] > .btn input[type="radio"], [data-toggle="buttons"] > .btn-ghost input[type="radio"], [data-toggle="buttons"] > .btn input[type="checkbox"], [data-toggle="buttons"] > .btn-ghost input[type="checkbox"], [data-toggle="buttons"] > .btn-group > .btn input[type="radio"], [data-toggle="buttons"] > .btn-group > .btn-ghost input[type="radio"], [data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"], [data-toggle="buttons"] > .btn-group > .btn-ghost input[type="checkbox"] { position: absolute; clip: rect(0, 0, 0, 0); pointer-events: none; }
+
+.input-group { position: relative; display: table; border-collapse: separate; }
+
+.input-group[class*="col-"] { float: none; padding-left: 0; padding-right: 0; }
+
+.input-group .form-control { position: relative; z-index: 2; float: left; width: 100%; margin-bottom: 0; }
+
+.input-group-addon, .input-group-btn, .input-group .form-control { display: table-cell; }
+
+.input-group-addon:not(:first-child):not(:last-child), .input-group-btn:not(:first-child):not(:last-child), .input-group .form-control:not(:first-child):not(:last-child) { border-radius: 0; }
+
+.input-group-addon, .input-group-btn { width: 1%; white-space: nowrap; vertical-align: middle; }
+
+.input-group-addon { padding: 6px 12px; font-size: 14px; font-weight: normal; line-height: 1; color: #666; text-align: center; background-color: #eeeeee; border: 1px solid #ccc; border-radius: 4px; }
+
+.input-group-addon.input-sm, .input-group-sm > .input-group-addon, .input-group-sm > .input-group-btn > .input-group-addon.btn, .input-group-sm > .input-group-btn > .input-group-addon.btn-ghost { padding: 5px 10px; font-size: 12px; border-radius: 3px; }
+
+.input-group-addon.input-lg, .input-group-lg > .input-group-addon, .input-group-lg > .input-group-btn > .input-group-addon.btn, .input-group-lg > .input-group-btn > .input-group-addon.btn-ghost { padding: 10px 16px; font-size: 18px; border-radius: 6px; }
+
+.input-group-addon input[type="radio"], .input-group-addon input[type="checkbox"] { margin-top: 0; }
+
+.input-group .form-control:first-child, .input-group-addon:first-child, .input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-ghost, .input-group-btn:first-child > .btn-group > .btn, .input-group-btn:first-child > .btn-group > .btn-ghost, .input-group-btn:first-child > .dropdown-toggle, .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle), .input-group-btn:last-child > .btn-ghost:not(:last-child):not(.dropdown-toggle), .input-group-btn:last-child > .btn-group:not(:last-child) > .btn, .input-group-btn:last-child > .btn-group:not(:last-child) > .btn-ghost { border-bottom-right-radius: 0; border-top-right-radius: 0; }
+
+.input-group-addon:first-child { border-right: 0; }
+
+.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-ghost, .input-group-btn:last-child > .btn-group > .btn, .input-group-btn:last-child > .btn-group > .btn-ghost, .input-group-btn:last-child > .dropdown-toggle, .input-group-btn:first-child > .btn:not(:first-child), .input-group-btn:first-child > .btn-ghost:not(:first-child), .input-group-btn:first-child > .btn-group:not(:first-child) > .btn, .input-group-btn:first-child > .btn-group:not(:first-child) > .btn-ghost { border-bottom-left-radius: 0; border-top-left-radius: 0; }
+
+.input-group-addon:last-child { border-left: 0; }
+
+.input-group-btn { position: relative; font-size: 0; white-space: nowrap; }
+
+.input-group-btn > .btn, .input-group-btn > .btn-ghost { position: relative; }
+
+.input-group-btn > .btn + .btn, .input-group-btn > .btn-ghost + .btn, .input-group-btn > .btn + .btn-ghost, .input-group-btn > .btn-ghost + .btn-ghost { margin-left: -1px; }
+
+.input-group-btn > .btn:hover, .input-group-btn > .btn-ghost:hover, .input-group-btn > .btn:focus, .input-group-btn > .btn-ghost:focus, .input-group-btn > .btn:active, .input-group-btn > .btn-ghost:active { z-index: 2; }
+
+.input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-ghost, .input-group-btn:first-child > .btn-group { margin-right: -1px; }
+
+.input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-ghost, .input-group-btn:last-child > .btn-group { margin-left: -1px; }
+
+.nav { margin-bottom: 0; padding-left: 0; list-style: none; }
+
+.nav:before, .nav:after { content: " "; display: table; }
+
+.nav:after { clear: both; }
+
+.nav > li { position: relative; display: block; }
+
+.nav > li > a { position: relative; display: block; padding: 10px 15px; }
+
+.nav > li > a:hover, .nav > li > a:focus { text-decoration: none; background-color: #eeeeee; }
+
+.nav > li.disabled > a { color: #999999; }
+
+.nav > li.disabled > a:hover, .nav > li.disabled > a:focus { color: #999999; text-decoration: none; background-color: transparent; cursor: not-allowed; }
+
+.nav .open > a, .nav .open > a:hover, .nav .open > a:focus { background-color: #eeeeee; border-color: #2e88be; }
+
+.nav .nav-divider { height: 1px; margin: 9px 0; overflow: hidden; background-color: #e5e5e5; }
+
+.nav > li > a > img { max-width: none; }
+
+.nav-tabs { border-bottom: 1px solid #ddd; }
+
+.nav-tabs > li { float: left; margin-bottom: -1px; }
+
+.nav-tabs > li > a { margin-right: 2px; line-height: 1.42857; border: 1px solid transparent; border-radius: 4px 4px 0 0; }
+
+.nav-tabs > li > a:hover { border-color: #eeeeee #eeeeee #ddd; }
+
+.nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus { color: #666; background-color: #fff; border: 1px solid #ddd; border-bottom-color: transparent; cursor: default; }
+
+.nav-pills > li { float: left; }
+
+.nav-pills > li > a { border-radius: 4px; }
+
+.nav-pills > li + li { margin-left: 2px; }
+
+.nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus { color: #666; background-color: #f1f1f1; }
+
+.nav-stacked > li { float: none; }
+
+.nav-stacked > li + li { margin-top: 2px; margin-left: 0; }
+
+.nav-justified, .nav-tabs.nav-justified { width: 100%; }
+
+.nav-justified > li, .nav-tabs.nav-justified > li { float: none; }
+
+.nav-justified > li > a, .nav-tabs.nav-justified > li > a { text-align: center; margin-bottom: 5px; }
+
+.nav-justified > .dropdown .dropdown-menu { top: auto; left: auto; }
+
+@media (min-width: 768px) { .nav-justified > li, .nav-tabs.nav-justified > li { display: table-cell; width: 1%; }
+  .nav-justified > li > a, .nav-tabs.nav-justified > li > a { margin-bottom: 0; } }
+
+.nav-tabs-justified, .nav-tabs.nav-justified { border-bottom: 0; }
+
+.nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a { margin-right: 0; border-radius: 4px; }
+
+.nav-tabs-justified > .active > a, .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover, .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus { border: 1px solid #ddd; }
+
+@media (min-width: 768px) { .nav-tabs-justified > li > a, .nav-tabs.nav-justified > li > a { border-bottom: 1px solid #ddd; border-radius: 4px 4px 0 0; }
+  .nav-tabs-justified > .active > a, .nav-tabs.nav-justified > .active > a, .nav-tabs-justified > .active > a:hover, .nav-tabs.nav-justified > .active > a:hover, .nav-tabs-justified > .active > a:focus, .nav-tabs.nav-justified > .active > a:focus { border-bottom-color: #fff; } }
+
+.tab-content > .tab-pane { display: none; }
+
+.tab-content > .active { display: block; }
+
+.nav-tabs .dropdown-menu { margin-top: -1px; border-top-right-radius: 0; border-top-left-radius: 0; }
+
+.navbar { position: relative; min-height: 50px; margin-bottom: 20px; border: 1px solid transparent; }
+
+.navbar:before, .navbar:after { content: " "; display: table; }
+
+.navbar:after { clear: both; }
+
+@media (min-width: 768px) { .navbar { border-radius: 4px; } }
+
+.navbar-header:before, .navbar-header:after { content: " "; display: table; }
+
+.navbar-header:after { clear: both; }
+
+@media (min-width: 768px) { .navbar-header { float: left; } }
+
+.navbar-collapse { overflow-x: visible; padding-right: 15px; padding-left: 15px; border-top: 1px solid transparent; box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1); -webkit-overflow-scrolling: touch; }
+
+.navbar-collapse:before, .navbar-collapse:after { content: " "; display: table; }
+
+.navbar-collapse:after { clear: both; }
+
+.navbar-collapse.in { overflow-y: auto; }
+
+@media (min-width: 768px) { .navbar-collapse { width: auto; border-top: 0; box-shadow: none; }
+  .navbar-collapse.collapse { display: block !important; height: auto !important; padding-bottom: 0; overflow: visible !important; }
+  .navbar-collapse.in { overflow-y: visible; }
+  .navbar-fixed-top .navbar-collapse, .navbar-static-top .navbar-collapse, .navbar-fixed-bottom .navbar-collapse { padding-left: 0; padding-right: 0; } }
+
+.navbar-fixed-top .navbar-collapse, .navbar-fixed-bottom .navbar-collapse { max-height: 340px; }
+
+@media (max-device-width: 480px) and (orientation: landscape) { .navbar-fixed-top .navbar-collapse, .navbar-fixed-bottom .navbar-collapse { max-height: 200px; } }
+
+.container > .navbar-header, .container > .navbar-collapse, .container-fluid > .navbar-header, .container-fluid > .navbar-collapse { margin-right: -15px; margin-left: -15px; }
+
+@media (min-width: 768px) { .container > .navbar-header, .container > .navbar-collapse, .container-fluid > .navbar-header, .container-fluid > .navbar-collapse { margin-right: 0; margin-left: 0; } }
+
+.navbar-static-top { z-index: 1000; border-width: 0 0 1px; }
+
+@media (min-width: 768px) { .navbar-static-top { border-radius: 0; } }
+
+.navbar-fixed-top, .navbar-fixed-bottom { position: fixed; right: 0; left: 0; z-index: 1030; }
+
+@media (min-width: 768px) { .navbar-fixed-top, .navbar-fixed-bottom { border-radius: 0; } }
+
+.navbar-fixed-top { top: 0; border-width: 0 0 1px; }
+
+.navbar-fixed-bottom { bottom: 0; margin-bottom: 0; border-width: 1px 0 0; }
+
+.navbar-brand { float: left; padding: 15px 15px; font-size: 18px; line-height: 20px; height: 50px; }
+
+.navbar-brand:hover, .navbar-brand:focus { text-decoration: none; }
+
+.navbar-brand > img { display: block; }
+
+@media (min-width: 768px) { .navbar > .container .navbar-brand, .navbar > .container-fluid .navbar-brand { margin-left: -15px; } }
+
+.navbar-toggle { position: relative; float: right; margin-right: 15px; padding: 9px 10px; margin-top: 8px; margin-bottom: 8px; background-color: transparent; background-image: none; border: 1px solid transparent; border-radius: 4px; }
+
+.navbar-toggle:focus { outline: 0; }
+
+.navbar-toggle .icon-bar { display: block; width: 22px; height: 2px; border-radius: 1px; }
+
+.navbar-toggle .icon-bar + .icon-bar { margin-top: 4px; }
+
+@media (min-width: 768px) { .navbar-toggle { display: none; } }
+
+.navbar-nav { margin: 7.5px -15px; }
+
+.navbar-nav > li > a { padding-top: 10px; padding-bottom: 10px; line-height: 20px; }
+
+@media (max-width: 767px) { .navbar-nav .open .dropdown-menu { position: static; float: none; width: auto; margin-top: 0; background-color: transparent; border: 0; box-shadow: none; }
+  .navbar-nav .open .dropdown-menu > li > a, .navbar-nav .open .dropdown-menu .dropdown-header { padding: 5px 15px 5px 25px; }
+  .navbar-nav .open .dropdown-menu > li > a { line-height: 20px; }
+  .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-nav .open .dropdown-menu > li > a:focus { background-image: none; } }
+
+@media (min-width: 768px) { .navbar-nav { float: left; margin: 0; }
+  .navbar-nav > li { float: left; }
+  .navbar-nav > li > a { padding-top: 15px; padding-bottom: 15px; } }
+
+.navbar-form { margin-left: -15px; margin-right: -15px; padding: 10px 15px; border-top: 1px solid transparent; border-bottom: 1px solid transparent; -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1); margin-top: 8px; margin-bottom: 8px; }
+
+@media (min-width: 768px) { .navbar-form .form-group { display: inline-block; margin-bottom: 0; vertical-align: middle; }
+  .navbar-form .form-control { display: inline-block; width: auto; vertical-align: middle; }
+  .navbar-form .form-control-static { display: inline-block; }
+  .navbar-form .input-group { display: inline-table; vertical-align: middle; }
+  .navbar-form .input-group .input-group-addon, .navbar-form .input-group .input-group-btn, .navbar-form .input-group .form-control { width: auto; }
+  .navbar-form .input-group > .form-control { width: 100%; }
+  .navbar-form .control-label { margin-bottom: 0; vertical-align: middle; }
+  .navbar-form .radio, .navbar-form .checkbox { display: inline-block; margin-top: 0; margin-bottom: 0; vertical-align: middle; }
+  .navbar-form .radio label, .navbar-form .checkbox label { padding-left: 0; }
+  .navbar-form .radio input[type="radio"], .navbar-form .checkbox input[type="checkbox"] { position: relative; margin-left: 0; }
+  .navbar-form .has-feedback .form-control-feedback { top: 0; } }
+
+@media (max-width: 767px) { .navbar-form .form-group { margin-bottom: 5px; }
+  .navbar-form .form-group:last-child { margin-bottom: 0; } }
+
+@media (min-width: 768px) { .navbar-form { width: auto; border: 0; margin-left: 0; margin-right: 0; padding-top: 0; padding-bottom: 0; -webkit-box-shadow: none; box-shadow: none; } }
+
+.navbar-nav > li > .dropdown-menu { margin-top: 0; border-top-right-radius: 0; border-top-left-radius: 0; }
+
+.navbar-fixed-bottom .navbar-nav > li > .dropdown-menu { margin-bottom: 0; border-top-right-radius: 4px; border-top-left-radius: 4px; border-bottom-right-radius: 0; border-bottom-left-radius: 0; }
+
+.navbar-btn { margin-top: 8px; margin-bottom: 8px; }
+
+.navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn, .btn-group-sm > .navbar-btn.btn-ghost { margin-top: 10px; margin-bottom: 10px; }
+
+.navbar-btn.btn-xs, .btn-group-xs > .navbar-btn.btn, .btn-group-xs > .navbar-btn.btn-ghost { margin-top: 14px; margin-bottom: 14px; }
+
+.navbar-text { margin-top: 15px; margin-bottom: 15px; }
+
+@media (min-width: 768px) { .navbar-text { float: left; margin-left: 15px; margin-right: 15px; } }
+
+@media (min-width: 768px) { .navbar-left { float: left !important; }
+  .navbar-right { float: right !important; margin-right: -15px; }
+  .navbar-right ~ .navbar-right { margin-right: 0; } }
+
+.navbar-default { background-color: #fff; border-color: #eeeeee; }
+
+.navbar-default .navbar-brand { color: #666; }
+
+.navbar-default .navbar-brand:hover, .navbar-default .navbar-brand:focus { color: #4d4d4d; background-color: transparent; }
+
+.navbar-default .navbar-text { color: #666; }
+
+.navbar-default .navbar-nav > li > a { color: #666; }
+
+.navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus { color: #333; background-color: transparent; }
+
+.navbar-default .navbar-nav > .active > a, .navbar-default .navbar-nav > .active > a:hover, .navbar-default .navbar-nav > .active > a:focus { color: #e53221; background-color: #f9f9f9; }
+
+.navbar-default .navbar-nav > .disabled > a, .navbar-default .navbar-nav > .disabled > a:hover, .navbar-default .navbar-nav > .disabled > a:focus { color: #ccc; background-color: transparent; }
+
+.navbar-default .navbar-toggle { border-color: #ddd; }
+
+.navbar-default .navbar-toggle:hover, .navbar-default .navbar-toggle:focus { background-color: #eee; }
+
+.navbar-default .navbar-toggle .icon-bar { background-color: #999; }
+
+.navbar-default .navbar-collapse, .navbar-default .navbar-form { border-color: #eeeeee; }
+
+.navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:hover, .navbar-default .navbar-nav > .open > a:focus { background-color: #f9f9f9; color: #e53221; }
+
+@media (max-width: 767px) { .navbar-default .navbar-nav .open .dropdown-menu > li > a { color: #666; }
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus { color: #333; background-color: transparent; }
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus { color: #e53221; background-color: #f9f9f9; }
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus { color: #ccc; background-color: transparent; } }
+
+.navbar-default .navbar-link { color: #666; }
+
+.navbar-default .navbar-link:hover { color: #333; }
+
+.navbar-default .btn-link, .navbar-default .btn-secondary { color: #666; }
+
+.navbar-default .btn-link:hover, .navbar-default .btn-secondary:hover, .navbar-default .btn-link:focus, .navbar-default .btn-secondary:focus { color: #333; }
+
+.navbar-default .btn-link[disabled]:hover, .navbar-default [disabled].btn-secondary:hover, .navbar-default .btn-link[disabled]:focus, .navbar-default [disabled].btn-secondary:focus, fieldset[disabled] .navbar-default .btn-link:hover, fieldset[disabled] .navbar-default .btn-secondary:hover, fieldset[disabled] .navbar-default .btn-link:focus, fieldset[disabled] .navbar-default .btn-secondary:focus { color: #ccc; }
+
+.navbar-inverse { background-color: #222; border-color: #090909; }
+
+.navbar-inverse .navbar-brand { color: #999999; }
+
+.navbar-inverse .navbar-brand:hover, .navbar-inverse .navbar-brand:focus { color: #fff; background-color: transparent; }
+
+.navbar-inverse .navbar-text { color: #999999; }
+
+.navbar-inverse .navbar-nav > li > a { color: #999999; }
+
+.navbar-inverse .navbar-nav > li > a:hover, .navbar-inverse .navbar-nav > li > a:focus { color: #fff; background-color: transparent; }
+
+.navbar-inverse .navbar-nav > .active > a, .navbar-inverse .navbar-nav > .active > a:hover, .navbar-inverse .navbar-nav > .active > a:focus { color: #fff; background-color: #090909; }
+
+.navbar-inverse .navbar-nav > .disabled > a, .navbar-inverse .navbar-nav > .disabled > a:hover, .navbar-inverse .navbar-nav > .disabled > a:focus { color: #444; background-color: transparent; }
+
+.navbar-inverse .navbar-toggle { border-color: #333; }
+
+.navbar-inverse .navbar-toggle:hover, .navbar-inverse .navbar-toggle:focus { background-color: #333; }
+
+.navbar-inverse .navbar-toggle .icon-bar { background-color: #fff; }
+
+.navbar-inverse .navbar-collapse, .navbar-inverse .navbar-form { border-color: #101010; }
+
+.navbar-inverse .navbar-nav > .open > a, .navbar-inverse .navbar-nav > .open > a:hover, .navbar-inverse .navbar-nav > .open > a:focus { background-color: #090909; color: #fff; }
+
+@media (max-width: 767px) { .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header { border-color: #090909; }
+  .navbar-inverse .navbar-nav .open .dropdown-menu .divider { background-color: #090909; }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a { color: #999999; }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus { color: #fff; background-color: transparent; }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a, .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus { color: #fff; background-color: #090909; }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a, .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover, .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus { color: #444; background-color: transparent; } }
+
+.navbar-inverse .navbar-link { color: #999999; }
+
+.navbar-inverse .navbar-link:hover { color: #fff; }
+
+.navbar-inverse .btn-link, .navbar-inverse .btn-secondary { color: #999999; }
+
+.navbar-inverse .btn-link:hover, .navbar-inverse .btn-secondary:hover, .navbar-inverse .btn-link:focus, .navbar-inverse .btn-secondary:focus { color: #fff; }
+
+.navbar-inverse .btn-link[disabled]:hover, .navbar-inverse [disabled].btn-secondary:hover, .navbar-inverse .btn-link[disabled]:focus, .navbar-inverse [disabled].btn-secondary:focus, fieldset[disabled] .navbar-inverse .btn-link:hover, fieldset[disabled] .navbar-inverse .btn-secondary:hover, fieldset[disabled] .navbar-inverse .btn-link:focus, fieldset[disabled] .navbar-inverse .btn-secondary:focus { color: #444; }
+
+.breadcrumb { padding: 8px 15px; margin-bottom: 20px; list-style: none; background-color: #f5f5f5; border-radius: 4px; }
+
+.breadcrumb > li { display: inline-block; }
+
+.breadcrumb > li + li:before { content: "/\\00a0"; padding: 0 5px; color: #ccc; }
+
+.breadcrumb > .active { color: #999999; }
+
+.pagination { display: inline-block; padding-left: 0; margin: 20px 0; border-radius: 4px; }
+
+.pagination > li { display: inline; }
+
+.pagination > li > a, .pagination > li > span { position: relative; float: left; padding: 6px 12px; line-height: 1.42857; text-decoration: none; color: #2e88be; background-color: #fff; border: 1px solid #ddd; margin-left: -1px; }
+
+.pagination > li:first-child > a, .pagination > li:first-child > span { margin-left: 0; border-bottom-left-radius: 4px; border-top-left-radius: 4px; }
+
+.pagination > li:last-child > a, .pagination > li:last-child > span { border-bottom-right-radius: 4px; border-top-right-radius: 4px; }
+
+.pagination > li > a:hover, .pagination > li > a:focus, .pagination > li > span:hover, .pagination > li > span:focus { color: #1f5c80; background-color: #eeeeee; border-color: #ddd; }
+
+.pagination > .active > a, .pagination > .active > a:hover, .pagination > .active > a:focus, .pagination > .active > span, .pagination > .active > span:hover, .pagination > .active > span:focus { z-index: 2; color: #fff; background-color: #f1f1f1; border-color: #f1f1f1; cursor: default; }
+
+.pagination > .disabled > span, .pagination > .disabled > span:hover, .pagination > .disabled > span:focus, .pagination > .disabled > a, .pagination > .disabled > a:hover, .pagination > .disabled > a:focus { color: #999999; background-color: #fff; border-color: #ddd; cursor: not-allowed; }
+
+.pagination-lg > li > a, .pagination-lg > li > span { padding: 10px 16px; font-size: 18px; }
+
+.pagination-lg > li:first-child > a, .pagination-lg > li:first-child > span { border-bottom-left-radius: 6px; border-top-left-radius: 6px; }
+
+.pagination-lg > li:last-child > a, .pagination-lg > li:last-child > span { border-bottom-right-radius: 6px; border-top-right-radius: 6px; }
+
+.pagination-sm > li > a, .pagination-sm > li > span { padding: 5px 10px; font-size: 12px; }
+
+.pagination-sm > li:first-child > a, .pagination-sm > li:first-child > span { border-bottom-left-radius: 3px; border-top-left-radius: 3px; }
+
+.pagination-sm > li:last-child > a, .pagination-sm > li:last-child > span { border-bottom-right-radius: 3px; border-top-right-radius: 3px; }
+
+.pager { padding-left: 0; margin: 20px 0; list-style: none; text-align: center; }
+
+.pager:before, .pager:after { content: " "; display: table; }
+
+.pager:after { clear: both; }
+
+.pager li { display: inline; }
+
+.pager li > a, .pager li > span { display: inline-block; padding: 5px 14px; background-color: #fff; border: 1px solid #ddd; border-radius: 15px; }
+
+.pager li > a:hover, .pager li > a:focus { text-decoration: none; background-color: #eeeeee; }
+
+.pager .next > a, .pager .next > span { float: right; }
+
+.pager .previous > a, .pager .previous > span { float: left; }
+
+.pager .disabled > a, .pager .disabled > a:hover, .pager .disabled > a:focus, .pager .disabled > span { color: #999999; background-color: #fff; cursor: not-allowed; }
+
+.label { display: inline; padding: 0.2em 0.6em 0.3em; font-size: 75%; font-weight: bold; line-height: 1; color: #fff; text-align: center; white-space: nowrap; vertical-align: baseline; border-radius: .25em; }
+
+.label:empty { display: none; }
+
+.btn .label, .btn-ghost .label { position: relative; top: -1px; }
+
+a.label:hover, a.label:focus { color: #fff; text-decoration: none; cursor: pointer; }
+
+.label-default { background-color: #999999; }
+
+.label-default[href]:hover, .label-default[href]:focus { background-color: gray; }
+
+.label-primary { background-color: #f1f1f1; }
+
+.label-primary[href]:hover, .label-primary[href]:focus { background-color: #d7d7d7; }
+
+.label-success { background-color: #9bb83a; }
+
+.label-success[href]:hover, .label-success[href]:focus { background-color: #7a912e; }
+
+.label-info { background-color: #389Bc9; }
+
+.label-info[href]:hover, .label-info[href]:focus { background-color: #2c7da2; }
+
+.label-warning { background-color: #e5d321; }
+
+.label-warning[href]:hover, .label-warning[href]:focus { background-color: #bdae16; }
+
+.label-danger { background-color: #e53221; }
+
+.label-danger[href]:hover, .label-danger[href]:focus { background-color: #bd2516; }
+
+.badge { display: inline-block; min-width: 10px; padding: 3px 7px; font-size: 12px; font-weight: bold; color: #fff; line-height: 1; vertical-align: baseline; white-space: nowrap; text-align: center; background-color: #999999; border-radius: 10px; }
+
+.badge:empty { display: none; }
+
+.btn .badge, .btn-ghost .badge { position: relative; top: -1px; }
+
+.btn-xs .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn-ghost .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn-ghost .badge { top: 0; padding: 1px 5px; }
+
+.list-group-item.active > .badge, .nav-pills > .active > a > .badge { color: #2e88be; background-color: #fff; }
+
+.list-group-item > .badge { float: right; }
+
+.list-group-item > .badge + .badge { margin-right: 5px; }
+
+.nav-pills > li > a > .badge { margin-left: 3px; }
+
+a.badge:hover, a.badge:focus { color: #fff; text-decoration: none; cursor: pointer; }
+
+.jumbotron { padding: 30px 15px; margin-bottom: 30px; color: inherit; background-color: #eeeeee; }
+
+.jumbotron h1, .jumbotron .h1 { color: inherit; }
+
+.jumbotron p { margin-bottom: 15px; font-size: 21px; font-weight: 200; }
+
+.jumbotron > hr { border-top-color: #d5d5d5; }
+
+.container .jumbotron, .container-fluid .jumbotron { border-radius: 6px; }
+
+.jumbotron .container { max-width: 100%; }
+
+@media screen and (min-width: 768px) { .jumbotron { padding: 48px 0; }
+  .container .jumbotron, .container-fluid .jumbotron { padding-left: 60px; padding-right: 60px; }
+  .jumbotron h1, .jumbotron .h1 { font-size: 63px; } }
+
+.thumbnail { display: block; padding: 4px; margin-bottom: 20px; line-height: 1.42857; background-color: #fff; border: 1px solid #ddd; border-radius: 4px; -webkit-transition: border 0.2s ease-in-out; -o-transition: border 0.2s ease-in-out; transition: border 0.2s ease-in-out; }
+
+.thumbnail > img, .thumbnail a > img { display: block; max-width: 100%; height: auto; margin-left: auto; margin-right: auto; }
+
+.thumbnail .caption { padding: 9px; color: #666; }
+
+a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active { border-color: #2e88be; }
+
+.alert { padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px; }
+
+.alert h4 { margin-top: 0; color: inherit; }
+
+.alert .alert-link { font-weight: bold; }
+
+.alert > p, .alert > ul { margin-bottom: 0; }
+
+.alert > p + p { margin-top: 5px; }
+
+.alert-dismissable, .alert-dismissible { padding-right: 35px; }
+
+.alert-dismissable .close, .alert-dismissible .close { position: relative; top: -2px; right: -21px; color: inherit; }
+
+.alert-success { background-color: #ebf1d8; border-color: #cddc9d; color: #4e5c1d; }
+
+.alert-success hr { border-top-color: #c3d58a; }
+
+.alert-success .alert-link { color: #2d3511; }
+
+.alert-info { background-color: #d7ebf4; border-color: #9ccde4; color: #1c4e65; }
+
+.alert-info hr { border-top-color: #88c3df; }
+
+.alert-info .alert-link { color: #112f3d; }
+
+.alert-warning { background-color: #faf6d3; border-color: #f2e990; color: #736a11; }
+
+.alert-warning hr { border-top-color: #efe479; }
+
+.alert-warning .alert-link { color: #47410a; }
+
+.alert-danger { background-color: #fad6d3; border-color: #f29990; color: #731911; }
+
+.alert-danger hr { border-top-color: #ef8479; }
+
+.alert-danger .alert-link { color: #470f0a; }
+
+@-webkit-keyframes progress-bar-stripes { from { background-position: 40px 0; }
+  to { background-position: 0 0; } }
+
+@keyframes progress-bar-stripes { from { background-position: 40px 0; }
+  to { background-position: 0 0; } }
+
+.progress { overflow: hidden; height: 20px; margin-bottom: 20px; background-color: #f5f5f5; border-radius: 4px; -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1); }
+
+.progress-bar { float: left; width: 0%; height: 100%; font-size: 12px; line-height: 20px; color: #fff; text-align: center; background-color: #f1f1f1; -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15); box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15); -webkit-transition: width 0.6s ease; -o-transition: width 0.6s ease; transition: width 0.6s ease; }
+
+.progress-striped .progress-bar, .progress-bar-striped { background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-size: 40px 40px; }
+
+.progress.active .progress-bar, .progress-bar.active { -webkit-animation: progress-bar-stripes 2s linear infinite; -o-animation: progress-bar-stripes 2s linear infinite; animation: progress-bar-stripes 2s linear infinite; }
+
+.progress-bar-success { background-color: #9bb83a; }
+
+.progress-striped .progress-bar-success { background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
+
+.progress-bar-info { background-color: #389Bc9; }
+
+.progress-striped .progress-bar-info { background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
+
+.progress-bar-warning { background-color: #e5d321; }
+
+.progress-striped .progress-bar-warning { background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
+
+.progress-bar-danger { background-color: #e53221; }
+
+.progress-striped .progress-bar-danger { background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
+
+.media { margin-top: 15px; }
+
+.media:first-child { margin-top: 0; }
+
+.media, .media-body { zoom: 1; overflow: hidden; }
+
+.media-body { width: 10000px; }
+
+.media-object { display: block; }
+
+.media-right, .media > .pull-right { padding-left: 10px; }
+
+.media-left, .media > .pull-left { padding-right: 10px; }
+
+.media-left, .media-right, .media-body { display: table-cell; vertical-align: top; }
+
+.media-middle { vertical-align: middle; }
+
+.media-bottom { vertical-align: bottom; }
+
+.media-heading { margin-top: 0; margin-bottom: 5px; }
+
+.media-list { padding-left: 0; list-style: none; }
+
+.list-group { margin-bottom: 20px; padding-left: 0; }
+
+.list-group-item { position: relative; display: block; padding: 10px 15px; margin-bottom: -1px; background-color: #fff; border: 1px solid #ddd; }
+
+.list-group-item:first-child { border-top-right-radius: 4px; border-top-left-radius: 4px; }
+
+.list-group-item:last-child { margin-bottom: 0; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; }
+
+a.list-group-item { color: #555; }
+
+a.list-group-item .list-group-item-heading { color: #333; }
+
+a.list-group-item:hover, a.list-group-item:focus { text-decoration: none; color: #555; background-color: #f5f5f5; }
+
+.list-group-item.disabled, .list-group-item.disabled:hover, .list-group-item.disabled:focus { background-color: #eeeeee; color: #999999; cursor: not-allowed; }
+
+.list-group-item.disabled .list-group-item-heading, .list-group-item.disabled:hover .list-group-item-heading, .list-group-item.disabled:focus .list-group-item-heading { color: inherit; }
+
+.list-group-item.disabled .list-group-item-text, .list-group-item.disabled:hover .list-group-item-text, .list-group-item.disabled:focus .list-group-item-text { color: #999999; }
+
+.list-group-item.active, .list-group-item.active:hover, .list-group-item.active:focus { z-index: 2; color: #666; background-color: #f1f1f1; border-color: #f1f1f1; }
+
+.list-group-item.active .list-group-item-heading, .list-group-item.active .list-group-item-heading > small, .list-group-item.active .list-group-item-heading > .small, .list-group-item.active:hover .list-group-item-heading, .list-group-item.active:hover .list-group-item-heading > small, .list-group-item.active:hover .list-group-item-heading > .small, .list-group-item.active:focus .list-group-item-heading, .list-group-item.active:focus .list-group-item-heading > small, .list-group-item.active:focus .list-group-item-heading > .small { color: inherit; }
+
+.list-group-item.active .list-group-item-text, .list-group-item.active:hover .list-group-item-text, .list-group-item.active:focus .list-group-item-text { color: white; }
+
+.list-group-item-success { color: #9bb83a; background-color: #f5f8eb; }
+
+a.list-group-item-success { color: #9bb83a; }
+
+a.list-group-item-success .list-group-item-heading { color: inherit; }
+
+a.list-group-item-success:hover, a.list-group-item-success:focus { color: #9bb83a; background-color: #ecf1d8; }
+
+a.list-group-item-success.active, a.list-group-item-success.active:hover, a.list-group-item-success.active:focus { color: #fff; background-color: #9bb83a; border-color: #9bb83a; }
+
+.list-group-item-info { color: #389Bc9; background-color: #ebf5f9; }
+
+a.list-group-item-info { color: #389Bc9; }
+
+a.list-group-item-info .list-group-item-heading { color: inherit; }
+
+a.list-group-item-info:hover, a.list-group-item-info:focus { color: #389Bc9; background-color: #d7ebf3; }
+
+a.list-group-item-info.active, a.list-group-item-info.active:hover, a.list-group-item-info.active:focus { color: #fff; background-color: #389Bc9; border-color: #389Bc9; }
+
+.list-group-item-warning { color: #e5d321; background-color: #fdfde9; }
+
+a.list-group-item-warning { color: #e5d321; }
+
+a.list-group-item-warning .list-group-item-heading { color: inherit; }
+
+a.list-group-item-warning:hover, a.list-group-item-warning:focus { color: #e5d321; background-color: #fbfbd2; }
+
+a.list-group-item-warning.active, a.list-group-item-warning.active:hover, a.list-group-item-warning.active:focus { color: #fff; background-color: #e5d321; border-color: #e5d321; }
+
+.list-group-item-danger { color: #e53221; background-color: #fceae8; }
+
+a.list-group-item-danger { color: #e53221; }
+
+a.list-group-item-danger .list-group-item-heading { color: inherit; }
+
+a.list-group-item-danger:hover, a.list-group-item-danger:focus { color: #e53221; background-color: #f9d5d1; }
+
+a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-group-item-danger.active:focus { color: #fff; background-color: #e53221; border-color: #e53221; }
+
+.list-group-item-heading { margin-top: 0; margin-bottom: 5px; }
+
+.list-group-item-text { margin-bottom: 0; line-height: 1.3; }
+
+.panel { margin-bottom: 20px; background-color: #fff; border: 1px solid transparent; border-radius: 4px; -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05); box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05); }
+
+.panel-body { padding: 15px; }
+
+.panel-body:before, .panel-body:after { content: " "; display: table; }
+
+.panel-body:after { clear: both; }
+
+.panel-heading { padding: 10px 15px; border-bottom: 1px solid transparent; border-top-right-radius: 3px; border-top-left-radius: 3px; }
+
+.panel-heading > .dropdown .dropdown-toggle { color: inherit; }
+
+.panel-title { margin-top: 0; margin-bottom: 0; font-size: 16px; color: inherit; }
+
+.panel-title > a, .panel-title > small, .panel-title > .small, .panel-title > small > a, .panel-title > .small > a { color: inherit; }
+
+.panel-footer { padding: 10px 15px; background-color: #f5f5f5; border-top: 1px solid #ddd; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; }
+
+.panel > .list-group, .panel > .panel-collapse > .list-group { margin-bottom: 0; }
+
+.panel > .list-group .list-group-item, .panel > .panel-collapse > .list-group .list-group-item { border-width: 1px 0; border-radius: 0; }
+
+.panel > .list-group:first-child .list-group-item:first-child, .panel > .panel-collapse > .list-group:first-child .list-group-item:first-child { border-top: 0; border-top-right-radius: 3px; border-top-left-radius: 3px; }
+
+.panel > .list-group:last-child .list-group-item:last-child, .panel > .panel-collapse > .list-group:last-child .list-group-item:last-child { border-bottom: 0; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; }
+
+.panel-heading + .list-group .list-group-item:first-child { border-top-width: 0; }
+
+.list-group + .panel-footer { border-top-width: 0; }
+
+.panel > .table, .panel > .table-responsive > .table, .panel > .panel-collapse > .table { margin-bottom: 0; }
+
+.panel > .table caption, .panel > .table-responsive > .table caption, .panel > .panel-collapse > .table caption { padding-left: 15px; padding-right: 15px; }
+
+.panel > .table:first-child, .panel > .table-responsive:first-child > .table:first-child { border-top-right-radius: 3px; border-top-left-radius: 3px; }
+
+.panel > .table:first-child > thead:first-child > tr:first-child, .panel > .table:first-child > tbody:first-child > tr:first-child, .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child, .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child { border-top-left-radius: 3px; border-top-right-radius: 3px; }
+
+.panel > .table:first-child > thead:first-child > tr:first-child td:first-child, .panel > .table:first-child > thead:first-child > tr:first-child th:first-child, .panel > .table:first-child > tbody:first-child > tr:first-child td:first-child, .panel > .table:first-child > tbody:first-child > tr:first-child th:first-child, .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:first-child, .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:first-child, .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:first-child, .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child { border-top-left-radius: 3px; }
+
+.panel > .table:first-child > thead:first-child > tr:first-child td:last-child, .panel > .table:first-child > thead:first-child > tr:first-child th:last-child, .panel > .table:first-child > tbody:first-child > tr:first-child td:last-child, .panel > .table:first-child > tbody:first-child > tr:first-child th:last-child, .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:last-child, .panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:last-child, .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:last-child, .panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child { border-top-right-radius: 3px; }
+
+.panel > .table:last-child, .panel > .table-responsive:last-child > .table:last-child { border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; }
+
+.panel > .table:last-child > tbody:last-child > tr:last-child, .panel > .table:last-child > tfoot:last-child > tr:last-child, .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child, .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child { border-bottom-left-radius: 3px; border-bottom-right-radius: 3px; }
+
+.panel > .table:last-child > tbody:last-child > tr:last-child td:first-child, .panel > .table:last-child > tbody:last-child > tr:last-child th:first-child, .panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child, .panel > .table:last-child > tfoot:last-child > tr:last-child th:first-child, .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:first-child, .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:first-child, .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:first-child, .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child { border-bottom-left-radius: 3px; }
+
+.panel > .table:last-child > tbody:last-child > tr:last-child td:last-child, .panel > .table:last-child > tbody:last-child > tr:last-child th:last-child, .panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child, .panel > .table:last-child > tfoot:last-child > tr:last-child th:last-child, .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:last-child, .panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:last-child, .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:last-child, .panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child { border-bottom-right-radius: 3px; }
+
+.panel > .panel-body + .table, .panel > .panel-body + .table-responsive, .panel > .table + .panel-body, .panel > .table-responsive + .panel-body { border-top: 1px solid #ddd; }
+
+.panel > .table > tbody:first-child > tr:first-child th, .panel > .table > tbody:first-child > tr:first-child td { border-top: 0; }
+
+.panel > .table-bordered, .panel > .table-responsive > .table-bordered { border: 0; }
+
+.panel > .table-bordered > thead > tr > th:first-child, .panel > .table-bordered > thead > tr > td:first-child, .panel > .table-bordered > tbody > tr > th:first-child, .panel > .table-bordered > tbody > tr > td:first-child, .panel > .table-bordered > tfoot > tr > th:first-child, .panel > .table-bordered > tfoot > tr > td:first-child, .panel > .table-responsive > .table-bordered > thead > tr > th:first-child, .panel > .table-responsive > .table-bordered > thead > tr > td:first-child, .panel > .table-responsive > .table-bordered > tbody > tr > th:first-child, .panel > .table-responsive > .table-bordered > tbody > tr > td:first-child, .panel > .table-responsive > .table-bordered > tfoot > tr > th:first-child, .panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child { border-left: 0; }
+
+.panel > .table-bordered > thead > tr > th:last-child, .panel > .table-bordered > thead > tr > td:last-child, .panel > .table-bordered > tbody > tr > th:last-child, .panel > .table-bordered > tbody > tr > td:last-child, .panel > .table-bordered > tfoot > tr > th:last-child, .panel > .table-bordered > tfoot > tr > td:last-child, .panel > .table-responsive > .table-bordered > thead > tr > th:last-child, .panel > .table-responsive > .table-bordered > thead > tr > td:last-child, .panel > .table-responsive > .table-bordered > tbody > tr > th:last-child, .panel > .table-responsive > .table-bordered > tbody > tr > td:last-child, .panel > .table-responsive > .table-bordered > tfoot > tr > th:last-child, .panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child { border-right: 0; }
+
+.panel > .table-bordered > thead > tr:first-child > td, .panel > .table-bordered > thead > tr:first-child > th, .panel > .table-bordered > tbody > tr:first-child > td, .panel > .table-bordered > tbody > tr:first-child > th, .panel > .table-responsive > .table-bordered > thead > tr:first-child > td, .panel > .table-responsive > .table-bordered > thead > tr:first-child > th, .panel > .table-responsive > .table-bordered > tbody > tr:first-child > td, .panel > .table-responsive > .table-bordered > tbody > tr:first-child > th { border-bottom: 0; }
+
+.panel > .table-bordered > tbody > tr:last-child > td, .panel > .table-bordered > tbody > tr:last-child > th, .panel > .table-bordered > tfoot > tr:last-child > td, .panel > .table-bordered > tfoot > tr:last-child > th, .panel > .table-responsive > .table-bordered > tbody > tr:last-child > td, .panel > .table-responsive > .table-bordered > tbody > tr:last-child > th, .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > td, .panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th { border-bottom: 0; }
+
+.panel > .table-responsive { border: 0; margin-bottom: 0; }
+
+.panel-group { margin-bottom: 20px; }
+
+.panel-group .panel { margin-bottom: 0; border-radius: 4px; }
+
+.panel-group .panel + .panel { margin-top: 5px; }
+
+.panel-group .panel-heading { border-bottom: 0; }
+
+.panel-group .panel-heading + .panel-collapse > .panel-body, .panel-group .panel-heading + .panel-collapse > .list-group { border-top: 1px solid #ddd; }
+
+.panel-group .panel-footer { border-top: 0; }
+
+.panel-group .panel-footer + .panel-collapse .panel-body { border-bottom: 1px solid #ddd; }
+
+.panel-default { border-color: #ddd; }
+
+.panel-default > .panel-heading { color: #333333; background-color: #f5f5f5; border-color: #ddd; }
+
+.panel-default > .panel-heading + .panel-collapse > .panel-body { border-top-color: #ddd; }
+
+.panel-default > .panel-heading .badge { color: #f5f5f5; background-color: #333333; }
+
+.panel-default > .panel-footer + .panel-collapse > .panel-body { border-bottom-color: #ddd; }
+
+.panel-primary { border-color: #f1f1f1; }
+
+.panel-primary > .panel-heading { color: #fff; background-color: #f1f1f1; border-color: #f1f1f1; }
+
+.panel-primary > .panel-heading + .panel-collapse > .panel-body { border-top-color: #f1f1f1; }
+
+.panel-primary > .panel-heading .badge { color: #f1f1f1; background-color: #fff; }
+
+.panel-primary > .panel-footer + .panel-collapse > .panel-body { border-bottom-color: #f1f1f1; }
+
+.panel-success { border-color: #f5f8eb; }
+
+.panel-success > .panel-heading { color: #9bb83a; background-color: #f5f8eb; border-color: #f5f8eb; }
+
+.panel-success > .panel-heading + .panel-collapse > .panel-body { border-top-color: #f5f8eb; }
+
+.panel-success > .panel-heading .badge { color: #f5f8eb; background-color: #9bb83a; }
+
+.panel-success > .panel-footer + .panel-collapse > .panel-body { border-bottom-color: #f5f8eb; }
+
+.panel-info { border-color: #ebf5f9; }
+
+.panel-info > .panel-heading { color: #389Bc9; background-color: #ebf5f9; border-color: #ebf5f9; }
+
+.panel-info > .panel-heading + .panel-collapse > .panel-body { border-top-color: #ebf5f9; }
+
+.panel-info > .panel-heading .badge { color: #ebf5f9; background-color: #389Bc9; }
+
+.panel-info > .panel-footer + .panel-collapse > .panel-body { border-bottom-color: #ebf5f9; }
+
+.panel-warning { border-color: #fdfde9; }
+
+.panel-warning > .panel-heading { color: #e5d321; background-color: #fdfde9; border-color: #fdfde9; }
+
+.panel-warning > .panel-heading + .panel-collapse > .panel-body { border-top-color: #fdfde9; }
+
+.panel-warning > .panel-heading .badge { color: #fdfde9; background-color: #e5d321; }
+
+.panel-warning > .panel-footer + .panel-collapse > .panel-body { border-bottom-color: #fdfde9; }
+
+.panel-danger { border-color: #fceae8; }
+
+.panel-danger > .panel-heading { color: #e53221; background-color: #fceae8; border-color: #fceae8; }
+
+.panel-danger > .panel-heading + .panel-collapse > .panel-body { border-top-color: #fceae8; }
+
+.panel-danger > .panel-heading .badge { color: #fceae8; background-color: #e53221; }
+
+.panel-danger > .panel-footer + .panel-collapse > .panel-body { border-bottom-color: #fceae8; }
+
+.embed-responsive { position: relative; display: block; height: 0; padding: 0; overflow: hidden; }
+
+.embed-responsive .embed-responsive-item, .embed-responsive iframe, .embed-responsive embed, .embed-responsive object, .embed-responsive video { position: absolute; top: 0; left: 0; bottom: 0; height: 100%; width: 100%; border: 0; }
+
+.embed-responsive-16by9 { padding-bottom: 56.25%; }
+
+.embed-responsive-4by3 { padding-bottom: 75%; }
+
+.well { min-height: 20px; padding: 19px; margin-bottom: 20px; background-color: #f5f5f5; border: 1px solid #e3e3e3; border-radius: 4px; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); }
+
+.well blockquote { border-color: #ddd; border-color: rgba(0, 0, 0, 0.15); }
+
+.well-lg { padding: 24px; border-radius: 6px; }
+
+.well-sm { padding: 9px; border-radius: 3px; }
+
+.close { float: right; font-size: 21px; font-weight: bold; line-height: 1; color: #000; text-shadow: 0 1px 0 #fff; opacity: 0.2; filter: alpha(opacity=20); }
+
+.close:hover, .close:focus { color: #000; text-decoration: none; cursor: pointer; opacity: 0.5; filter: alpha(opacity=50); }
+
+button.close { padding: 0; cursor: pointer; background: transparent; border: 0; -webkit-appearance: none; }
+
+.modal-open { overflow: hidden; }
+
+.modal { display: none; overflow: hidden; position: fixed; top: 0; right: 0; bottom: 0; left: 0; z-index: 1050; -webkit-overflow-scrolling: touch; outline: 0; }
+
+.modal.fade .modal-dialog { -webkit-transform: translate(0, -25%); -ms-transform: translate(0, -25%); -o-transform: translate(0, -25%); transform: translate(0, -25%); -webkit-transition: -webkit-transform 0.3s ease-out; -moz-transition: -moz-transform 0.3s ease-out; -o-transition: -o-transform 0.3s ease-out; transition: transform 0.3s ease-out; }
+
+.modal.in .modal-dialog { -webkit-transform: translate(0, 0); -ms-transform: translate(0, 0); -o-transform: translate(0, 0); transform: translate(0, 0); }
+
+.modal-open .modal { overflow-x: hidden; overflow-y: auto; }
+
+.modal-dialog { position: relative; width: auto; margin: 10px; }
+
+.modal-content { position: relative; background-color: #fff; border: 1px solid #999; border: 1px solid #bbb; border-radius: 6px; -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5); box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5); background-clip: padding-box; outline: 0; }
+
+.modal-backdrop { position: fixed; top: 0; right: 0; bottom: 0; left: 0; z-index: 1040; background-color: #000; }
+
+.modal-backdrop.fade { opacity: 0; filter: alpha(opacity=0); }
+
+.modal-backdrop.in { opacity: 0.5; filter: alpha(opacity=50); }
+
+.modal-header { padding: 15px; border-bottom: 1px solid #ddd; min-height: 16.42857px; }
+
+.modal-header .close { margin-top: -2px; }
+
+.modal-title { margin: 0; line-height: 1.42857; }
+
+.modal-body { position: relative; padding: 15px; }
+
+.modal-footer { padding: 15px; text-align: right; border-top: 1px solid #ddd; }
+
+.modal-footer:before, .modal-footer:after { content: " "; display: table; }
+
+.modal-footer:after { clear: both; }
+
+.modal-footer .btn + .btn, .modal-footer .btn-ghost + .btn, .modal-footer .btn + .btn-ghost, .modal-footer .btn-ghost + .btn-ghost { margin-left: 5px; margin-bottom: 0; }
+
+.modal-footer .btn-group .btn + .btn, .modal-footer .btn-group .btn-ghost + .btn, .modal-footer .btn-group .btn + .btn-ghost, .modal-footer .btn-group .btn-ghost + .btn-ghost { margin-left: -1px; }
+
+.modal-footer .btn-block + .btn-block { margin-left: 0; }
+
+.modal-scrollbar-measure { position: absolute; top: -9999px; width: 50px; height: 50px; overflow: scroll; }
+
+@media (min-width: 768px) { .modal-dialog { width: 600px; margin: 30px auto; }
+  .modal-content { -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
+  .modal-sm { width: 300px; } }
+
+@media (min-width: 992px) { .modal-lg { width: 900px; } }
+
+.tooltip { position: absolute; z-index: 1070; display: block; font-family: "Source Sans Pro", Arial, sans-serif; font-size: 12px; font-weight: normal; line-height: 1.4; opacity: 0; filter: alpha(opacity=0); }
+
+.tooltip.in { opacity: 0.9; filter: alpha(opacity=90); }
+
+.tooltip.top { margin-top: -3px; padding: 5px 0; }
+
+.tooltip.right { margin-left: 3px; padding: 0 5px; }
+
+.tooltip.bottom { margin-top: 3px; padding: 5px 0; }
+
+.tooltip.left { margin-left: -3px; padding: 0 5px; }
+
+.tooltip-inner { max-width: 200px; padding: 3px 8px; color: #fff; text-align: center; text-decoration: none; background-color: #000; border-radius: 4px; }
+
+.tooltip-arrow { position: absolute; width: 0; height: 0; border-color: transparent; border-style: solid; }
+
+.tooltip.top .tooltip-arrow { bottom: 0; left: 50%; margin-left: -5px; border-width: 5px 5px 0; border-top-color: #000; }
+
+.tooltip.top-left .tooltip-arrow { bottom: 0; right: 5px; margin-bottom: -5px; border-width: 5px 5px 0; border-top-color: #000; }
+
+.tooltip.top-right .tooltip-arrow { bottom: 0; left: 5px; margin-bottom: -5px; border-width: 5px 5px 0; border-top-color: #000; }
+
+.tooltip.right .tooltip-arrow { top: 50%; left: 0; margin-top: -5px; border-width: 5px 5px 5px 0; border-right-color: #000; }
+
+.tooltip.left .tooltip-arrow { top: 50%; right: 0; margin-top: -5px; border-width: 5px 0 5px 5px; border-left-color: #000; }
+
+.tooltip.bottom .tooltip-arrow { top: 0; left: 50%; margin-left: -5px; border-width: 0 5px 5px; border-bottom-color: #000; }
+
+.tooltip.bottom-left .tooltip-arrow { top: 0; right: 5px; margin-top: -5px; border-width: 0 5px 5px; border-bottom-color: #000; }
+
+.tooltip.bottom-right .tooltip-arrow { top: 0; left: 5px; margin-top: -5px; border-width: 0 5px 5px; border-bottom-color: #000; }
+
+.popover { position: absolute; top: 0; left: 0; z-index: 1060; display: none; max-width: 276px; padding: 1px; font-family: "Source Sans Pro", Arial, sans-serif; font-size: 14px; font-weight: normal; line-height: 1.42857; text-align: left; background-color: #fff; background-clip: padding-box; border: 1px solid #ccc; border: 1px solid rgba(0, 0, 0, 0.2); border-radius: 6px; -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2); box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2); white-space: normal; }
+
+.popover.top { margin-top: -10px; }
+
+.popover.right { margin-left: 10px; }
+
+.popover.bottom { margin-top: 10px; }
+
+.popover.left { margin-left: -10px; }
+
+.popover-title { margin: 0; padding: 8px 14px; font-size: 14px; background-color: #f7f7f7; border-bottom: 1px solid #ebebeb; border-radius: 5px 5px 0 0; }
+
+.popover-content { padding: 9px 14px; }
+
+.popover > .arrow, .popover > .arrow:after { position: absolute; display: block; width: 0; height: 0; border-color: transparent; border-style: solid; }
+
+.popover > .arrow { border-width: 11px; }
+
+.popover > .arrow:after { border-width: 10px; content: ""; }
+
+.popover.top > .arrow { left: 50%; margin-left: -11px; border-bottom-width: 0; border-top-color: #999999; border-top-color: rgba(0, 0, 0, 0.05); bottom: -11px; }
+
+.popover.top > .arrow:after { content: " "; bottom: 1px; margin-left: -10px; border-bottom-width: 0; border-top-color: #fff; }
+
+.popover.right > .arrow { top: 50%; left: -11px; margin-top: -11px; border-left-width: 0; border-right-color: #999999; border-right-color: rgba(0, 0, 0, 0.05); }
+
+.popover.right > .arrow:after { content: " "; left: 1px; bottom: -10px; border-left-width: 0; border-right-color: #fff; }
+
+.popover.bottom > .arrow { left: 50%; margin-left: -11px; border-top-width: 0; border-bottom-color: #999999; border-bottom-color: rgba(0, 0, 0, 0.05); top: -11px; }
+
+.popover.bottom > .arrow:after { content: " "; top: 1px; margin-left: -10px; border-top-width: 0; border-bottom-color: #fff; }
+
+.popover.left > .arrow { top: 50%; right: -11px; margin-top: -11px; border-right-width: 0; border-left-color: #999999; border-left-color: rgba(0, 0, 0, 0.05); }
+
+.popover.left > .arrow:after { content: " "; right: 1px; border-right-width: 0; border-left-color: #fff; bottom: -10px; }
+
+.carousel { position: relative; }
+
+.carousel-inner { position: relative; overflow: hidden; width: 100%; }
+
+.carousel-inner > .item { display: none; position: relative; -webkit-transition: 0.6s ease-in-out left; -o-transition: 0.6s ease-in-out left; transition: 0.6s ease-in-out left; }
+
+.carousel-inner > .item > img, .carousel-inner > .item > a > img { display: block; max-width: 100%; height: auto; line-height: 1; }
+
+@media all and (transform-3d), (-webkit-transform-3d) { .carousel-inner > .item { -webkit-transition: -webkit-transform 0.6s ease-in-out; -moz-transition: -moz-transform 0.6s ease-in-out; -o-transition: -o-transform 0.6s ease-in-out; transition: transform 0.6s ease-in-out; -webkit-backface-visibility: hidden; -moz-backface-visibility: hidden; backface-visibility: hidden; -webkit-perspective: 1000; -moz-perspective: 1000; perspective: 1000; }
+  .carousel-inner > .item.next, .carousel-inner > .item.active.right { -webkit-transform: translate3d(100%, 0, 0); transform: translate3d(100%, 0, 0); left: 0; }
+  .carousel-inner > .item.prev, .carousel-inner > .item.active.left { -webkit-transform: translate3d(-100%, 0, 0); transform: translate3d(-100%, 0, 0); left: 0; }
+  .carousel-inner > .item.next.left, .carousel-inner > .item.prev.right, .carousel-inner > .item.active { -webkit-transform: translate3d(0, 0, 0); transform: translate3d(0, 0, 0); left: 0; } }
+
+.carousel-inner > .active, .carousel-inner > .next, .carousel-inner > .prev { display: block; }
+
+.carousel-inner > .active { left: 0; }
+
+.carousel-inner > .next, .carousel-inner > .prev { position: absolute; top: 0; width: 100%; }
+
+.carousel-inner > .next { left: 100%; }
+
+.carousel-inner > .prev { left: -100%; }
+
+.carousel-inner > .next.left, .carousel-inner > .prev.right { left: 0; }
+
+.carousel-inner > .active.left { left: -100%; }
+
+.carousel-inner > .active.right { left: 100%; }
+
+.carousel-control { position: absolute; top: 0; left: 0; bottom: 0; width: 15%; opacity: 0.5; filter: alpha(opacity=50); font-size: 20px; color: #fff; text-align: center; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
+
+.carousel-control.left { background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%); background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%); background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%); background-repeat: repeat-x; filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1); }
+
+.carousel-control.right { left: auto; right: 0; background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%); background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%); background-image: linear-gradient(to right, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%); background-repeat: repeat-x; filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1); }
+
+.carousel-control:hover, .carousel-control:focus { outline: 0; color: #fff; text-decoration: none; opacity: 0.9; filter: alpha(opacity=90); }
+
+.carousel-control .icon-prev, .carousel-control .icon-next, .carousel-control .glyphicon-chevron-left, .carousel-control .glyphicon-chevron-right { position: absolute; top: 50%; z-index: 5; display: inline-block; }
+
+.carousel-control .icon-prev, .carousel-control .glyphicon-chevron-left { left: 50%; margin-left: -10px; }
+
+.carousel-control .icon-next, .carousel-control .glyphicon-chevron-right { right: 50%; margin-right: -10px; }
+
+.carousel-control .icon-prev, .carousel-control .icon-next { width: 20px; height: 20px; margin-top: -10px; line-height: 1; font-family: serif; }
+
+.carousel-control .icon-prev:before { content: '\2039'; }
+
+.carousel-control .icon-next:before { content: '\203a'; }
+
+.carousel-indicators { position: absolute; bottom: 10px; left: 50%; z-index: 15; width: 60%; margin-left: -30%; padding-left: 0; list-style: none; text-align: center; }
+
+.carousel-indicators li { display: inline-block; width: 10px; height: 10px; margin: 1px; text-indent: -999px; border: 1px solid #fff; border-radius: 10px; cursor: pointer; background-color: #000 \9; background-color: transparent; }
+
+.carousel-indicators .active { margin: 0; width: 12px; height: 12px; background-color: #fff; }
+
+.carousel-caption { position: absolute; left: 15%; right: 15%; bottom: 20px; z-index: 10; padding-top: 20px; padding-bottom: 20px; color: #fff; text-align: center; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
+
+.carousel-caption .btn, .carousel-caption .btn-ghost { text-shadow: none; }
+
+@media screen and (min-width: 768px) { .carousel-control .glyphicon-chevron-left, .carousel-control .glyphicon-chevron-right, .carousel-control .icon-prev, .carousel-control .icon-next { width: 30px; height: 30px; margin-top: -15px; font-size: 30px; }
+  .carousel-control .glyphicon-chevron-left, .carousel-control .icon-prev { margin-left: -15px; }
+  .carousel-control .glyphicon-chevron-right, .carousel-control .icon-next { margin-right: -15px; }
+  .carousel-caption { left: 20%; right: 20%; padding-bottom: 30px; }
+  .carousel-indicators { bottom: 20px; } }
+
+.clearfix:before, .clearfix:after { content: " "; display: table; }
+
+.clearfix:after { clear: both; }
+
+.center-block { display: block; margin-left: auto; margin-right: auto; }
+
+.pull-right { float: right !important; }
+
+.pull-left { float: left !important; }
+
+.hide { display: none !important; }
+
+.show { display: block !important; }
+
+.invisible { visibility: hidden; }
+
+.text-hide { font: 0/0 a; color: transparent; text-shadow: none; background-color: transparent; border: 0; }
+
+.hidden { display: none !important; }
+
+.affix { position: fixed; }
+
+@-ms-viewport { width: device-width; }
+
+.visible-xs { display: none !important; }
+
+.visible-sm { display: none !important; }
+
+.visible-md { display: none !important; }
+
+.visible-lg { display: none !important; }
+
+.visible-xs-block, .visible-xs-inline, .visible-xs-inline-block, .visible-sm-block, .visible-sm-inline, .visible-sm-inline-block, .visible-md-block, .visible-md-inline, .visible-md-inline-block, .visible-lg-block, .visible-lg-inline, .visible-lg-inline-block { display: none !important; }
+
+@media (max-width: 767px) { .visible-xs { display: block !important; }
+  table.visible-xs { display: table; }
+  tr.visible-xs { display: table-row !important; }
+  th.visible-xs, td.visible-xs { display: table-cell !important; } }
+
+@media (max-width: 767px) { .visible-xs-block { display: block !important; } }
+
+@media (max-width: 767px) { .visible-xs-inline { display: inline !important; } }
+
+@media (max-width: 767px) { .visible-xs-inline-block { display: inline-block !important; } }
+
+@media (min-width: 768px) and (max-width: 991px) { .visible-sm { display: block !important; }
+  table.visible-sm { display: table; }
+  tr.visible-sm { display: table-row !important; }
+  th.visible-sm, td.visible-sm { display: table-cell !important; } }
+
+@media (min-width: 768px) and (max-width: 991px) { .visible-sm-block { display: block !important; } }
+
+@media (min-width: 768px) and (max-width: 991px) { .visible-sm-inline { display: inline !important; } }
+
+@media (min-width: 768px) and (max-width: 991px) { .visible-sm-inline-block { display: inline-block !important; } }
+
+@media (min-width: 992px) and (max-width: 1199px) { .visible-md { display: block !important; }
+  table.visible-md { display: table; }
+  tr.visible-md { display: table-row !important; }
+  th.visible-md, td.visible-md { display: table-cell !important; } }
+
+@media (min-width: 992px) and (max-width: 1199px) { .visible-md-block { display: block !important; } }
+
+@media (min-width: 992px) and (max-width: 1199px) { .visible-md-inline { display: inline !important; } }
+
+@media (min-width: 992px) and (max-width: 1199px) { .visible-md-inline-block { display: inline-block !important; } }
+
+@media (min-width: 1200px) { .visible-lg { display: block !important; }
+  table.visible-lg { display: table; }
+  tr.visible-lg { display: table-row !important; }
+  th.visible-lg, td.visible-lg { display: table-cell !important; } }
+
+@media (min-width: 1200px) { .visible-lg-block { display: block !important; } }
+
+@media (min-width: 1200px) { .visible-lg-inline { display: inline !important; } }
+
+@media (min-width: 1200px) { .visible-lg-inline-block { display: inline-block !important; } }
+
+@media (max-width: 767px) { .hidden-xs { display: none !important; } }
+
+@media (min-width: 768px) and (max-width: 991px) { .hidden-sm { display: none !important; } }
+
+@media (min-width: 992px) and (max-width: 1199px) { .hidden-md { display: none !important; } }
+
+@media (min-width: 1200px) { .hidden-lg { display: none !important; } }
+
+.visible-print { display: none !important; }
+
+@media print { .visible-print { display: block !important; }
+  table.visible-print { display: table; }
+  tr.visible-print { display: table-row !important; }
+  th.visible-print, td.visible-print { display: table-cell !important; } }
+
+.visible-print-block { display: none !important; }
+
+@media print { .visible-print-block { display: block !important; } }
+
+.visible-print-inline { display: none !important; }
+
+@media print { .visible-print-inline { display: inline !important; } }
+
+.visible-print-inline-block { display: none !important; }
+
+@media print { .visible-print-inline-block { display: inline-block !important; } }
+
+@media print { .hidden-print { display: none !important; } }
+
+/*doc --- title: Units extended name: units_extended category: Variables --- Those are the units that you can use <div class="clearfix"> <div class="variable-box"> <span>$base-unit = $base-unit // 14px</span> </div> <div class="variable-box"> <span>$base-unit-x2 = $base-unit-x2</span> </div> <div class="variable-box"> <span>$base-unit-x3 = $base-unit-x3</span> </div> <div class="variable-box"> <span>$space = 10px</span> </div> <div class="variable-box"> <span>$space-small = $space / 2</span> </div> <div class="variable-box"> <span>$space-large = $space * 2</span> </div> <div class="variable-box"> <span>$space-larger = $space * 4</span> </div> <div class="variable-box"> <span>$font-size-larger = 38px</span> </div> </div> */
+/*doc --- title: Colors extended name: colors_extended category: Variables --- Those are the colors that you can use <div class="clearfix"> <div class="color-box gray-lighten"> <span>$gray-lighten</span> </div> <div class="color-box gray-lightest"> <span>$gray-lightest</span> </div> <div class="color-box white"> <span>$white</span> </div> <div class="color-box brand-primary-custom"> <span>$brand-primary-custom</span> </div> <div class="color-box blue-light"> <span>$blue-light</span> </div> </div> */
+body { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+
+body #sb-site a[name] { content: ""; display: block; height: 76px; margin-top: -76px; }
+
+/*doc --- title: Units extended name: units_extended category: Variables --- Those are the units that you can use <div class="clearfix"> <div class="variable-box"> <span>$base-unit = $base-unit // 14px</span> </div> <div class="variable-box"> <span>$base-unit-x2 = $base-unit-x2</span> </div> <div class="variable-box"> <span>$base-unit-x3 = $base-unit-x3</span> </div> <div class="variable-box"> <span>$space = 10px</span> </div> <div class="variable-box"> <span>$space-small = $space / 2</span> </div> <div class="variable-box"> <span>$space-large = $space * 2</span> </div> <div class="variable-box"> <span>$space-larger = $space * 4</span> </div> <div class="variable-box"> <span>$font-size-larger = 38px</span> </div> </div> */
+/*doc --- title: Colors extended name: colors_extended category: Variables --- Those are the colors that you can use <div class="clearfix"> <div class="color-box gray-lighten"> <span>$gray-lighten</span> </div> <div class="color-box gray-lightest"> <span>$gray-lightest</span> </div> <div class="color-box white"> <span>$white</span> </div> <div class="color-box brand-primary-custom"> <span>$brand-primary-custom</span> </div> <div class="color-box blue-light"> <span>$blue-light</span> </div> </div> */
+/*doc --- title: Colors name: colors category: Variables --- Those are the colors that you can use <div class="clearfix"> <div class="color-box gray-darker"> <span>$gray-darker</span> </div> <div class="color-box gray-dark"> <span>$gray-dark</span> </div> <div class="color-box gray"> <span>$gray</span> </div> <div class="color-box gray-light"> <span>$gray-light</span> </div> <div class="color-box gray-lighter"> <span>$gray-lighter</span> </div> <div class="color-box brand-primary"> <span>$brand-primary</span> </div> <div class="color-box brand-success"> <span>$brand-success</span> </div> <div class="color-box brand-info"> <span>$brand-info</span> </div> <div class="color-box brand-warning"> <span>$brand-warning</span> </div> <div class="color-box brand-danger"> <span>$brand-danger</span> </div> </div> */
+.table tbody > tr > td.vert-align { vertical-align: middle; }
+
+@media screen and (min-width: 768px) { .text-left-sm { text-align: left; } }
+
+@media screen and (min-width: 992px) { .text-left-md { text-align: left; } }
+
+@media screen and (min-width: 1200px) { .text-left-lg { text-align: left; } }
+
+/*doc --- title: Buttons name: Buttons category: CSS --- ```html_example_table <p><button class="btn btn-default btn-lg">Large</button></p> <p><button class="btn btn-default">Normal</button></p> <p><button class="btn btn-default btn-sm">Small</button></p> <p><button class="btn btn-default btn-xs">Extra Small</button></p> <p><button class="btn btn-default">Default</button></p> <p><button class="btn btn-primary">Primary</button></p> <p><button class="btn btn-primary-alt">Primary Alt</button></p> <p><button class="btn btn-danger">Danger</button></p> <p><button class="btn btn-secondary">Secondary</button></p> <p><button class="btn-ghost btn-default">Default Ghost</button></p> <p><button class="btn-ghost btn-primary">Primary Ghost</button></p> <p><button class="btn-ghost btn-primary-alt">Primary Alt Ghost</button></p> <p><button class="btn-ghost btn-danger">Danger Ghost</button></p> ``` */
+.btn-default:hover { background-color: #f9fafb; color: #999999; }
+
+.btn-primary:hover { background: #89a334; }
+
+.btn-secondary { color: #666; }
+
+.btn-secondary:hover { color: #333333; text-decoration: none; }
+
+.btn-ghost { background-color: transparent; }
+
+.btn-ghost.btn-default { border-color: #999999; color: #999999; }
+
+.btn-ghost.btn-default:hover { color: #fff; background-color: #999999; }
+
+.btn-ghost.btn-primary { border-color: #9bb83a; color: #9bb83a; }
+
+.btn-ghost.btn-primary:hover { color: #fff; }
+
+.btn-ghost.btn-primary-alt { border-color: #e53221; color: #e53221; }
+
+.btn-ghost.btn-primary-alt:hover { color: #fff; }
+
+.btn-ghost.btn-danger, .btn-ghost.btn-primary-alt { border-color: #e53221; color: #e53221; }
+
+.btn-ghost.btn-danger:hover, .btn-ghost.btn-primary-alt:hover { color: #fff; }
 
 /*doc
 //---
@@ -6321,165 +2677,40 @@ category: CSS
 //category: CSS
 //---
 */
-/*doc
----
-title: Forms
-name: forms
-category: CSS
----
+/*doc --- title: Forms name: forms category: CSS --- ```html_example_table <h2>Panel form</h2> <form> <div class="panel panel-default"> <div class="panel-heading">Form heading</div> <div class="panel-body"> <div class="form-group"> <label for="to">To</label> <input type="email" class="form-control" id="to" placeholder="Enter email"> </div> <div class="form-group has-success"> <label for="to">To (.has-success)</label> <input type="email" class="form-control" id="to" placeholder="Enter email"> <p class="help-block">Example block-level help text here.</p> </div> <div class="form-group has-warning"> <label for="to">To (.has-warning)</label> <input type="email" class="form-control" id="to" placeholder="Enter email"> <p class="help-block">Example block-level help text here.</p> </div> <div class="form-group has-error"> <label for="to">To (.has-error)</label> <input type="email" class="form-control" id="to" placeholder="Enter email"> <p class="help-block">Example block-level help text here.</p> </div> <div class="form-group"> <label for="subject">Subject</label> <input type="text" class="form-control" id="subject" placeholder="Enter subject"> </div> <div class="form-group"> <label for="message">Message</label> <textarea class="form-control" id="subject" placeholder="Enter message"></textarea> </div> <div class="form-group"> <div class="checkbox"> <label> <input type="checkbox" name="samecheck"> Check me out </label> <br> <label> <input type="checkbox" name="samecheck"> Check me out again </label> </div> </div> <div class="form-group"> <div class="radio"> <label> <input type="radio" name="sameradio"> Check me out </label> <br> <label> <input type="radio" name="sameradio"> Check me out again </label> </div> </div> <div class="form-group"> <select class="form-control"> <option>option 1</option> <option>option 2</option> <option>option 3</option> <option>option 4</option> </select> </div> </div> </div> <div class="form-group text-right form-actions"> <button type="reset" class="btn btn-secondary">Cancel</button> <button type="submit" class="btn btn-default">Submit</button> </div> </form> <h2>Inline form</h2> <form class="form-inline"> <div class="form-group"> <label for="exampleInputName2">Name</label> <input type="text" class="form-control" id="exampleInputName2" placeholder="Jane Doe"> </div> <div class="form-group"> <label for="exampleInputEmail2">Email</label> <input type="email" class="form-control" id="exampleInputEmail2" placeholder="jane.doe@example.com"> </div> <button type="submit" class="btn btn-default">Send invitation</button> </form> <h2>Form links</h2> <form> <div class="form-group"> <label for="favorite">Favorite PO</label> <input type="text" class="form-control" id="favorite" placeholder="Mike"> </div> <button type="submit" class="btn btn-default pull-right">Send spam</button> <div class="form-group form-links"> <a href="#" class="pull-left">Link one</a> <a href="#" class="pull-left">Link two</a> <a href="#" class="pull-right">Link three</a> </div> </form> ``` */
+.form-group { margin-bottom: 20px; }
 
-```html_example_table
-<h2>Panel form</h2>
-<form>
-  <div class="panel panel-default">
-    <div class="panel-heading">Form heading</div>
-    <div class="panel-body">
-      <div class="form-group">
-        <label for="to">To</label>
-        <input type="email" class="form-control" id="to" placeholder="Enter email">
-      </div>
-      <div class="form-group has-success">
-        <label for="to">To (.has-success)</label>
-        <input type="email" class="form-control" id="to" placeholder="Enter email">
-        <p class="help-block">Example block-level help text here.</p>
-      </div>
-      <div class="form-group has-warning">
-        <label for="to">To (.has-warning)</label>
-        <input type="email" class="form-control" id="to" placeholder="Enter email">
-        <p class="help-block">Example block-level help text here.</p>
-      </div>
-      <div class="form-group has-error">
-        <label for="to">To (.has-error)</label>
-        <input type="email" class="form-control" id="to" placeholder="Enter email">
-        <p class="help-block">Example block-level help text here.</p>
-      </div>
-      <div class="form-group">
-        <label for="subject">Subject</label>
-        <input type="text" class="form-control" id="subject" placeholder="Enter subject">
-      </div>
-      <div class="form-group">
-        <label for="message">Message</label>
-        <textarea class="form-control" id="subject" placeholder="Enter message"></textarea>
-      </div>
-      <div class="form-group">
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" name="samecheck"> Check me out
-          </label>
-          <br>
-          <label>
-            <input type="checkbox" name="samecheck"> Check me out again
-          </label>
-        </div>
-      </div>
-      <div class="form-group">
-        <div class="radio">
-          <label>
-            <input type="radio" name="sameradio"> Check me out
-          </label>
-          <br>
-          <label>
-            <input type="radio" name="sameradio"> Check me out again
-          </label>
-        </div>
-      </div>
-      <div class="form-group">
-        <select class="form-control">
-          <option>option 1</option>
-          <option>option 2</option>
-          <option>option 3</option>
-          <option>option 4</option>
-        </select>
-      </div>
-    </div>
-  </div>
-  <div class="form-group text-right form-actions">
-    <button type="reset" class="btn btn-secondary">Cancel</button>
-    <button type="submit" class="btn btn-default">Submit</button>
-  </div>
-</form>
+.form-actions { padding-top: 20px; }
 
-<h2>Inline form</h2>
-<form class="form-inline">
-  <div class="form-group">
-    <label for="exampleInputName2">Name</label>
-    <input type="text" class="form-control" id="exampleInputName2" placeholder="Jane Doe">
-  </div>
-  <div class="form-group">
-    <label for="exampleInputEmail2">Email</label>
-    <input type="email" class="form-control" id="exampleInputEmail2" placeholder="jane.doe@example.com">
-  </div>
-  <button type="submit" class="btn btn-default">Send invitation</button>
-</form>
+.form-control { background: transparent; border: 1px solid #bbb; box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1); }
 
-<h2>Form links</h2>
-<form>
-  <div class="form-group">
-    <label for="favorite">Favorite PO</label>
-    <input type="text" class="form-control" id="favorite" placeholder="Mike">
-  </div>
-  <button type="submit" class="btn btn-default pull-right">Send spam</button>
-  <div class="form-group form-links">
-    <a href="#" class="pull-left">Link one</a>
-    <a href="#" class="pull-left">Link two</a>
-    <a href="#" class="pull-right">Link three</a>
-  </div>
-</form>
-```
-*/
-.form-group {
-  margin-bottom: 20px; }
+.form-control::-webkit-input-placeholder { color: #999999; }
 
-.form-actions {
-  padding-top: 20px; }
+.form-control::-moz-placeholder { color: #999999; }
 
-.form-control {
-  background: transparent;
-  border: 1px solid #bbb;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1); }
-  .form-control::-webkit-input-placeholder {
-    color: #999999; }
-  .form-control::-moz-placeholder {
-    color: #999999; }
-  .form-control:-moz-placeholder {
-    color: #999999; }
-  .form-control:-ms-input-placeholder {
-    color: #999999; }
-  .form-control:focus {
-    box-shadow: none; }
+.form-control:-moz-placeholder { color: #999999; }
 
-.has-error .form-control,
-.has-warning .form-control,
-.has-success .form-control {
-  box-shadow: none; }
-  .has-error .form-control:focus,
-  .has-warning .form-control:focus,
-  .has-success .form-control:focus {
-    box-shadow: none; }
+.form-control:-ms-input-placeholder { color: #999999; }
 
-label {
-  color: #666;
-  margin-bottom: 10px; }
+.form-control:focus { box-shadow: none; }
 
-.checkbox label,
-.radio label {
-  color: #666;
-  font-size: 14px;
-  margin-bottom: 0;
-  text-transform: none; }
+.has-error .form-control, .has-warning .form-control, .has-success .form-control { box-shadow: none; }
 
-.form-group.has-error label {
-  color: #e53221; }
+.has-error .form-control:focus, .has-warning .form-control:focus, .has-success .form-control:focus { box-shadow: none; }
 
-textarea {
-  resize: vertical; }
+label { color: #666; margin-bottom: 10px; }
 
-.form-links {
-  text-align: left; }
-  .form-links a {
-    padding: 7px 13px; }
-    .form-links a.pull-left:first-child {
-      padding-left: 0; }
+.checkbox label, .radio label { color: #666; font-size: 14px; margin-bottom: 0; text-transform: none; }
+
+.form-group.has-error label { color: #e53221; }
+
+textarea { resize: vertical; }
+
+.form-links { text-align: left; }
+
+.form-links a { padding: 7px 13px; }
+
+.form-links a.pull-left:first-child { padding-left: 0; }
 
 /*doc
 ---
@@ -6488,9 +2719,7 @@ name: grid
 category: CSS
 ---
 */
-.container-fluid {
-  padding-left: 20px;
-  padding-right: 20px; }
+.container-fluid { padding-left: 20px; padding-right: 20px; }
 
 /*doc
 //---
@@ -6513,57 +2742,10 @@ category: CSS
 //category: CSS
 //---
 */
-/*doc
----
-title: Tables
-name: tables
-category: CSS
+/*doc --- title: Tables name: tables category: CSS --- ```html_example <table class="table table-striped"> <thead> <tr> <th>Story</th> <th colspan="2">Date</th> </tr> </thead> <tbody> <tr> <td>The magic story that never ends</td> <td>31 jan, 2015</td> <td class="table-actions"><a href="#" title="Action Titile">Action 1</a> <a href="#" title="Action Title">Action 2</a></td> </tr> <tr> <td>Story title goes here</td> <td>12 jan, 2015</td> <td class="table-actions"><a href="#" title="Action Titile">Action 1</a> <a href="#" title="Action Title">Action 2</a></td> </tr> <tr> <td>Another story that have a long text of around SEO max length</td> <td>31 dec, 2014</td> <td class="table-actions"><a href="#" title="Action Titile">Action 1</a></td> </tr> <tr> <td>My story</td> <td>25 aug, 2012</td> <td class="table-actions"><a href="#" title="Action Titile">Action 1</a></td> </tr> <tr> <td>Old story title</td> <td>10 jun, 1977</td> <td class="table-actions"><a href="#" title="Action Titile">Action 1</a></td> </tr> </tbody> </table> ``` */
+.table > tbody > tr > td { border-top: 0; border-bottom: 1px solid #ddd; }
 
----
-```html_example
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>Story</th>
-      <th colspan="2">Date</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>The magic story that never ends</td>
-      <td>31 jan, 2015</td>
-      <td class="table-actions"><a href="#" title="Action Titile">Action 1</a> <a href="#" title="Action Title">Action 2</a></td>
-    </tr>
-    <tr>
-      <td>Story title goes here</td>
-      <td>12 jan, 2015</td>
-      <td class="table-actions"><a href="#" title="Action Titile">Action 1</a> <a href="#" title="Action Title">Action 2</a></td>
-    </tr>
-    <tr>
-      <td>Another story that have a long text of around SEO max length</td>
-      <td>31 dec, 2014</td>
-      <td class="table-actions"><a href="#" title="Action Titile">Action 1</a></td>
-    </tr>
-    <tr>
-      <td>My story</td>
-      <td>25 aug, 2012</td>
-      <td class="table-actions"><a href="#" title="Action Titile">Action 1</a></td>
-    </tr>
-    <tr>
-      <td>Old story title</td>
-      <td>10 jun, 1977</td>
-      <td class="table-actions"><a href="#" title="Action Titile">Action 1</a></td>
-    </tr>
-  </tbody>
-</table>
-```
-*/
-.table > tbody > tr > td {
-  border-top: 0;
-  border-bottom: 1px solid #ddd; }
-
-.table-actions {
-  text-align: right; }
+.table-actions { text-align: right; }
 
 /*doc
 ---
@@ -6594,125 +2776,39 @@ parent: typo
 <h6>h6. Bootstrap heading <small>with small text</small></h6>
 ```
 */
-/*doc
----
-title: Body copy
-name: body_copy
-parent: typo
----
-```html_example
-<p class="lead">
-  <strong>.lead</strong> Bacon ipsum dolor amet brisket chicken shank, turducken venison shoulder beef ribs.
-  Shoulder kielbasa cupim filet mignon. Ham pork chop andouille bacon turducken jowl fatback filet mignon meatloaf landjaeger.
-  Pork belly boudin brisket tri-tip sirloin hamburger shankle tenderloin meatball venison picanha frankfurter.
-  Kevin picanha andouille meatball, sirloin kielbasa ribeye corned beef pork belly bacon ground round.
-  Pancetta swine flank prosciutto meatball. Swine ball tip chicken hamburger pork sirloin.
-</p>
-<p>
-  Bacon ipsum dolor amet brisket chicken shank, turducken venison shoulder beef ribs.
-  Shoulder kielbasa cupim filet mignon. Ham pork chop andouille bacon turducken jowl fatback filet mignon meatloaf landjaeger.
-  Pork belly boudin brisket tri-tip sirloin hamburger shankle tenderloin meatball venison picanha frankfurter.
-  Kevin picanha andouille meatball, sirloin kielbasa ribeye corned beef pork belly bacon ground round.
-  Pancetta swine flank prosciutto meatball. Swine ball tip chicken hamburger pork sirloin.
-</p>
-```
-*/
-/*doc
- ---
- title: Jumbotron
- name: jumbotron
- category: Components
- ---
- The jumbotron is used for specific forms and popups
+/*doc --- title: Body copy name: body_copy parent: typo --- ```html_example <p class="lead"> <strong>.lead</strong> Bacon ipsum dolor amet brisket chicken shank, turducken venison shoulder beef ribs. Shoulder kielbasa cupim filet mignon. Ham pork chop andouille bacon turducken jowl fatback filet mignon meatloaf landjaeger. Pork belly boudin brisket tri-tip sirloin hamburger shankle tenderloin meatball venison picanha frankfurter. Kevin picanha andouille meatball, sirloin kielbasa ribeye corned beef pork belly bacon ground round. Pancetta swine flank prosciutto meatball. Swine ball tip chicken hamburger pork sirloin. </p> <p> Bacon ipsum dolor amet brisket chicken shank, turducken venison shoulder beef ribs. Shoulder kielbasa cupim filet mignon. Ham pork chop andouille bacon turducken jowl fatback filet mignon meatloaf landjaeger. Pork belly boudin brisket tri-tip sirloin hamburger shankle tenderloin meatball venison picanha frankfurter. Kevin picanha andouille meatball, sirloin kielbasa ribeye corned beef pork belly bacon ground round. Pancetta swine flank prosciutto meatball. Swine ball tip chicken hamburger pork sirloin. </p> ``` */
+/*doc --- title: Jumbotron name: jumbotron category: Components --- The jumbotron is used for specific forms and popups ```html_example <div class="jumbotron"> <div class="jumbotron-description"> <h1>Register a new account</h1> <p>You have to register to publish your stories for the world to see. Please take a moment to enter these details.</p> </div> <form accept-charset="UTF-8" action="/" method="post" role="form"> <div class="row"> <div class="col-sm-12 "> <div class="form-group email optional mndx_user_email"> <label class="email optional control-label" for="mndx_user_email">Email</label> <input class="string email optional form-control" type="email" name="mndx_user[email]" id="mndx_user_email" /> </div> </div> </div> <div class="row"> <div class="col-sm-6"> <div class="form-group password optional"> <label class="password optional control-label" for="mndx_user_password">New password</label> <input class="password optional form-control" type="password" name="mndx_user[password]" id="mndx_user_password" /> </div> </div> <div class="col-sm-6"> <div class="form-group password optional"> <label class="password optional control-label" for="mndx_user_password_confirmation">Confirm new password</label> <input class="password optional form-control" type="password" name="mndx_user[password_confirmation]" id="mndx_user_password_confirmation" /> </div> </div> </div> <div class="form-group form-actions"> <input type="submit" name="commit" value="Register" class="btn btn-primary btn-block" /> </div> </form> <a class="jumbotron-link" href="#">Sign in</a> </div> ``` */
+.jumbotron { background-color: #fff; border: 1px solid #bbb; border-radius: 4px; margin: 30px auto 0; max-width: 480px; padding: 30px; text-align: center; }
 
-```html_example
-<div class="jumbotron">
-  <div class="jumbotron-description">
-    <h1>Register a new account</h1>
-    <p>You have to register to publish your stories for the world to see. Please take a moment to enter these details.</p>
-  </div>
-  <form accept-charset="UTF-8" action="/" method="post" role="form">
-    <div class="row">
-      <div class="col-sm-12 ">
-        <div class="form-group email optional mndx_user_email">
-          <label class="email optional control-label" for="mndx_user_email">Email</label>
-          <input class="string email optional form-control" type="email" name="mndx_user[email]" id="mndx_user_email" />
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-6">
-        <div class="form-group password optional">
-          <label class="password optional control-label" for="mndx_user_password">New password</label>
-          <input class="password optional form-control" type="password" name="mndx_user[password]" id="mndx_user_password" />
-        </div>
-      </div>
-      <div class="col-sm-6">
-        <div class="form-group password optional">
-          <label class="password optional control-label" for="mndx_user_password_confirmation">Confirm new password</label>
-          <input class="password optional form-control" type="password" name="mndx_user[password_confirmation]" id="mndx_user_password_confirmation" />
-        </div>
-      </div>
-    </div>
-    <div class="form-group form-actions">
-      <input type="submit" name="commit" value="Register" class="btn btn-primary btn-block" />
-    </div>
-  </form>
-  <a class="jumbotron-link" href="#">Sign in</a>
-</div>
-```
-*/
-.jumbotron {
-  background-color: #fff;
-  border: 1px solid #bbb;
-  border-radius: 4px;
-  margin: 30px auto 0;
-  max-width: 480px;
-  padding: 30px;
-  text-align: center; }
-  @media screen and (min-width: 768px) {
-    .jumbotron {
-      margin: 40px auto 0;
-      padding: 60px; } }
-  .jumbotron .jumbotron-description {
-    margin-bottom: 20px; }
-    @media screen and (min-width: 768px) {
-      .jumbotron .jumbotron-description {
-        margin-bottom: 30px; } }
-    .jumbotron .jumbotron-description h1 {
-      color: #333333;
-      font-size: 38px;
-      font-weight: 600;
-      margin-bottom: 30px;
-      margin-top: 0; }
-      @media screen and (min-width: 768px) {
-        .jumbotron .jumbotron-description h1 {
-          margin-bottom: 20px; } }
-    .jumbotron .jumbotron-description p {
-      color: #666;
-      font-size: 14px;
-      font-weight: normal; }
-  .jumbotron .jumbotron-link {
-    margin-right: 20px; }
-    .jumbotron .jumbotron-link:last-child {
-      margin-right: 0; }
-  .jumbotron form {
-    margin-top: 0; }
-    .jumbotron form .form-group {
-      text-align: left; }
+@media screen and (min-width: 768px) { .jumbotron { margin: 40px auto 0; padding: 60px; } }
 
-.jumbotron-transparent {
-  background: transparent;
-  border: 0; }
-  .jumbotron-transparent .jumbotron-description h1,
-  .jumbotron-transparent .jumbotron-description p {
-    color: #fff; }
-  .jumbotron-transparent .control-label {
-    color: #fff; }
-  .jumbotron-transparent .form-control {
-    background: #fff; }
-  .jumbotron-transparent .form-links a {
-    color: #fff; }
+.jumbotron .jumbotron-description { margin-bottom: 20px; }
+
+@media screen and (min-width: 768px) { .jumbotron .jumbotron-description { margin-bottom: 30px; } }
+
+.jumbotron .jumbotron-description h1 { color: #333333; font-size: 38px; font-weight: 600; margin-bottom: 30px; margin-top: 0; }
+
+@media screen and (min-width: 768px) { .jumbotron .jumbotron-description h1 { margin-bottom: 20px; } }
+
+.jumbotron .jumbotron-description p { color: #666; font-size: 14px; font-weight: normal; }
+
+.jumbotron .jumbotron-link { margin-right: 20px; }
+
+.jumbotron .jumbotron-link:last-child { margin-right: 0; }
+
+.jumbotron form { margin-top: 0; }
+
+.jumbotron form .form-group { text-align: left; }
+
+.jumbotron-transparent { background: transparent; border: 0; }
+
+.jumbotron-transparent .jumbotron-description h1, .jumbotron-transparent .jumbotron-description p { color: #fff; }
+
+.jumbotron-transparent .control-label { color: #fff; }
+
+.jumbotron-transparent .form-control { background: #fff; }
+
+.jumbotron-transparent .form-links a { color: #fff; }
 
 /*doc
 ---
@@ -6779,102 +2875,38 @@ category: Components
 //category: Components
 //---
 */
-/*doc
- ---
- title: Jumbotron
- name: jumbotron
- category: Components
- ---
- The jumbotron is used for specific forms and popups
+/*doc --- title: Jumbotron name: jumbotron category: Components --- The jumbotron is used for specific forms and popups ```html_example <div class="jumbotron"> <div class="jumbotron-description"> <h1>Register a new account</h1> <p>You have to register to publish your stories for the world to see. Please take a moment to enter these details.</p> </div> <form accept-charset="UTF-8" action="/" method="post" role="form"> <div class="row"> <div class="col-sm-12 "> <div class="form-group email optional mndx_user_email"> <label class="email optional control-label" for="mndx_user_email">Email</label> <input class="string email optional form-control" type="email" name="mndx_user[email]" id="mndx_user_email" /> </div> </div> </div> <div class="row"> <div class="col-sm-6"> <div class="form-group password optional"> <label class="password optional control-label" for="mndx_user_password">New password</label> <input class="password optional form-control" type="password" name="mndx_user[password]" id="mndx_user_password" /> </div> </div> <div class="col-sm-6"> <div class="form-group password optional"> <label class="password optional control-label" for="mndx_user_password_confirmation">Confirm new password</label> <input class="password optional form-control" type="password" name="mndx_user[password_confirmation]" id="mndx_user_password_confirmation" /> </div> </div> </div> <div class="form-group form-actions"> <input type="submit" name="commit" value="Register" class="btn btn-primary btn-block" /> </div> </form> <a class="jumbotron-link" href="#">Sign in</a> </div> ``` */
+.jumbotron { background-color: #fff; border: 1px solid #bbb; border-radius: 4px; margin: 30px auto 0; max-width: 480px; padding: 30px; text-align: center; }
 
-```html_example
-<div class="jumbotron">
-  <div class="jumbotron-description">
-    <h1>Register a new account</h1>
-    <p>You have to register to publish your stories for the world to see. Please take a moment to enter these details.</p>
-  </div>
-  <form accept-charset="UTF-8" action="/" method="post" role="form">
-    <div class="row">
-      <div class="col-sm-12 ">
-        <div class="form-group email optional mndx_user_email">
-          <label class="email optional control-label" for="mndx_user_email">Email</label>
-          <input class="string email optional form-control" type="email" name="mndx_user[email]" id="mndx_user_email" />
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-6">
-        <div class="form-group password optional">
-          <label class="password optional control-label" for="mndx_user_password">New password</label>
-          <input class="password optional form-control" type="password" name="mndx_user[password]" id="mndx_user_password" />
-        </div>
-      </div>
-      <div class="col-sm-6">
-        <div class="form-group password optional">
-          <label class="password optional control-label" for="mndx_user_password_confirmation">Confirm new password</label>
-          <input class="password optional form-control" type="password" name="mndx_user[password_confirmation]" id="mndx_user_password_confirmation" />
-        </div>
-      </div>
-    </div>
-    <div class="form-group form-actions">
-      <input type="submit" name="commit" value="Register" class="btn btn-primary btn-block" />
-    </div>
-  </form>
-  <a class="jumbotron-link" href="#">Sign in</a>
-</div>
-```
-*/
-.jumbotron {
-  background-color: #fff;
-  border: 1px solid #bbb;
-  border-radius: 4px;
-  margin: 30px auto 0;
-  max-width: 480px;
-  padding: 30px;
-  text-align: center; }
-  @media screen and (min-width: 768px) {
-    .jumbotron {
-      margin: 40px auto 0;
-      padding: 60px; } }
-  .jumbotron .jumbotron-description {
-    margin-bottom: 20px; }
-    @media screen and (min-width: 768px) {
-      .jumbotron .jumbotron-description {
-        margin-bottom: 30px; } }
-    .jumbotron .jumbotron-description h1 {
-      color: #333333;
-      font-size: 38px;
-      font-weight: 600;
-      margin-bottom: 30px;
-      margin-top: 0; }
-      @media screen and (min-width: 768px) {
-        .jumbotron .jumbotron-description h1 {
-          margin-bottom: 20px; } }
-    .jumbotron .jumbotron-description p {
-      color: #666;
-      font-size: 14px;
-      font-weight: normal; }
-  .jumbotron .jumbotron-link {
-    margin-right: 20px; }
-    .jumbotron .jumbotron-link:last-child {
-      margin-right: 0; }
-  .jumbotron form {
-    margin-top: 0; }
-    .jumbotron form .form-group {
-      text-align: left; }
+@media screen and (min-width: 768px) { .jumbotron { margin: 40px auto 0; padding: 60px; } }
 
-.jumbotron-transparent {
-  background: transparent;
-  border: 0; }
-  .jumbotron-transparent .jumbotron-description h1,
-  .jumbotron-transparent .jumbotron-description p {
-    color: #fff; }
-  .jumbotron-transparent .control-label {
-    color: #fff; }
-  .jumbotron-transparent .form-control {
-    background: #fff; }
-  .jumbotron-transparent .form-links a {
-    color: #fff; }
+.jumbotron .jumbotron-description { margin-bottom: 20px; }
+
+@media screen and (min-width: 768px) { .jumbotron .jumbotron-description { margin-bottom: 30px; } }
+
+.jumbotron .jumbotron-description h1 { color: #333333; font-size: 38px; font-weight: 600; margin-bottom: 30px; margin-top: 0; }
+
+@media screen and (min-width: 768px) { .jumbotron .jumbotron-description h1 { margin-bottom: 20px; } }
+
+.jumbotron .jumbotron-description p { color: #666; font-size: 14px; font-weight: normal; }
+
+.jumbotron .jumbotron-link { margin-right: 20px; }
+
+.jumbotron .jumbotron-link:last-child { margin-right: 0; }
+
+.jumbotron form { margin-top: 0; }
+
+.jumbotron form .form-group { text-align: left; }
+
+.jumbotron-transparent { background: transparent; border: 0; }
+
+.jumbotron-transparent .jumbotron-description h1, .jumbotron-transparent .jumbotron-description p { color: #fff; }
+
+.jumbotron-transparent .control-label { color: #fff; }
+
+.jumbotron-transparent .form-control { background: #fff; }
+
+.jumbotron-transparent .form-links a { color: #fff; }
 
 /*doc
 //---
@@ -6883,145 +2915,44 @@ category: Components
 //category: Components
 //---
 */
-/*doc
----
-title: List group
-name: list_group
-category: Components
----
-```html_example
-<ul class="list-group">
-  <li class="list-group-item">This is my Story</li>
-  <li class="list-group-item">Item 2</li>
-  <li class="list-group-item">Item 3</li>
-</ul>
-```
-*/
-/*doc
----
-title: Striped List Group
-name: list_group_striped
-parent: list_group
----
+/*doc --- title: List group name: list_group category: Components --- ```html_example <ul class="list-group"> <li class="list-group-item">This is my Story</li> <li class="list-group-item">Item 2</li> <li class="list-group-item">Item 3</li> </ul> ``` */
+/*doc --- title: Striped List Group name: list_group_striped parent: list_group --- ```html_example <ul class="list-group list-group-striped"> <li class="list-group-item">This is my Story - February 06, 2015 15:53</li> <li class="list-group-item">Item 2</li> <li class="list-group-item">Item 3</li> </ul> ``` */
+.list-group { border: none; }
 
-```html_example
-<ul class="list-group list-group-striped">
-  <li class="list-group-item">This is my Story - February 06, 2015 15:53</li>
-  <li class="list-group-item">Item 2</li>
-  <li class="list-group-item">Item 3</li>
-</ul>
-```
-*/
-.list-group {
-  border: none; }
-  .list-group-item {
-    border-width: 1px 0; }
-    .list-group-item:first-child {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0; }
-    .list-group-item:last-child {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0; }
-  .list-group-striped .list-group-item:nth-child(odd) {
-    background: #f1f8fb; }
+.list-group-item { border-width: 1px 0; }
 
-/*doc
----
-title: Content List
-name: content_list
-category: Components
----
+.list-group-item:first-child { border-top-left-radius: 0; border-top-right-radius: 0; }
 
-Custom list for editable content
+.list-group-item:last-child { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
 
-```html_example
-<ul class="content-list">
-  <li class="content-list-row content-list-header">
-    <div class="content-list-column">Draft</div>
-    <div class="content-list-column">Last edited</div>
-    <div class="content-list-column">Actions</div>
-  </li>
-  <li class="content-list-row">
-    <div class="content-list-column"><a href="#">Press Release Name #1</a></div>
-    <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div>
-    <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div>
-  </li>
-  <li class="content-list-row">
-    <div class="content-list-column"><a href="#">Press Release Name #2</a></div>
-    <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div>
-    <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div>
-  </li>
-  <li class="content-list-row">
-    <div class="content-list-column"><a href="#">Press Release Name #3</a></div>
-    <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div>
-    <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div>
-  </li>
-</ul>
+.list-group-striped .list-group-item:nth-child(odd) { background: #f1f8fb; }
 
-<ul class="content-list content-list-striped">
-  <li class="content-list-row content-list-header">
-    <div class="content-list-column">Draft</div>
-    <div class="content-list-column">Last edited</div>
-    <div class="content-list-column">Actions</div>
-  </li>
-  <li class="content-list-row">
-    <div class="content-list-column"><a href="#">Press Release Name #1</a></div>
-    <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div>
-    <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div>
-  </li>
-  <li class="content-list-row">
-    <div class="content-list-column"><a href="#">Press Release Name #2</a></div>
-    <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div>
-    <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div>
-  </li>
-  <li class="content-list-row">
-    <div class="content-list-column"><a href="#">Press Release Name #3</a></div>
-    <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div>
-    <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div>
-  </li>
-</ul>
-```
-*/
-.content-list {
-  border-collapse: collapse;
-  border-spacing: 0;
-  display: table;
-  list-style-type: none;
-  margin-bottom: 20px;
-  max-width: 100%;
-  table-layout: fixed;
-  width: 100%; }
-  .content-list:last-child {
-    margin-bottom: 0; }
-  .content-list .content-list-row {
-    border-bottom: 1px solid #eeeeee;
-    display: table-row; }
-  .content-list .content-list-column {
-    display: table-cell;
-    padding: 15px;
-    text-align: right; }
-    .content-list .content-list-column:first-child {
-      text-align: left;
-      display: table-cell; }
-    .content-list .content-list-column:nth-child(n+2) {
-      display: none; }
-      @media screen and (min-width: 768px) {
-        .content-list .content-list-column:nth-child(n+2) {
-          display: table-cell; } }
-    .content-list .content-list-column:last-child {
-      display: table-cell; }
-  .content-list .content-list-action {
-    display: inline-block;
-    margin-left: 25px; }
-    .content-list .content-list-action:first-child {
-      margin-left: 0; }
-  .content-list .content-list-header {
-    font-weight: bold; }
+/*doc --- title: Content List name: content_list category: Components --- Custom list for editable content ```html_example <ul class="content-list"> <li class="content-list-row content-list-header"> <div class="content-list-column">Draft</div> <div class="content-list-column">Last edited</div> <div class="content-list-column">Actions</div> </li> <li class="content-list-row"> <div class="content-list-column"><a href="#">Press Release Name #1</a></div> <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div> <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div> </li> <li class="content-list-row"> <div class="content-list-column"><a href="#">Press Release Name #2</a></div> <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div> <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div> </li> <li class="content-list-row"> <div class="content-list-column"><a href="#">Press Release Name #3</a></div> <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div> <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div> </li> </ul> <ul class="content-list content-list-striped"> <li class="content-list-row content-list-header"> <div class="content-list-column">Draft</div> <div class="content-list-column">Last edited</div> <div class="content-list-column">Actions</div> </li> <li class="content-list-row"> <div class="content-list-column"><a href="#">Press Release Name #1</a></div> <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div> <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div> </li> <li class="content-list-row"> <div class="content-list-column"><a href="#">Press Release Name #2</a></div> <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div> <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div> </li> <li class="content-list-row"> <div class="content-list-column"><a href="#">Press Release Name #3</a></div> <div class="content-list-column"><span class="hidden-sm">Published at </span>Feb, 28 2015</div> <div class="content-list-column"><a class="content-list-action" href="#">Edit</a><a class="content-list-action" href="#">Publish</a></div> </li> </ul> ``` */
+.content-list { border-collapse: collapse; border-spacing: 0; display: table; list-style-type: none; margin-bottom: 20px; max-width: 100%; table-layout: fixed; width: 100%; }
 
-.content-list-striped .content-list-row {
-  border-bottom: 0; }
-  .content-list-striped .content-list-row:nth-child(even) {
-    background-color: #f8fafd; }
+.content-list:last-child { margin-bottom: 0; }
+
+.content-list .content-list-row { border-bottom: 1px solid #eeeeee; display: table-row; }
+
+.content-list .content-list-column { display: table-cell; padding: 15px; text-align: right; }
+
+.content-list .content-list-column:first-child { text-align: left; display: table-cell; }
+
+.content-list .content-list-column:nth-child(n+2) { display: none; }
+
+@media screen and (min-width: 768px) { .content-list .content-list-column:nth-child(n+2) { display: table-cell; } }
+
+.content-list .content-list-column:last-child { display: table-cell; }
+
+.content-list .content-list-action { display: inline-block; margin-left: 25px; }
+
+.content-list .content-list-action:first-child { margin-left: 0; }
+
+.content-list .content-list-header { font-weight: bold; }
+
+.content-list-striped .content-list-row { border-bottom: 0; }
+
+.content-list-striped .content-list-row:nth-child(even) { background-color: #f8fafd; }
 
 /*doc
 //---
@@ -7117,48 +3048,31 @@ Modular section setup which allows using a combination of header, body and foote
 ```
 
 */
-section.solid {
-  background-color: #F2F2F2; }
+section.solid { background-color: #F2F2F2; }
 
-section > .content header, section > .content .body, section > .content footer {
-  text-align: center; }
+section > .content header, section > .content .body, section > .content footer { text-align: center; }
 
-section > .content header {
-  margin: 100px 0 50px; }
-  section > .content header h2 {
-    font-size: 36px;
-    margin: 0; }
-  section > .content header p {
-    margin: 10px 0 0;
-    font-weight: 200; }
+section > .content header { margin: 100px 0 50px; }
 
-section > .content .body {
-  margin: 50px 0; }
+section > .content header h2 { font-size: 36px; margin: 0; }
 
-section > .content footer {
-  margin: 50px 0 100px; }
+section > .content header p { margin: 10px 0 0; font-weight: 200; }
 
-section > .content h2 {
-  font-size: 24px;
-  font-weight: 200;
-  margin-top: 0; }
-  @media (min-width: 992px) {
-    section > .content h2 {
-      font-weight: 200;
-      font-size: 32px; } }
-  @media (min-width: 1200px) {
-    section > .content h2 {
-      font-size: 48px; } }
+section > .content .body { margin: 50px 0; }
 
-section > .content p {
-  font-size: 18px;
-  font-weight: 200; }
-  @media (min-width: 992px) {
-    section > .content p {
-      font-size: 20px; } }
+section > .content footer { margin: 50px 0 100px; }
 
-section > .content a {
-  font-weight: normal; }
+section > .content h2 { font-size: 24px; font-weight: 200; margin-top: 0; }
+
+@media (min-width: 992px) { section > .content h2 { font-weight: 200; font-size: 32px; } }
+
+@media (min-width: 1200px) { section > .content h2 { font-size: 48px; } }
+
+section > .content p { font-size: 18px; font-weight: 200; }
+
+@media (min-width: 992px) { section > .content p { font-size: 20px; } }
+
+section > .content a { font-weight: normal; }
 
 /*doc
 ---
@@ -7174,57 +3088,11 @@ category: Components
 //category: Components
 //---
 */
-/*doc
----
-title: Modal
-name: modal
-category: JavaScript
+/*doc --- title: Modal name: modal category: JavaScript --- ```html_example <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"> <div class="modal-dialog"> <div class="modal-content"> <div class="modal-header"> <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button> <h4 class="modal-title">Modal title</h4> </div> <div class="modal-body"> <p> Ut massa lacus, posuere in facilisis a, blandit ac tortor. Praesent euismod posuere sodales. Nunc maximus eros vitae massa vehicula pharetra. Praesent id nunc ac odio tristique faucibus*. </p> <p class="footnote"> Mauris imperdiet gravida nisl a venenatis. Nulla vel orci congue, efficitur enim eu, cursus justo. Maecenas hendrerit eu elit et hendrerit. Mauris eget eros mi. </p> </div> <div class="modal-footer"> <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button> <button type="button" class="btn btn-primary">Save changes</button> </div> </div> </div> </div> <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal"> Launch demo modal </button> ``` */
+.modal-backdrop { position: fixed; bottom: 0; }
 
----
-```html_example
-<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Modal title</h4>
-      </div>
-      <div class="modal-body">
-        <p>
-          Ut massa lacus, posuere in facilisis a, blandit ac tortor. Praesent euismod posuere
-          sodales. Nunc maximus eros vitae massa vehicula pharetra. Praesent id nunc ac odio
-          tristique faucibus*.
-        </p>
-        <p class="footnote">
-          * Mauris imperdiet gravida nisl a venenatis. Nulla vel orci congue, efficitur enim eu, cursus
-          justo. Maecenas hendrerit eu elit et hendrerit. Mauris eget eros mi.
-        </p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
-      </div>
-    </div>
-  </div>
-</div>
+.modal-content { -webkit-box-shadow: 0 2px 4px rgba(187, 187, 187, 0.4); box-shadow: 0 2px 4px rgba(187, 187, 187, 0.4); overflow: hidden; }
 
-<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
-  Launch demo modal
-</button>
-```
-*/
-.modal-backdrop {
-  position: fixed;
-  bottom: 0; }
+.modal-header { background-color: #fcfcfc; }
 
-.modal-content {
-  -webkit-box-shadow: 0 2px 4px rgba(187, 187, 187, 0.4);
-  box-shadow: 0 2px 4px rgba(187, 187, 187, 0.4);
-  overflow: hidden; }
-
-.modal-header {
-  background-color: #fcfcfc; }
-
-.modal-dialog .footnote {
-  color: #999999;
-  font-size: 12px; }
+.modal-dialog .footnote { color: #999999; font-size: 12px; }

--- a/doc_assets/_header.html
+++ b/doc_assets/_header.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="styleguide.css">
     <script src="javascripts/jquery.min.js"></script>
     <script src="javascripts/bootstrap.min.js"></script>
-    <script src="//localhost:35729/livereload.js"></script>
     <script src="https://fb.me/react-0.13.3.js"></script>
     <script src="mnd.js"></script>
     <script src="https://fb.me/JSXTransformer-0.13.3.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var hologram = require('gulp-hologram');
 var notify = require('gulp-notify');
 var runSequence = require('run-sequence');
 var request = require('superagent');
-var gulpSass = require('gulp-sass');
+var sass = require('gulp-sass');
 var clean = require('gulp-rimraf');
 
 var argv = require('yargs')
@@ -64,7 +64,7 @@ gulp.task('watch-styleguide', function() {
 
 gulp.task('mnd-bootstrap-sass', function() {
   return gulp.src('src/mnd-bootstrap.scss')
-    .pipe(gulpSass({ outputStyle: 'compact', includePaths: [config.bowerDir]}))
+    .pipe(sass({ outputStyle: 'compact', includePaths: [config.bowerDir]}))
     .on('error', function (err) { console.log(err.message); })
     .pipe(gulp.dest('dist/'))
     .pipe(gulp.dest('public/dist'))
@@ -74,7 +74,7 @@ gulp.task('mnd-bootstrap-sass', function() {
 
 gulp.task('styleguide-sass', function() {
   return gulp.src('doc_assets/styleguide.scss')
-    .pipe(gulpSass({ outputStyle: 'compact', includePaths: [config.bowerDir]}))
+    .pipe(sass({ outputStyle: 'compact', includePaths: [config.bowerDir]}))
     .on('error', function (err) { console.log(err.message); })
     .pipe(gulp.dest('public/'))
     .pipe(notify({message: 'Styleguide-sass task complete'}));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -114,7 +114,8 @@ gulp.task('styleguide', [
   ], function() {
   return gulp.src('hologram_config.yml')
     .pipe(hologram())
-    .pipe(notify({message: 'Hologram task complete'}));
+    .pipe(notify({message: 'Hologram task complete'}))
+    .pipe(reload({ stream:true }));
 });
 
 // Increment version number

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,12 +30,12 @@ gulp.task('serve', function() {
       baseDir: config.publicDir
     }
   });
-  gulp.start('watch-scss');
+  gulp.start('watch-bootstrap');
 });
 
 // Dev task: build, serve and watch
 gulp.task('default', function() {
-  gulp.start('serve', 'watch-styleguide', 'watch-scss');
+  gulp.start('serve', 'watch-styleguide', 'watch-bootstrap');
 });
 
 gulp.task('documentation', function() {
@@ -59,7 +59,7 @@ gulp.task('clean', function() {
   return gulp.src('public/dist/').pipe(clean());
 });
 
-gulp.task('watch-scss', function (){
+gulp.task('watch-bootstrap', function (){
   gulp.watch(['src/**/*.scss'], ['mnd-bootstrap-sass']);
 });
 
@@ -85,8 +85,6 @@ gulp.task('mnd-bootstrap-sass', function() {
     .pipe(notify({message: 'mnd-bootstrap-sass task complete'}))
     .pipe(reload({ stream:true }));
 });
-
-
 
 gulp.task('styleguide-sass', function() {
   return gulp.src('doc_assets/styleguide.scss')
@@ -118,7 +116,6 @@ gulp.task('styleguide', [
     .pipe(hologram())
     .pipe(notify({message: 'Hologram task complete'}));
 });
-
 
 // Increment version number
 gulp.task('bump', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ gulp.task('watch-styleguide', function() {
 
 gulp.task('mnd-bootstrap-sass', function() {
   return gulp.src('src/mnd-bootstrap.scss')
-    .pipe(gulpSass({includePaths: [config.bowerDir]}))
+    .pipe(gulpSass({ outputStyle: 'compact', includePaths: [config.bowerDir]}))
     .on('error', function (err) { console.log(err.message); })
     .pipe(gulp.dest('dist/'))
     .pipe(gulp.dest('public/dist'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,6 @@ var runSequence = require('run-sequence');
 var request = require('superagent');
 var sass = require('gulp-ruby-sass');
 var gulpSass = require('gulp-sass');
-var webserver = require('gulp-webserver');
 var clean = require('gulp-rimraf');
 
 var argv = require('yargs')
@@ -36,18 +35,6 @@ gulp.task('serve', function() {
 // Dev task: build, serve and watch
 gulp.task('default', function() {
   gulp.start('serve', 'watch-styleguide', 'watch-bootstrap');
-});
-
-gulp.task('documentation', function() {
-  gulp.start('styleguide', 'serve', 'watch-styleguide');
-});
-
-// Serve the style-guide
-gulp.task('webserver', function() {
-  gulp.src('public')
-    .pipe(webserver({
-      livereload: true
-    }));
 });
 
 // Release a new version and update the doc (style-guide)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp');
+var browserSync = require('browser-sync');
 var bump = require('gulp-bump');
 var deploy = require('gulp-gh-pages');
 var git = require('gulp-git');
@@ -7,6 +8,7 @@ var notify = require('gulp-notify');
 var runSequence = require('run-sequence');
 var request = require('superagent');
 var sass = require('gulp-ruby-sass');
+var gulpSass = require('gulp-sass');
 var webserver = require('gulp-webserver');
 var clean = require('gulp-rimraf');
 
@@ -14,9 +16,38 @@ var argv = require('yargs')
   .default('level', 'minor')
   .argv;
 
+var reload = browserSync.reload;
+
+var config = {
+    bowerDir: './bower_components',
+    bootstrapDir: './bower_components/bootstrap-sass',
+    publicDir: './public'
+};
+
+gulp.task('serve', function() {
+  browserSync({
+    server: {
+      baseDir: config.publicDir
+    }
+  });
+  gulp.start('watch-scss');
+});
+
 // Dev task: build, serve and watch
 gulp.task('default', function() {
-  gulp.start('webserver', 'watch');
+  gulp.start('serve', 'watch-styleguide', 'mnd-bootstrap-sass');
+});
+
+gulp.task('documentation', function() {
+  gulp.start('styleguide', 'serve', 'watch-styleguide', 'sass')
+});
+
+// Serve the style-guide
+gulp.task('webserver', function() {
+  gulp.src('public')
+    .pipe(webserver({
+      livereload: true
+    }));
 });
 
 // Release a new version and update the doc (style-guide)
@@ -24,31 +55,38 @@ gulp.task('release', function(done) {
   runSequence('tag', 'rails-assets', 'gh-pages', done);
 });
 
-// Recompile the styleguide on scss file change
-gulp.task('watch', function() {
-  gulp.watch(['src/**/*.scss', 'doc_assets/**/*.scss' ,'doc_assets/**/*.html'], ['hologram']);
-  gulp.watch(['src/**/*.js'], ['hologram']);
-});
-
-// Compile sass files
-gulp.task('sass', function() {
-  return gulp.src('src/mnd-bootstrap.scss')
-    .pipe(sass({ style: 'compressed', loadPath: ['./bower_components/'] }))
-    .on('error', function (err) { console.log(err.message); })
-    .pipe(gulp.dest('dist/'))
-    .pipe(notify({message: 'Sass task complete'}));
-});
-
 gulp.task('clean', function() {
   return gulp.src('public/dist/').pipe(clean());
 });
+
+gulp.task('watch-scss', function (){
+  gulp.watch(['src/**/*.scss'], ['mnd-bootstrap-sass']);
+});
+
+// Recompile the styleguide on scss file change
+gulp.task('watch-styleguide', function() {
+  gulp.watch(['src/**/*.scss', 'doc_assets/**/*.scss' ,'doc_assets/**/*.html'], ['styleguide-sass','styleguide']);
+  gulp.watch(['src/**/*.js'], ['styleguide']);
+});
+
+gulp.task('mnd-bootstrap-sass', function() {
+  return gulp.src('src/mnd-bootstrap.scss')
+    .pipe(gulpSass({includePaths: [config.bowerDir]}))
+    .on('error', function (err) { console.log(err.message); })
+    .pipe(gulp.dest('dist/'))
+    .pipe(gulp.dest('public/dist'))
+    .pipe(notify({message: 'mnd-bootstrap-sass task complete'}))
+    .pipe(reload({ stream:true }));
+});
+
+
 
 gulp.task('styleguide-sass', function() {
   return gulp.src('doc_assets/styleguide.scss')
     .pipe(sass({ style: 'expanded', loadPath: ['src/', './bower_components/'] }))
     .on('error', function (err) { console.log(err.message); })
     .pipe(gulp.dest('public/'))
-    .pipe(notify({message: 'Sass task complete'}));
+    .pipe(notify({message: 'Styleguide-sass task complete'}));
 });
 
 gulp.task('styleguide-assets', function() {
@@ -63,19 +101,12 @@ gulp.task('styleguide-assets', function() {
 });
 
 // Compile style-guide
-gulp.task('hologram', ['clean', 'sass', 'styleguide-sass', 'styleguide-assets'], function() {
+gulp.task('styleguide', ['clean', 'mnd-bootstrap-sass', 'styleguide-sass', 'styleguide-assets'], function() {
   return gulp.src('hologram_config.yml')
     .pipe(hologram())
     .pipe(notify({message: 'Hologram task complete'}));
 });
 
-// Serve the style-guide
-gulp.task('webserver', ['hologram'], function() {
-  gulp.src('public')
-    .pipe(webserver({
-      livereload: true
-    }));
-});
 
 // Increment version number
 gulp.task('bump', function() {
@@ -116,7 +147,7 @@ gulp.task('rails-assets', function(done) {
 });
 
 // Push ./public to gh-pages after hologram build
-gulp.task('gh-pages', ['hologram'], function() {
+gulp.task('gh-pages', ['styleguide'], function() {
   return gulp.src('./public/**/*')
     .pipe(deploy());
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ var hologram = require('gulp-hologram');
 var notify = require('gulp-notify');
 var runSequence = require('run-sequence');
 var request = require('superagent');
-var sass = require('gulp-ruby-sass');
 var gulpSass = require('gulp-sass');
 var clean = require('gulp-rimraf');
 
@@ -75,7 +74,7 @@ gulp.task('mnd-bootstrap-sass', function() {
 
 gulp.task('styleguide-sass', function() {
   return gulp.src('doc_assets/styleguide.scss')
-    .pipe(sass({ style: 'expanded', loadPath: ['src/', './bower_components/'] }))
+    .pipe(gulpSass({ outputStyle: 'compact', includePaths: [config.bowerDir]}))
     .on('error', function (err) { console.log(err.message); })
     .pipe(gulp.dest('public/'))
     .pipe(notify({message: 'Styleguide-sass task complete'}));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ var config = {
     publicDir: './public'
 };
 
+// Just do the CSS stuff, build bootstrap, browserSync
 gulp.task('serve', function() {
   browserSync({
     server: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,11 +35,11 @@ gulp.task('serve', function() {
 
 // Dev task: build, serve and watch
 gulp.task('default', function() {
-  gulp.start('serve', 'watch-styleguide', 'mnd-bootstrap-sass');
+  gulp.start('serve', 'watch-styleguide', 'watch-scss');
 });
 
 gulp.task('documentation', function() {
-  gulp.start('styleguide', 'serve', 'watch-styleguide', 'sass')
+  gulp.start('styleguide', 'serve', 'watch-styleguide');
 });
 
 // Serve the style-guide
@@ -65,7 +65,14 @@ gulp.task('watch-scss', function (){
 
 // Recompile the styleguide on scss file change
 gulp.task('watch-styleguide', function() {
-  gulp.watch(['src/**/*.scss', 'doc_assets/**/*.scss' ,'doc_assets/**/*.html'], ['styleguide-sass','styleguide']);
+  gulp.watch([
+    'src/**/*.scss',
+    'doc_assets/**/*.scss',
+    'doc_assets/**/*.html'
+  ],[
+    'styleguide-sass',
+    'styleguide'
+  ]);
   gulp.watch(['src/**/*.js'], ['styleguide']);
 });
 
@@ -101,7 +108,12 @@ gulp.task('styleguide-assets', function() {
 });
 
 // Compile style-guide
-gulp.task('styleguide', ['clean', 'mnd-bootstrap-sass', 'styleguide-sass', 'styleguide-assets'], function() {
+gulp.task('styleguide', [
+    'clean',
+    'mnd-bootstrap-sass',
+    'styleguide-sass',
+    'styleguide-assets'
+  ], function() {
   return gulp.src('hologram_config.yml')
     .pipe(hologram())
     .pipe(notify({message: 'Hologram task complete'}));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('serve', function() {
 });
 
 // Dev task: build, serve and watch
-gulp.task('default', function() {
+gulp.task('default',['styleguide'], function() {
   gulp.start('serve', 'watch-styleguide', 'watch-bootstrap');
 });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gulp-rimraf": "^0.1.1",
     "gulp-ruby-sass": "^0.7.1",
     "gulp-sass": "^2.0.4",
-    "gulp-webserver": "^0.9.0",
     "moment": "^2.10.3",
     "react-widgets": "^2.6.0",
     "run-sequence": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^0.13.0"
   },
   "devDependencies": {
+    "browser-sync": "^2.9.1",
     "classnames": "^2.1.1",
     "gulp": "^3.8.10",
     "gulp-bump": "^0.1.11",
@@ -21,6 +22,7 @@
     "gulp-notify": "^2.1.0",
     "gulp-rimraf": "^0.1.1",
     "gulp-ruby-sass": "^0.7.1",
+    "gulp-sass": "^2.0.4",
     "gulp-webserver": "^0.9.0",
     "moment": "^2.10.3",
     "react-widgets": "^2.6.0",

--- a/src/mnd-bootstrap/_variables.scss
+++ b/src/mnd-bootstrap/_variables.scss
@@ -87,7 +87,7 @@ $link-hover-color:      darken($link-color, 15%);
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);
+@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic");
 $font-family-sans-serif:  "Source Sans Pro", Arial, sans-serif;
 $font-family-serif:       Georgia, "Times New Roman", Times, serif;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.


### PR DESCRIPTION
Change from gulp-ruby-sass to gulp-sass and it seems like this can boost our performance working with the StyleGuide.

Example:

Before:
[13:55:34] Finished 'sass' after 3.18 s

After:
[13:49:19] Finished 'mnd-bootstrap-sass' after 478 ms