### PR TITLE
Included progressbar component in Documentation

### DIFF
--- a/src/mnd-bootstrap/components/_progress_bars.scss
+++ b/src/mnd-bootstrap/components/_progress_bars.scss
@@ -1,8 +1,31 @@
 /*doc
-//---
-//title: Progress bars
-//name: progress_bars
-//category: Components
-//---
-*/
+ ---
+ title: Progress bars
+ name: progress_bar
+ category: Components
+ ---
+ The progress bar is used for specific progress indicators.
 
+```html_example
+<div class="progress">
+  <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+    <span class="sr-only">40% Complete (success)</span>
+  </div>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+    <span class="sr-only">20% Complete</span>
+  </div>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
+    <span class="sr-only">60% Complete (warning)</span>
+  </div>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+    <span class="sr-only">80% Complete (danger)</span>
+  </div>
+</div>
+```
+*/


### PR DESCRIPTION
Include progressbar in documentation since we use it for file upload for example - ![progressbar](https://cloud.githubusercontent.com/assets/39583/9956306/f89fe32e-5df7-11e5-8091-a7a8c9c1459c.png)
