### PR TITLE
Webpack compatible variables

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,9 +18,13 @@ npm install --save mndx-bootstrap
 ## Usage
 
 ```
-@import "mnd-bootstrap/src/mnd-bootstrap";
-// Optionally import your own bootstrap variables.
 @import "mnd-bootstrap/src/bootstrap";
+
+// Load sass variables via the variables file
+@import "mnd-bootstrap/src/mnd-bootstrap/variables";
+
+// Or if you're building with webpack
+@import "mnd-bootstrap/src/mnd-bootstrap/variables.webpack";
 ```
 
 ## Development setup

--- a/src/mnd-bootstrap/_variables.scss
+++ b/src/mnd-bootstrap/_variables.scss
@@ -1,5 +1,5 @@
-@import "bourbon/app/assets/stylesheets/bourbon";
-@import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "~bourbon/app/assets/stylesheets/bourbon";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 
 @import "variables/measures";
 @import "variables/colors";

--- a/src/mnd-bootstrap/_variables.webpack.scss
+++ b/src/mnd-bootstrap/_variables.webpack.scss
@@ -1,5 +1,5 @@
-@import "bourbon/app/assets/stylesheets/bourbon";
-@import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "~bourbon/app/assets/stylesheets/bourbon";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 
 @import "variables/measures";
 @import "variables/colors";


### PR DESCRIPTION
Webpack uses `~` prefix to load things as modules which is required for the `bootstrap-sass` and `bourbon` dependencies to work when included in `mndx-web`.

For future iterations I'm not sure that using dependencies from within mnd-bootstrap is a good idea. It might be better to use a "peer dependencies" approach where `mndx-web` becomes responsible for loading `bootstrap-sass` and `bourbon` before `mndx-bootstrap` is imported.