### PR TITLE
Fix takeover header width

### DIFF
--- a/dist/mnd-bootstrap.css
+++ b/dist/mnd-bootstrap.css
@@ -693,19 +693,19 @@ hr { margin-top: 22px; margin-bottom: 22px; border: 0; border-top: 1px solid #ee
 
 [role="button"] { cursor: pointer; }
 
-h1, h2, h3, h4, h5, h6, .h1, .modal-header .modal-title, .takeover-header .modal-title, .h2, .h3, .h4, .h5, .h6 { font-family: inherit; font-weight: 600; line-height: 1.1; color: #333; }
+h1, h2, h3, h4, h5, h6, .h1, .modal-header .modal-title, .h2, .h3, .h4, .h5, .h6 { font-family: inherit; font-weight: 600; line-height: 1.1; color: #333; }
 
-h1 small, h1 .small, h2 small, h2 .small, h3 small, h3 .small, h4 small, h4 .small, h5 small, h5 .small, h6 small, h6 .small, .h1 small, .modal-header .modal-title small, .takeover-header .modal-title small, .h1 .small, .modal-header .modal-title .small, .takeover-header .modal-title .small, .h2 small, .h2 .small, .h3 small, .h3 .small, .h4 small, .h4 .small, .h5 small, .h5 .small, .h6 small, .h6 .small { font-weight: normal; line-height: 1; color: #777777; }
+h1 small, h1 .small, h2 small, h2 .small, h3 small, h3 .small, h4 small, h4 .small, h5 small, h5 .small, h6 small, h6 .small, .h1 small, .modal-header .modal-title small, .h1 .small, .modal-header .modal-title .small, .h2 small, .h2 .small, .h3 small, .h3 .small, .h4 small, .h4 .small, .h5 small, .h5 .small, .h6 small, .h6 .small { font-weight: normal; line-height: 1; color: #777777; }
 
-h1, .h1, .modal-header .modal-title, .takeover-header .modal-title, h2, .h2, h3, .h3 { margin-top: 22px; margin-bottom: 11px; }
+h1, .h1, .modal-header .modal-title, h2, .h2, h3, .h3 { margin-top: 22px; margin-bottom: 11px; }
 
-h1 small, h1 .small, .h1 small, .modal-header .modal-title small, .takeover-header .modal-title small, .h1 .small, .modal-header .modal-title .small, .takeover-header .modal-title .small, h2 small, h2 .small, .h2 small, .h2 .small, h3 small, h3 .small, .h3 small, .h3 .small { font-size: 65%; }
+h1 small, h1 .small, .h1 small, .modal-header .modal-title small, .h1 .small, .modal-header .modal-title .small, h2 small, h2 .small, .h2 small, .h2 .small, h3 small, h3 .small, .h3 small, .h3 .small { font-size: 65%; }
 
 h4, .h4, h5, .h5, h6, .h6 { margin-top: 11px; margin-bottom: 11px; }
 
 h4 small, h4 .small, .h4 small, .h4 .small, h5 small, h5 .small, .h5 small, .h5 .small, h6 small, h6 .small, .h6 small, .h6 .small { font-size: 75%; }
 
-h1, .h1, .modal-header .modal-title, .takeover-header .modal-title { font-size: 56px; }
+h1, .h1, .modal-header .modal-title { font-size: 56px; }
 
 h2, .h2 { font-size: 18px; }
 
@@ -2059,7 +2059,7 @@ a.badge:hover, a.badge:focus { color: #fff; text-decoration: none; cursor: point
 
 .jumbotron { padding-top: 30px; padding-bottom: 30px; margin-bottom: 30px; color: inherit; background-color: #eeeeee; }
 
-.jumbotron h1, .jumbotron .h1, .jumbotron .modal-header .modal-title, .modal-header .jumbotron .modal-title, .jumbotron .takeover-header .modal-title, .takeover-header .jumbotron .modal-title { color: inherit; }
+.jumbotron h1, .jumbotron .h1, .jumbotron .modal-header .modal-title, .modal-header .jumbotron .modal-title { color: inherit; }
 
 .jumbotron p { margin-bottom: 15px; font-size: 21px; font-weight: 200; }
 
@@ -2071,7 +2071,7 @@ a.badge:hover, a.badge:focus { color: #fff; text-decoration: none; cursor: point
 
 @media screen and (min-width: 768px) { .jumbotron { padding-top: 48px; padding-bottom: 48px; }
   .container .jumbotron, .container-fluid .jumbotron { padding-left: 60px; padding-right: 60px; }
-  .jumbotron h1, .jumbotron .h1, .jumbotron .modal-header .modal-title, .modal-header .jumbotron .modal-title, .jumbotron .takeover-header .modal-title, .takeover-header .jumbotron .modal-title { font-size: 63px; } }
+  .jumbotron h1, .jumbotron .h1, .jumbotron .modal-header .modal-title, .modal-header .jumbotron .modal-title { font-size: 63px; } }
 
 .thumbnail { display: block; padding: 4px; margin-bottom: 22px; line-height: 1.375; background-color: #fff; border: 1px solid #ddd; border-radius: 4px; -webkit-transition: border 0.2s ease-in-out; -o-transition: border 0.2s ease-in-out; transition: border 0.2s ease-in-out; }
 
@@ -2431,13 +2431,13 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .modal-backdrop.in { opacity: 0.5; filter: alpha(opacity=50); }
 
-.modal-header, .takeover-header { padding: 15px; border-bottom: 1px solid #fff; }
+.modal-header { padding: 15px; border-bottom: 1px solid #fff; }
 
-.modal-header:before, .takeover-header:before, .modal-header:after, .takeover-header:after { content: " "; display: table; }
+.modal-header:before, .modal-header:after { content: " "; display: table; }
 
-.modal-header:after, .takeover-header:after { clear: both; }
+.modal-header:after { clear: both; }
 
-.modal-header .close, .takeover-header .close { margin-top: -2px; }
+.modal-header .close { margin-top: -2px; }
 
 .modal-title { margin: 0; line-height: 1.375; }
 
@@ -3206,13 +3206,13 @@ category: Components
 
 .modal-content .close, .takeover-content .close { position: absolute; right: 15px; top: 15px; }
 
-.modal-header, .takeover-header { padding: 30px 10px; }
+.modal-header { padding: 30px 10px; }
 
-@media screen and (min-width: 768px) { .modal-header, .takeover-header { padding: 60px 30px 30px; } }
+@media screen and (min-width: 768px) { .modal-header { padding: 60px 30px 30px; } }
 
-.modal-header a, .takeover-header a { text-decoration: underline; }
+.modal-header a { text-decoration: underline; }
 
-.modal-header .header-icon, .takeover-header .header-icon { color: #0096d1; font-size: 160px; }
+.modal-header .header-icon { color: #0096d1; font-size: 160px; }
 
 .modal-body p:last-child, .takeover-body p:last-child { margin-bottom: 0; }
 
@@ -3225,13 +3225,13 @@ category: Components
 .modal-dialog .footnote, .takeover-dialog .footnote { color: #888; font-size: 12px; }
 
 /*doc --- title: Takeover name: takeover category: JavaScript --- Based on bootstrap modal. `.takeover-body` optionally takes a `.wide` class to support takeovers with more content. Note** that `data-backdrop` needs to be set to false and `data-toggle` and `data-dismiss` on trigger elements needs to take the value modal. ```html_example_table <div class="takeover fade" id="default-takeover" data-backdrop="false" tabindex="-1" role="dialog" aria-labelledby="myTakeoverLabel" aria-hidden="true"> <div class="takeover-dialog"> <div class="takeover-content"> <div class="takeover-header text-center"> <h1>Success!</h1> <p>You’ve successfully posted your story on <a href="#">Saga</a> and <a href="#">3 other channels</a>.</p> </div> <div class="takeover-body text-center"> <p> Ut massa lacus, posuere in facilisis a, blandit ac tortor. Praesent euismod posuere sodales. Nunc maximus eros vitae massa vehicula pharetra. Praesent id nunc ac odio tristique faucibus*. </p> </div> <div class="takeover-footer"> <button type="button" class="btn btn-default" data-dismiss="modal">Secondary Action</button> <button type="button" class="btn btn-primary">Primary Action</button> </div> </div> </div> </div> <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#default-takeover"> Launch default takeover </button> <div class="takeover fade" id="wide-takeover" data-backdrop="false" tabindex="-1" role="dialog" aria-labelledby="myTakeoverLabel" aria-hidden="true"> <div class="takeover-dialog"> <div class="takeover-content"> <div class="takeover-header text-center"> <h1>Success!</h1> <p>You’ve successfully posted your story on <a href="#">Saga</a> and <a href="#">3 other channels</a>.</p> </div> <div class="takeover-body wide text-center"> <p> Ut massa lacus, posuere in facilisis a, blandit ac tortor. Praesent euismod posuere sodales. Nunc maximus eros vitae massa vehicula pharetra. Praesent id nunc ac odio tristique faucibus*. </p> </div> <div class="takeover-footer"> <button type="button" class="btn btn-default" data-dismiss="modal">Secondary Action</button> <button type="button" class="btn btn-primary">Primary Action</button> </div> </div> </div> </div> <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#wide-takeover"> Launch wide takeover </button> ``` ```jsx_example <Takeover label="Label" show={@state.showTakeover}> <Takeover.Header title="Success!"> <p>You’ve successfully posted your story on <a href="#">Saga</a> and <a href="#">3 other channels</a>.</p> </Takeover.Header> <Takeover.Body wide={true} className="text-center"> <p> Ut massa lacus, posuere in facilisis a, blandit ac tortor. Praesent euismod posuere sodales. Nunc maximus eros vitae massa vehicula pharetra. Praesent id nunc ac odio tristique faucibus*. </p> </Takeover.Body> <Takeover.Footer> <Button onClick={@toggleTakeover}>Secondary Action</Button> <Button bsStyle="primary">Primary Action</Button> </Takeover.Footer> </Takeover> ``` */
-.takeover-header, .takeover-body, .takeover-footer { margin: 0 auto; max-width: 550px; }
+.takeover-header, .takeover-body, .takeover-footer { margin: 0 auto; max-width: 600px; }
 
 .takeover-dialog { background-color: rgba(255, 255, 255, 0.96); bottom: 0; left: 0; margin: 0; overflow: auto; position: fixed; right: 0; top: 0; width: auto; }
 
 .takeover-content { background-color: transparent; border: none; border-radius: 0; box-shadow: none; margin: 0 auto; overflow: hidden; position: relative; }
 
-.takeover-header { padding: 60px 90px 30px; }
+.takeover-header { padding: 0 10px 20px 10px; }
 
 .takeover-header a { text-decoration: underline; }
 

--- a/src/mnd-bootstrap/javascript/_takeover.scss
+++ b/src/mnd-bootstrap/javascript/_takeover.scss
@@ -83,7 +83,7 @@ Based on bootstrap modal.
 */
 %centered-content {
   margin: 0 auto;
-  max-width: 550px;
+  max-width: $takeover-max-width;
 }
 
 .takeover {
@@ -116,9 +116,8 @@ Based on bootstrap modal.
 }
 
 .takeover-header {
-  @extend .modal-header;
   @extend %centered-content;
-  padding: $gutter-vertical-x2 $gutter-vertical-x3 $gutter-vertical;
+  padding: 0 $padding-small-vertical $padding-small-horizontal;
 
   a {
     text-decoration: underline;

--- a/src/mnd-bootstrap/variables/_measures.scss
+++ b/src/mnd-bootstrap/variables/_measures.scss
@@ -44,3 +44,6 @@ $component-offset-horizontal: 180px;
 $border-radius-base: 6px;
 $border-radius-large: $border-radius-base;
 $border-radius-small: 2px;
+
+//## takeover max-width
+$takeover-max-width: 600px;


### PR DESCRIPTION
Make the header wider by removing massive padding and increasing max-width to 600px. It still scales and looks good, even better!

## Before:
<img width="665" alt="skarmklipp 2016-02-04 11 05 59" src="https://cloud.githubusercontent.com/assets/906570/12811837/4daee3b6-cb2f-11e5-8ce8-167717461e49.png">

## After:
<img width="661" alt="skarmklipp 2016-02-04 10 45 00" src="https://cloud.githubusercontent.com/assets/906570/12811841/56c6f1aa-cb2f-11e5-8416-fd5cc0591402.png">
