### PR TITLE
Reduce the padding on `.takeover-body`

### DIFF
--- a/dist/mnd-bootstrap.css
+++ b/dist/mnd-bootstrap.css
@@ -2443,7 +2443,7 @@ button.close { padding: 0; cursor: pointer; background: transparent; border: 0; 
 
 .modal-title { margin: 0; line-height: 1.375; }
 
-.modal-body, .takeover-body { position: relative; padding: 0 40px 30px; }
+.modal-body { position: relative; padding: 0 40px 30px; }
 
 .modal-footer, .takeover-footer { padding: 0 40px 30px; text-align: right; border-top: 1px solid #fff; }
 
@@ -3235,7 +3235,7 @@ category: Components
 
 .modal-header .header-icon { color: #3eb991; font-size: 160px; }
 
-.modal-body p:last-child, .takeover-body p:last-child { margin-bottom: 0; }
+.modal-body p:last-child { margin-bottom: 0; }
 
 .modal-footer, .takeover-footer { padding-bottom: 60px; text-align: center; }
 
@@ -3255,6 +3255,8 @@ category: Components
 .takeover-header { padding: 0 10px 20px; }
 
 .takeover-header a { text-decoration: underline; }
+
+.takeover-body { padding: 0; }
 
 .takeover-body p:last-child { margin-bottom: 0; }
 

--- a/src/mnd-bootstrap/javascript/_takeover.scss
+++ b/src/mnd-bootstrap/javascript/_takeover.scss
@@ -125,8 +125,10 @@ Based on bootstrap modal.
 }
 
 .takeover-body {
-  @extend .modal-body;
   @extend %centered-content;
+  @extend %modal-body;
+
+  padding: 0;
 
   p:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
When using the `.takeover-body` class the content gets very narrow on mobile
due to all the padding.