### PR TITLE
NPM package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "bootstrap"
   ],
   "dependencies": {
-    "bootstrap-sass-twbs": "*",
+    "bootstrap-sass": "*",
     "bourbon": "~4.1.1",
     "font-awesome": "fontawesome#~4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,14 +2,19 @@
   "name": "mnd-bootstrap",
   "version": "4.10.2",
   "description": "",
-  "main": "Gruntfile.js",
-  "author": "Zoee Silcock",
+  "main": "",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "author": "Team Skywalkers",
   "repository": {
     "type": "git",
     "url": "https://github.com/mynewsdesk/mnd-bootstrap.git"
   },
-  "peerDependencies": {
-    "react": "^0.13.0"
+  "dependencies": {
+    "bootstrap-sass": "^3.3",
+    "bourbon": "^4.2"
   },
   "devDependencies": {
     "browser-sync": "^2.9.1",

--- a/src/bootstrap.scss
+++ b/src/bootstrap.scss
@@ -1,1 +1,1 @@
-@import "bootstrap-sass-twbs/assets/stylesheets/bootstrap";
+@import "bootstrap-sass/assets/stylesheets/bootstrap";

--- a/src/mnd-bootstrap/_variables.scss
+++ b/src/mnd-bootstrap/_variables.scss
@@ -1,5 +1,5 @@
 @import "bourbon/app/assets/stylesheets/bourbon";
-@import "bootstrap-sass-twbs/assets/stylesheets/bootstrap/variables";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
 
 @import "variables/measures";
 @import "variables/colors";


### PR DESCRIPTION
This allows us to install mnd-bootstrap via npm via github.

Changes the legacy bootstrap-sass-twbs to bootstrap-sass which seems to work both for bower and npm.

I guess we might want to hook this up to the official npm registry as well. Input appreciated.