### PR TITLE
Icon component that adds some margin right to icons

### DIFF
--- a/dist/mnd-bootstrap.css
+++ b/dist/mnd-bootstrap.css
@@ -2972,12 +2972,18 @@ A calendar, designed for the datepicker
 //---
 */
 /*doc
-//---
-//title: Icons
-//name: icons
-//category: Components
-//---
+---
+title: Icons
+name: icons
+category: Components
+---
+
+```html_example
+<i class="inline-icon fa fa-check"></i>This icon has some padding-right
+```
 */
+.inline-icon { padding-right: 10px; }
+
 /*doc
 ---
 //title: Input groups

--- a/src/mnd-bootstrap/components/_icons.scss
+++ b/src/mnd-bootstrap/components/_icons.scss
@@ -1,8 +1,15 @@
 /*doc
-//---
-//title: Icons
-//name: icons
-//category: Components
-//---
+---
+title: Icons
+name: icons
+category: Components
+---
+
+```html_example
+<i class="inline-icon fa fa-check"></i>This icon has some padding-right
+```
 */
 
+.inline-icon {
+  padding-right: $padding-inside;
+}


### PR DESCRIPTION
We needed an icon with one padding-inside margin to the right of it.

Is it a good idea to have this css class for adding margin to an icon?

Should it be in the component section of the style-guide even though
it's just one css selector?

@frontend