### PR TITLE
Scoreboard redesign

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "mnd-bootstrap",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "authors": [
     "Zoee Silcock <zoee.silcock@mynewsdesk.com>"
   ],

--- a/dist/mnd-bootstrap.css
+++ b/dist/mnd-bootstrap.css
@@ -3128,14 +3128,20 @@ category: Components
 //category: Components
 //---
 */
-/*doc --- title: Scoreboard name: scoreboard category: Components --- Component to display numbers ```html_example <div class="scoreboard"> <div class="scoreboard-box"> <div class="scoreboard-box-number">124</div> <div class="scoreboard-box-label">Sent</div> </div> <div class="scoreboard-box"> <div class="scoreboard-box-number">109</div> <div class="scoreboard-box-label">Delivered</div> </div> <div class="scoreboard-box"> <div class="scoreboard-box-number">49</div> <div class="scoreboard-box-label">Reached</div> </div> <div class="scoreboard-box"> <div class="scoreboard-box-number">24</div> <div class="scoreboard-box-label">Engaged</div> </div> </div> ``` */
-.scoreboard { display: -webkit-box; display: -moz-box; display: box; display: -webkit-flex; display: -moz-flex; display: -ms-flexbox; display: flex; -webkit-box-orient: vertical; -moz-box-orient: vertical; box-orient: vertical; -webkit-flex-direction: column; -moz-flex-direction: column; flex-direction: column; -ms-flex-direction: column; -webkit-box-align: center; -moz-box-align: center; box-align: center; -webkit-align-items: center; -moz-align-items: center; -ms-align-items: center; -o-align-items: center; align-items: center; -ms-flex-align: center; background-color: #fafafa; border-radius: 6px; padding-bottom: 50px; padding-top: 50px; }
+/*doc --- title: Scoreboard name: scoreboard category: Components --- Component to display numbers ```html_example <div class="container"> <div class="row"> <div class="col-xs-12 col-sm-6 col-md-4"> <div class="scoreboard-box scoreboard-box-large"> <div class="scoreboard-box-number">124000</div> <div class="scoreboard-box-label">title</div> <div class="scoreboard-box-hint">subtitle</div> </div> </div> <div class="col-xs-12 col-sm-6 col-md-4"> <div class="scoreboard-box scoreboard-box-large"> <div class="scoreboard-box-number">1090</div> <div class="scoreboard-box-label">title</div> <div class="scoreboard-box-hint">subtitle</div> </div> </div> <div class="col-xs-12 col-sm-6 col-md-4"> <div class="scoreboard-box scoreboard-box-large"> <div class="scoreboard-box-number">1</div> <div class="scoreboard-box-label">title</div> <div class="scoreboard-box-hint">subtitle</div> </div> </div> </div> <div class="row"> <div class="col-xs-12 col-sm-6 col-md-3"> <div class="scoreboard-box"> <div class="scoreboard-box-number">12004</div> <div class="scoreboard-box-label">title</div> <div class="scoreboard-box-hint">subtitle</div> </div> </div> <div class="col-xs-12 col-sm-6 col-md-3"> <div class="scoreboard-box"> <div class="scoreboard-box-number">1009</div> <div class="scoreboard-box-label">title</div> <div class="scoreboard-box-hint">subtitle</div> </div> </div> <div class="col-xs-12 col-sm-6 col-md-3"> <div class="scoreboard-box"> <div class="scoreboard-box-number">230</div> <div class="scoreboard-box-label">title that breaks</div> <div class="scoreboard-box-hint">subtitle</div> </div> </div> <div class="col-xs-12 col-sm-6 col-md-3"> <div class="scoreboard-box"> <div class="scoreboard-box-number">3</div> <div class="scoreboard-box-label">title</div> <div class="scoreboard-box-hint">subtitle thats sometimes goes over two rows</div> </div> </div> </div> </div> ``` */
+.scoreboard-box { font-family: "Source Sans Pro", Arial, sans-serif; }
 
-@media (min-width: 768px) { .scoreboard { -webkit-box-orient: horizontal; -moz-box-orient: horizontal; box-orient: horizontal; -webkit-flex-direction: row; -moz-flex-direction: row; flex-direction: row; -ms-flex-direction: row; } }
+.scoreboard-box-number { color: #333; font-size: 60px; font-weight: bold; line-height: 66px; }
 
-.scoreboard-box { -webkit-box-flex: 1; -moz-box-flex: 1; box-flex: 1; -webkit-flex: 1; -moz-flex: 1; -ms-flex: 1; flex: 1; text-align: center; }
+.scoreboard-box-number .percentage { font-size: 40px; line-height: 0; }
 
-.scoreboard-box-number { color: #333; font-size: 60px; line-height: 1.1em; }
+.scoreboard-box-large .scoreboard-box-number { font-size: 90px; line-height: 99px; }
+
+.scoreboard-box-large .scoreboard-box-number .percentage { font-size: 60px; line-height: 0; }
+
+.scoreboard-box-label { font-weight: bold; }
+
+.scoreboard-box-hint { font-style: italic; }
 
 /*doc
 //---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mnd-bootstrap",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "",
   "main": "Gruntfile.js",
   "author": "Zoee Silcock",

--- a/src/mnd-bootstrap/components/_scoreboard.scss
+++ b/src/mnd-bootstrap/components/_scoreboard.scss
@@ -7,50 +7,96 @@ category: Components
 Component to display numbers
 
 ```html_example
-<div class="scoreboard">
-  <div class="scoreboard-box">
-    <div class="scoreboard-box-number">124</div>
-    <div class="scoreboard-box-label">Sent</div>
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-md-4">
+      <div class="scoreboard-box scoreboard-box-large">
+        <div class="scoreboard-box-number">124000</div>
+        <div class="scoreboard-box-label">title</div>
+        <div class="scoreboard-box-hint">subtitle</div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-4">
+      <div class="scoreboard-box scoreboard-box-large">
+        <div class="scoreboard-box-number">1090</div>
+        <div class="scoreboard-box-label">title</div>
+        <div class="scoreboard-box-hint">subtitle</div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-4">
+      <div class="scoreboard-box scoreboard-box-large">
+        <div class="scoreboard-box-number">1</div>
+        <div class="scoreboard-box-label">title</div>
+        <div class="scoreboard-box-hint">subtitle</div>
+      </div>
+    </div>
   </div>
-  <div class="scoreboard-box">
-    <div class="scoreboard-box-number">109</div>
-    <div class="scoreboard-box-label">Delivered</div>
-  </div>
-  <div class="scoreboard-box">
-    <div class="scoreboard-box-number">49</div>
-    <div class="scoreboard-box-label">Reached</div>
-  </div>
-  <div class="scoreboard-box">
-    <div class="scoreboard-box-number">24</div>
-    <div class="scoreboard-box-label">Engaged</div>
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-md-3">
+      <div class="scoreboard-box">
+        <div class="scoreboard-box-number">12004</div>
+        <div class="scoreboard-box-label">title</div>
+        <div class="scoreboard-box-hint">subtitle</div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-3">
+      <div class="scoreboard-box">
+        <div class="scoreboard-box-number">1009</div>
+        <div class="scoreboard-box-label">title</div>
+        <div class="scoreboard-box-hint">subtitle</div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-3">
+      <div class="scoreboard-box">
+        <div class="scoreboard-box-number">230</div>
+        <div class="scoreboard-box-label">title that breaks</div>
+        <div class="scoreboard-box-hint">subtitle</div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-3">
+      <div class="scoreboard-box">
+        <div class="scoreboard-box-number">3</div>
+        <div class="scoreboard-box-label">title</div>
+        <div class="scoreboard-box-hint">subtitle thats sometimes goes over two rows</div>
+      </div>
+    </div>
   </div>
 </div>
 ```
 */
 
-.scoreboard {
-  @include display(flex);
-  @include flex-direction(column);
-  @include align-items(center);
-  background-color: $gray-lightest;
-  border-radius: $border-radius-base;
-  padding-bottom: $padding-inside-very-large;
-  padding-top: $padding-inside-very-large;
-}
-
-@media (min-width: $screen-sm-min) {
-  .scoreboard {
-    @include flex-direction(row);
-  }
-}
-
 .scoreboard-box {
-  @include flex(1);
-  text-align: center;
-}
+  font-family: $font-family-sans-serif;
 
-.scoreboard-box-number {
-  color: $black;
-  font-size: $font-size-very-large;
-  line-height: 1.1em;
+  &-number {
+    color: $black;
+    font-size: $font-size-very-large;
+    font-weight: bold;
+    line-height: $line-height-very-large;
+
+    .percentage {
+      font-size: $font-size-medium-large;
+      line-height: 0; // it will create extra space otherwise
+    }
+  }
+
+  &-large {
+    .scoreboard-box-number {
+      font-size: $font-size-extremly-large;
+      line-height: $line-height-extremly-large;
+
+      .percentage {
+        font-size: $font-size-very-large;
+        line-height: 0; // it will create extra space otherwise
+      }
+    }
+  }
+
+  &-label {
+    font-weight: bold;
+  }
+
+  &-hint {
+    font-style: italic;
+  }
 }

--- a/src/mnd-bootstrap/variables/_typography.scss
+++ b/src/mnd-bootstrap/variables/_typography.scss
@@ -55,15 +55,20 @@ $font-family-base: $font-family-sans-serif;
 $font-size-base: 16px;
 $font-size-large: ceil(($font-size-base * 1.125)); // ~18px
 $font-size-larger: 22px;
+$font-size-medium-large: ceil(($font-size-base * 2.5)); // 40px
 $font-size-very-large: ceil(($font-size-base * 3.73)); // 56px
+$font-size-extremly-large: ceil(($font-size-base * 5.625)); // 90px
 $font-size-small: ceil(($font-size-base * 0.75)); // ~12px
 
 $font-size-h1: $font-size-base * 3.5; // 56px
 $font-size-h2: $font-size-large; // 18px
 $font-size-h3: $font-size-base; // 16px
 
+$line-height-base-small: 1.1;
 $line-height-base: 1.375; // 22/16
 $line-height-computed: floor(($font-size-base * $line-height-base)); // 22px
+$line-height-very-large: floor(($font-size-very-large * $line-height-base-small)); // 77px
+$line-height-extremly-large: floor(($font-size-extremly-large * $line-height-base-small)); // 123px
 
 $headings-font-weight: 600;
 // TODO: h1 should be 700


### PR DESCRIPTION
New design of the scoreboard, we use bootstrap grid system and then we have a emphasized state where the font is bigger.

This is only going to be used in Insights as of now. 

<img width="1126" alt="skarmavbild 2015-12-18 kl 14 16 53" src="https://cloud.githubusercontent.com/assets/906570/11897684/0699876e-a592-11e5-94d4-6de4863fe52e.png">

